### PR TITLE
Op Registration Refactor

### DIFF
--- a/test/test_mnist.py
+++ b/test/test_mnist.py
@@ -38,8 +38,8 @@ class TinyConvNet:
 
   def forward(self, x):
     x.data = x.data.reshape((-1, 1, 28, 28)) # hacks
-    x = x.conv2d(self.c1).relu().max_pool2d()
-    x = x.conv2d(self.c2).relu().max_pool2d()
+    x = x.conv2d(self.c1).relu().maxpool2d()
+    x = x.conv2d(self.c2).relu().maxpool2d()
     x = x.reshape(shape=[x.shape[0], -1])
     return x.dot(self.l1).logsoftmax()
 

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -75,8 +75,8 @@ class TestConvSpeed(unittest.TestCase):
     for i in range(1+cnt):
       et0 = time.time()
       x = Tensor.randn(128, 1, 28, 28)
-      x = x.conv2d(c1).relu().avg_pool2d()
-      x = x.conv2d(c2).relu().max_pool2d()
+      x = x.conv2d(c1).relu().avgpool2d()
+      x = x.conv2d(c2).relu().maxpool2d()
       x = x.reshape(shape=(x.shape[0], -1))
       out = x.dot(l1).logsoftmax()
       out = out.mean()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -78,16 +78,16 @@ class TestOps(unittest.TestCase):
       lambda x,w: Tensor.conv2d(x,w,stride=(2,1)).relu(), atol=2e-5, grad_atol=2e-6, gpu=self.gpu)
 
   def test_maxpool2x2(self):
-    helper_test_op([(32,2,110,28)], lambda x: torch.nn.functional.max_pool2d(x, (2,2)), Tensor.max_pool2d, gpu=self.gpu)
+    helper_test_op([(32,2,110,28)], lambda x: torch.nn.functional.max_pool2d(x, (2,2)), Tensor.maxpool2d, gpu=self.gpu)
 
   def test_maxpool_sizes(self):
     for sz in [(2,2), (3,3), (3,2), (5,5), (5,1)]:
       helper_test_op([(32,2,110,28)],
         lambda x: torch.nn.functional.max_pool2d(x, kernel_size=sz),
-        lambda x: Tensor.max_pool2d(x, kernel_size=sz), gpu=self.gpu)
+        lambda x: Tensor.maxpool2d(x, kernel_size=sz), gpu=self.gpu)
 
   def test_avgpool2x2(self):
-    helper_test_op([(32,2,111,28)], lambda x: torch.nn.functional.avg_pool2d(x, (2,2)), Tensor.avg_pool2d, gpu=self.gpu)
+    helper_test_op([(32,2,111,28)], lambda x: torch.nn.functional.avg_pool2d(x, (2,2)), Tensor.avgpool2d, gpu=self.gpu)
 
 if GPU:
   class TestOpsGPU(TestOps):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -180,6 +180,19 @@ def register(name, fxn, gpu=False):
     setattr(Tensor, "__%s__" % name, dispatch)
     setattr(Tensor, "__i%s__" % name, lambda self,x: self.assign(dispatch(self,x)))
 
+class Registered(type):
+  def __new__(meta, name, bases, class_dict):
+      fxn = type.__new__(meta, name, bases, class_dict)
+      name = str(name).lower()
+      register(name, fxn)
+      return fxn
+
+class RegisteredGPU(type):
+  def __new__(meta, name, bases, class_dict):
+      fxn = type.__new__(meta, name, bases, class_dict)
+      name = str(name).lower()
+      register(name, fxn, gpu=True)
+      return fxn
 
 # this registers all the operations
 import tinygrad.ops


### PR DESCRIPTION
Refactored `register` function into `Registered` and `RegisteredGPU` metaclasses for readability and robustness. Five tests currently fail because the refactor requires renaming `max_pool2d`, `avg_pool2d` to `maxpool2d`, `avgpool2d`.