### PR TITLE
fix for invalid GPU error caused by (test/test_net_speed.py::TestConvSpeed::test_mnist) when testing in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Dependencies
-      run: pip install -r requirements.txt
+      run: |
+        pip install -r requirements.txt
+        pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Run Pytest
       run: python -m pytest -s -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Dependencies
-      run: |
-        pip install -r requirements.txt
-        pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      run: pip install -r requirements.txt
     - name: Run Pytest
       run: python -m pytest -s -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 # util deps
 requests
 # testing deps
-torch
+# torch
 pytest
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ numpy
 # util deps
 requests
 # testing deps
-torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+--find-links https://download.pytorch.org/whl/torch_stable.html
+torch==1.6.0+cpu
+torchvision==0.7.0+cpu
 pytest
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 # util deps
 requests
 # testing deps
-# torch
+torch==1.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 pytest
 tqdm


### PR DESCRIPTION
Getting rid of invalid GPU error by getting pytorch cpu-only version