### PR TITLE
Fix temp location for windows

### DIFF
--- a/tinygrad/utils.py
+++ b/tinygrad/utils.py
@@ -10,12 +10,9 @@ def layer_init_uniform(*x):
   return ret.astype(np.float32)
 
 def fetch(url):
-  import requests, os, hashlib
+  import requests, os, hashlib, tempfile
   if os.name == 'nt':
-    import tempfile
-    fp = os.path.join(tempfile.gettempdir(), hashlib.md5(url.encode('utf-8')).hexdigest())
-  else:
-    fp = os.path.join("/tmp", hashlib.md5(url.encode('utf-8')).hexdigest())
+  fp = os.path.join(tempfile.gettempdir(), hashlib.md5(url.encode('utf-8')).hexdigest())    
   if os.path.isfile(fp):
     with open(fp, "rb") as f:
       dat = f.read()

--- a/tinygrad/utils.py
+++ b/tinygrad/utils.py
@@ -11,7 +11,11 @@ def layer_init_uniform(*x):
 
 def fetch(url):
   import requests, os, hashlib
-  fp = os.path.join("/tmp", hashlib.md5(url.encode('utf-8')).hexdigest())
+  if os.name == 'nt':
+    import tempfile
+    fp = os.path.join(tempfile.gettempdir(), hashlib.md5(url.encode('utf-8')).hexdigest())
+  else:
+    fp = os.path.join("/tmp", hashlib.md5(url.encode('utf-8')).hexdigest())
   if os.path.isfile(fp):
     with open(fp, "rb") as f:
       dat = f.read()

--- a/tinygrad/utils.py
+++ b/tinygrad/utils.py
@@ -11,7 +11,6 @@ def layer_init_uniform(*x):
 
 def fetch(url):
   import requests, os, hashlib, tempfile
-  if os.name == 'nt':
   fp = os.path.join(tempfile.gettempdir(), hashlib.md5(url.encode('utf-8')).hexdigest())    
   if os.path.isfile(fp):
     with open(fp, "rb") as f:


### PR DESCRIPTION
This allows tinygrad to work on windows during first time run. (As Windows unable to understand /tmp path, caused it unable to load)
