### PR TITLE
fixing local imports

### DIFF
--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -9,12 +9,20 @@ import io
 import time
 import numpy as np
 np.set_printoptions(suppress=True)
+# Fix local imports
+sys.path.append(os.getcwd())
 
 from tinygrad.tensor import Tensor
 from tinygrad.utils import fetch
 
 # BatchNorm2D and swish
 from tinygrad.nn import *
+
+# Check to see that we have 1 argument only
+if len(sys.argv) != 2:
+  print ("Usage: python3 examples/efficientnet.py <argument>")
+  print ("Where <argument> can be either https://url.to/image.jpeg or webcam")
+  sys.exit(0)
 
 class MBConvBlock:
   def __init__(self, kernel_size, strides, expand_ratio, input_filters, output_filters, se_ratio):

--- a/test/test_mnist.py
+++ b/test/test_mnist.py
@@ -2,6 +2,10 @@
 import os
 import unittest
 import numpy as np
+# Fix local imports
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.tensor import Tensor, GPU
 from tinygrad.utils import layer_init_uniform, fetch_mnist
 import tinygrad.optim as optim

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -5,6 +5,11 @@ import pstats
 import unittest
 import numpy as np
 import torch
+# Fix local imports
+import os
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.tensor import Tensor
 
 def start_profile():

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+# Fix local imports
+import os
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.nn import *
 import torch
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -3,6 +3,11 @@ import numpy as np
 import unittest
 import timeit
 import functools
+# Fix local imports
+import os
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.tensor import Tensor, GPU
 
 def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=1e-7, grad_atol=1e-7, gpu=False, forward_only=False):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,6 +1,11 @@
 import numpy as np
 import torch
 import unittest
+# Fix local imports
+import os
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.tensor import Tensor
 from tinygrad.optim import Adam, SGD, RMSprop
 

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,6 +1,11 @@
 import numpy as np
 import torch
 import unittest
+# Fix local imports
+import os
+import sys
+sys.path.append(os.getcwd())
+
 from tinygrad.tensor import Tensor
 from tinygrad.gradcheck import numerical_jacobian, jacobian, gradcheck
 


### PR DESCRIPTION
I had troubles running python3 examples/efficientnet.py or test/test_*…. 
Python3 had no idea where the local imports where, like the fetch() for example, this fixes that. And added a check on arguments to the efficientnet.py