### PR TITLE
alternative to einsum which is slow in extreme cases

### DIFF
--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -139,11 +139,11 @@ if __name__ == "__main__":
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
     
   # if you want to look at the cat
-  '''
+  """
   import matplotlib.pyplot as plt
   plt.imshow(img[0].mean(axis=0))
   plt.show()
-  '''
+  """
 
   # category labels
   import ast

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -148,8 +148,6 @@ if __name__ == "__main__":
   lbls = fetch("https://gist.githubusercontent.com/yrevar/942d3a0ac09ec9e5eb3a/raw/238f720ff059c1f82f368259d1ca4ffa5dd8f9f5/imagenet1000_clsidx_to_labels.txt")
   lbls = ast.literal_eval(lbls.decode('utf-8'))
 
-  print(lbls)
-
   # run the net
   import time
   st = time.time()

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -128,10 +128,12 @@ if __name__ == "__main__":
     url = "https://raw.githubusercontent.com/karpathy/micrograd/master/puppy.jpg"
   img = Image.open(io.BytesIO(fetch(url)))
   aspect_ratio = img.size[0] / img.size[1]
-  img = img.resize((int(224*aspect_ratio), 224))
+  img = img.resize((int(224*max(aspect_ratio,1.0)), int(224*max(1.0/aspect_ratio,1.0))))
+
   img = np.array(img)
-  chapo = (img.shape[1]-224)//2
-  img = img[:, chapo:chapo+224]
+  print(img.shape)
+  y0,x0=(np.asarray(img.shape)[:2]-224)//2
+  img = img[y0:y0+224, x0:x0+224]
   img = np.moveaxis(img, [2,0,1], [0,1,2])
   img = img.astype(np.float32).reshape(1,3,224,224)
   img /= 255.0

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
   img = img[:, chapo:chapo+224]
   img = np.moveaxis(img, [2,0,1], [0,1,2])
   img = img.astype(np.float32).reshape(1,3,224,224)
-  img /= 256
+  img /= 255.0
   img -= np.array([0.485, 0.456, 0.406]).reshape((1,-1,1,1))
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
 

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -124,20 +124,20 @@ if __name__ == "__main__":
   img = img[:, 87:-87]
   img = np.moveaxis(img, [2,0,1], [0,1,2])
   img = img.astype(np.float32).reshape(1,3,224,224)
-  img /= 256
+  img /= 255.0
   img -= np.array([0.485, 0.456, 0.406]).reshape((1,-1,1,1))
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
-
+    
   # if you want to look at the cat
-  """
   import matplotlib.pyplot as plt
   plt.imshow(img[0].mean(axis=0))
   plt.show()
-  """
 
   # category labels
   lbls = fetch("https://gist.githubusercontent.com/aaronpolhamus/964a4411c0906315deb9f4a3723aac57/raw/aa66dd9dbf6b56649fa3fab83659b2acbf3cbfd1/map_clsloc.txt")
   lbls = dict([(int(x.split(" ")[1]), x.split(" ")[2]) for x in lbls.decode('utf-8').split("\n")])
+
+  print(lbls)
 
   # run the net
   import time
@@ -145,4 +145,5 @@ if __name__ == "__main__":
   out = model.forward(Tensor(img))
   print("did inference in %.2f s" % (time.time()-st))
   print(np.argmax(out.data), np.max(out.data), lbls[np.argmax(out.data)])
+  print(out.data[0,9])
 

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -139,9 +139,11 @@ if __name__ == "__main__":
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
     
   # if you want to look at the cat
-  #import matplotlib.pyplot as plt
-  #plt.imshow(img[0].mean(axis=0))
-  #plt.show()
+  '''
+  import matplotlib.pyplot as plt
+  plt.imshow(img[0].mean(axis=0))
+  plt.show()
+  '''
 
   # category labels
   import ast

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -131,7 +131,6 @@ if __name__ == "__main__":
   img = img.resize((int(224*max(aspect_ratio,1.0)), int(224*max(1.0/aspect_ratio,1.0))))
 
   img = np.array(img)
-  print(img.shape)
   y0,x0=(np.asarray(img.shape)[:2]-224)//2
   img = img[y0:y0+224, x0:x0+224]
   img = np.moveaxis(img, [2,0,1], [0,1,2])

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -139,9 +139,9 @@ if __name__ == "__main__":
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
     
   # if you want to look at the cat
-  import matplotlib.pyplot as plt
-  plt.imshow(img[0].mean(axis=0))
-  plt.show()
+  #import matplotlib.pyplot as plt
+  #plt.imshow(img[0].mean(axis=0))
+  #plt.show()
 
   # category labels
   import ast

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
   if len(sys.argv) > 1:
     url = sys.argv[1]
   else:
-    url = "https://c.files.bbci.co.uk/12A9B/production/_111434467_gettyimages-1143489763.jpg"
+    url = "https://raw.githubusercontent.com/karpathy/micrograd/master/puppy.jpg"
   img = Image.open(io.BytesIO(fetch(url)))
   aspect_ratio = img.size[0] / img.size[1]
   img = img.resize((int(224*aspect_ratio), 224))
@@ -134,11 +134,11 @@ if __name__ == "__main__":
   img = img[:, chapo:chapo+224]
   img = np.moveaxis(img, [2,0,1], [0,1,2])
   img = img.astype(np.float32).reshape(1,3,224,224)
-  img /= 255.0
+  img /= 256
   img -= np.array([0.485, 0.456, 0.406]).reshape((1,-1,1,1))
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
-  
-  # if you want to look at the cat
+
+  # if you want to look at the micrograd puppy
   """
   import matplotlib.pyplot as plt
   plt.imshow(img[0].mean(axis=0))

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -137,7 +137,7 @@ if __name__ == "__main__":
   img /= 255.0
   img -= np.array([0.485, 0.456, 0.406]).reshape((1,-1,1,1))
   img /= np.array([0.229, 0.224, 0.225]).reshape((1,-1,1,1))
-    
+  
   # if you want to look at the cat
   """
   import matplotlib.pyplot as plt

--- a/tinygrad/gradcheck.py
+++ b/tinygrad/gradcheck.py
@@ -29,14 +29,13 @@ def numerical_jacobian(func, input, eps = 1e-6):
 
   for i in range(ji):
     eps_perturb = mask_like(input.data, i, mask_value = eps)
-    for o in range(jo):
 
-      output_perturb_add = func(Tensor(input.data + eps_perturb)).data.reshape(-1)[o]
-      output_perturb_sub = func(Tensor(input.data - eps_perturb)).data.reshape(-1)[o]
+    output_perturb_add = func(Tensor(input.data + eps_perturb)).data.reshape(-1)
+    output_perturb_sub = func(Tensor(input.data - eps_perturb)).data.reshape(-1)
 
-      grad_approx = ((output_perturb_add) - (output_perturb_sub)) / (2*eps)
+    grad_approx = ((output_perturb_add) - (output_perturb_sub)) / (2*eps)
 
-      NJ[o,i] = grad_approx
+    NJ[:,i] = grad_approx
   return NJ
 
 def gradcheck(func, input, eps = 1e-06, atol = 1e-5, rtol = 0.001):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -188,7 +188,7 @@ class Conv2D(Function):
       ret = np.zeros((bs,ctx.groups,rcout,oy,ox),dtype=x.dtype)
       for g in range(ctx.groups):
         #ijYXyx,kjyx -> iYXk ->ikYX
-        ret[:,g,:,:,:]+=np.moveaxis(np.tensordot(tx[:,g,:,:,:,:,:], tw[g,:,:,:,:],((1,4,5),(1,2,3))),3,1)
+        ret[:,g]+=np.moveaxis(np.tensordot(tx[:,g], tw[g],((1,4,5),(1,2,3))),3,1)
     return ret.reshape(bs, cout, oy, ox) 
 
 

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -162,9 +162,6 @@ class Conv2D(Function):
     assert cout % ctx.groups == 0
     rcout = cout//ctx.groups
 
-    #testing
-    assert ctx.groups*rcout == cout
-
     ctx.save_for_backward(x, w)
 
     ret = np.zeros((bs, ctx.groups, rcout, oy, ox), dtype=w.dtype)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -165,15 +165,12 @@ class Conv2D(Function):
     ctx.save_for_backward(x, w)
 
     ret = np.zeros((bs, ctx.groups, rcout, oy, ox), dtype=w.dtype)
-    
     gw = w.reshape(groups,rcout, -1)
     for Y in range(oy):
       for X in range(ox):
         iY,iX = Y*ys, X*xs
         gx = x[:,:,iY:iY+H, iX:iX+W].reshape(bs,groups,-1)
         ret[:, :, :, Y, X] += np.einsum('igj,gkj -> igk',gx,gw)
-
-      
     return ret.reshape(bs, cout, oy, ox)
 
   @staticmethod

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -196,9 +196,9 @@ class Conv2D(Function):
     _,rcout,cin,H,W = tw.shape
     ys,xs = ctx.stride
     OY,OX = x_shape[2:4]
-    
+
     ggg = grad_output.reshape(bs,ctx.groups,rcout,oy,ox)
-    
+
     gdw = np.zeros((ctx.groups,rcout,cin,H,W), dtype=tx.dtype)
     #gdw = np.einsum('igkYX,igjYXyx -> gkjyx',ggg,tx)
     for g in range(ctx.groups):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -179,7 +179,7 @@ class Conv2D(Function):
                     gx.strides[3], gx.strides[4]),
            writeable=False,
          )
-    tx = np.ravel(tx).reshape(tx.shape)
+    #tx = np.ravel(tx).reshape(tx.shape)
     tw = w.reshape(ctx.groups, rcout, cin, H, W)
     ctx.save_for_backward(tx, tw, x.shape)
     if use_einsum:


### PR DESCRIPTION
I don't really like two code options and not liking the `g` loop. I anyways leave it here. It is 10% slower on `efficientnet` but 5x faster `test_net_speed.py`. Probably needing to write own tensorop anyways.