### PR TITLE
pyopencl 2020.3.1 works

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-pyopencl==2020.2.2
+pyopencl
 # util deps
 requests
 # testing deps


### PR DESCRIPTION
Feel free to ignore, but it should work now for version 2020.3.1

For reference: https://github.com/inducer/pyopencl/issues/404