### PR TITLE
fix pyopencl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pyopencl
+pyopencl==2020.2.2
 # util deps
 requests
 # testing deps


### PR DESCRIPTION
Seeing if tests pass with fixed pyopencl version. Not entirely sure how test suite works but guessing we're pip installing newest version