### PR TITLE
clean up CI (triggered events)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Unit Tests
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   lines:


### PR DESCRIPTION
no need to append a colon for these events as we didn't specify any activity types or configuration