### PR TITLE
General broadcasting of binary operations

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -65,8 +65,6 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: x.tanh(), Tensor.tanh, atol=1e-6, grad_atol=1e-6)
 
   def test_broadcast_full(self):
-    if self.gpu:
-      raise unittest.SkipTest('GPU broadcasting not fully supported')
     for torch_op, tinygrad_op in [(torch.add, Tensor.add), (torch.sub, Tensor.sub), (torch.mul, Tensor.mul),
                                   (torch.div, Tensor.div), (torch.pow, Tensor.pow)]:
       for shapes in [((5,13,24,16), (5,1,24,1)), ((1,3,1,7,1), (2,1,5,1,8))]:

--- a/tinygrad/opsgpu.py
+++ b/tinygrad/opsgpu.py
@@ -10,10 +10,10 @@ def buffer_new(ctx, shape):
   return res_g
 
 def buff(ctx, np_array):
-    res_g = cl.Buffer(ctx.cl_ctx, cl.mem_flags.WRITE_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=np_array)
-    res_g.shape = np_array.shape
-    res_g.dtype = np_array.dtype
-    return res_g
+  res_g = cl.Buffer(ctx.cl_ctx, cl.mem_flags.WRITE_ONLY | cl.mem_flags.COPY_HOST_PTR, hostbuf=np_array)
+  res_g.shape = np_array.shape
+  res_g.dtype = np_array.dtype
+  return res_g
 
 def buffer_zeros(ctx, shape):
   return buff(ctx, np.zeros(shape, dtype=np.float32))


### PR DESCRIPTION
Semantics of broadcasting that were implemented:
 - dimensions of the same size can be broadcast together
 - dimensions can be broadcast together as long as at least one of them has size 1
 - if one of the two tensors to be broadcast has fewer dimensions, its shape will be padded with 1s (added onto the end)

To do this, I also refactored `buffer_zeros` by creating a function `buff` that creates a buffer from a numpy array.