### PR TITLE
Delete unnecessary import in utils.py

### DIFF
--- a/tinygrad/utils.py
+++ b/tinygrad/utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 
 def mask_like(like, mask_inx, mask_value = 1.0):
   mask = np.zeros_like(like).reshape(-1)


### PR DESCRIPTION
This was introduced by PR #65. os is imported in fetch and is not needed elsewhere. I mean line count matters, right?