### PR TITLE
Fix OOM in efficientnet on CPU

### DIFF
--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -49,7 +49,9 @@ class MBConvBlock:
     x = swish(self._bn1(x))
 
     # has_se
-    x_squeezed = x.avg_pool2d(kernel_size=x.shape[2:4])
+    # TODO: replace with global average pooling op
+    x_squeezed = Tensor(x.data)
+    x_squeezed.data = np.mean(x.data, axis=(2,3), keepdims=True, dtype=x.data.dtype)
     x_squeezed = swish(x_squeezed.conv2d(self._se_reduce).add(self._se_reduce_bias.reshape(shape=[1, -1, 1, 1])))
     x_squeezed = x_squeezed.conv2d(self._se_expand).add(self._se_expand_bias.reshape(shape=[1, -1, 1, 1]))
     x = x.mul(x_squeezed.sigmoid())

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -260,6 +260,8 @@ def unstack_for_pool(fxn, s, kernel_size, stride):
 class MaxPool2D(Function):
   @staticmethod
   def forward(ctx, x, kernel_size=(2, 2), stride=None):
+    if np.amax(kernel_size) > 10:
+      raise ValueError("%s doesn't support kernel_size > 10 on any axis" % __class__.__name__)
     if not stride:
       ctx.stride = stride = kernel_size
     stack, (my, mx) = stack_for_pool(x, kernel_size, stride, fill_value=-np.inf)
@@ -281,6 +283,8 @@ register('max_pool2d', MaxPool2D)
 class AvgPool2D(Function):
   @staticmethod
   def forward(ctx, x, kernel_size=(2, 2), stride=None):
+    if np.amax(kernel_size) > 10:
+      raise ValueError("%s doesn't support kernel_size > 10 on any axis" % __class__.__name__)
     if not stride:
       ctx.stride = stride = kernel_size
     stack, (my, mx) = stack_for_pool(x, kernel_size, stride, fill_value=np.nan)


### PR DESCRIPTION
fixes #86 caused by large kernel_size passed to CPU AvgPool2D in efficientnet.py, when the intention is really for GlobalAvgPool2D. 