### PR TITLE
Define `ProfileOp` class once

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -32,7 +32,6 @@ class ProfileOp:
       debug_counts[self.name] += 1
       debug_times[self.name] += et
       print("%20s : %7.2f ms  %s" % (self.name, et, [y.shape for y in self.x]))
-    else: pass
 
 cl_ctx, cl_queue = None, None
 def require_init_gpu():

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -22,13 +22,10 @@ if DEBUG:
 
 class ProfileOp:
   def __init__(self, name, x, backward=False):
-    if DEBUG:
-      self.name = ("back_" if backward else "")+name
-      self.x = x
-    else: pass
+    self.name = ("back_" if backward else "")+name
+    self.x = x
   def __enter__(self):
     if DEBUG: self.st = time.time()
-    else: pass
   def __exit__(self, *junk):
     if DEBUG:
       et = (time.time()-self.st)*1000.

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -19,25 +19,23 @@ if DEBUG:
     for name, _ in sorted(debug_times.items(), key=lambda x: -x[1]):
       print("%20s : %3d  %10.2f ms" % (name, debug_counts[name], debug_times[name]))
   atexit.register(print_debug_exit)
-  class ProfileOp:
-    def __init__(self, name, x, backward=False):
+
+class ProfileOp:
+  def __init__(self, name, x, backward=False):
+    if DEBUG:
       self.name = ("back_" if backward else "")+name
       self.x = x
-    def __enter__(self):
-      self.st = time.time()
-    def __exit__(self, *junk):
+    else: pass
+  def __enter__(self):
+    if DEBUG: self.st = time.time()
+    else: pass
+  def __exit__(self, *junk):
+    if DEBUG:
       et = (time.time()-self.st)*1000.
       debug_counts[self.name] += 1
       debug_times[self.name] += et
       print("%20s : %7.2f ms  %s" % (self.name, et, [y.shape for y in self.x]))
-else:
-  class ProfileOp:
-    def __init__(self, name, x, backward=False):
-      pass
-    def __enter__(self):
-      pass
-    def __exit__(self, *junk):
-      pass
+    else: pass
 
 cl_ctx, cl_queue = None, None
 def require_init_gpu():


### PR DESCRIPTION
In [`tensor.py`](https://github.com/geohot/tinygrad/blob/master/tinygrad/tensor.py#L14-L40) the `ProfileOp` class is defined twice for `DEBUG` and otherwise, I've defined it once by just `pass`ing it if it's not `DEBUG`.

I don't know if that's a good approach but defining it once seems nicer and [saves some lines yo](https://github.com/geohot/tinygrad/blob/master/tinygrad/tensor.py#L12) (https://github.com/geohot/tinygrad/issues/94).

### :test_tube: Tests

```
================================= test session starts =================================
platform linux -- Python 3.8.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/mufeedvh/open-source/tinygrad
collected 58 items

test/test_mnist.py ......                                                       [ 10%]
test/test_net_speed.py .                                                        [ 12%]
test/test_nn.py .                                                               [ 13%]
test/test_ops.py ............................................                   [ 89%]
test/test_optim.py ...                                                          [ 94%]
test/test_tensor.py ...                                                         [100%]

=========================== 58 passed in 171.43s (0:02:51) ============================
```
