### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='tinygrad',
         "License :: OSI Approved :: MIT License"
       ],
       install_requires=['numpy', 'requests'],
-      python_requires='>=3.6',
+      python_requires='>=3.8',
       include_package_data=True)


### PR DESCRIPTION
Apparently, `:=` in tinygrad/test/test_mnist.py actually needs 3.8 [see here](https://docs.python.org/3/whatsnew/3.8.html)