### PR TITLE
GPU Selection works when len(answers)>ngpus

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -15,8 +15,8 @@ def require_init_gpu():
     try:
       # for Macbook 16 inch
       cl_ctx = cl.create_some_context(answers=[0,2])
-    except cl._cl.RuntimeError:
-      cl_ctx = cl.create_some_context(answers=[0,0])
+    except (cl._cl.RuntimeError, TypeError):
+      cl_ctx = cl.create_some_context(interactive=False)
     cl_queue = cl.CommandQueue(cl_ctx)
 
 # **** start with two base classes ****
@@ -73,7 +73,7 @@ class Tensor:
   @staticmethod
   def eye(dim):
     return Tensor(np.eye(dim).astype(np.float32))
-    
+
   def backward(self, allow_fill=True):
     #print("running backward on", self)
     if self._ctx is None:


### PR DESCRIPTION
Fixes TypeError: sequence item 0: expected str instance, int found
triggered by https://github.com/inducer/pyopencl/blob/v2020.2.2/pyopencl/__init__.py#L1500
in pyopencl v2020.2.2

e.g. when answers=[0,2] but only one GPU is available