### PR TITLE
Add pytest marker for tests dependent on PyTorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ tinygrad will always be below 1000 lines. If it isn't, we will revert commits un
 python3 -m pytest
 ```
 
+To run only the subset of tests that don't presently depend on PyTorch, deselect the ones that do via:
+
+```bash
+python3 -m pytest -m "not torch"
+```
+
 ### TODO
 
 * Train an EfficientNet on ImageNet

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    torch: marks tests as dependent on PyTorch (deselect with '-m "not torch"')

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -2,9 +2,10 @@
 import time
 import cProfile
 import pstats
+import pytest
 import unittest
 import numpy as np
-import torch
+from utils.import_facade import torch
 from tinygrad.tensor import Tensor
 
 def start_profile():
@@ -20,6 +21,7 @@ def stop_profile(pr, sort='cumtime'):
   ps.sort_stats(sort)
   ps.print_stats(0.2)
 
+@pytest.mark.torch
 class TestConvSpeed(unittest.TestCase):
   def test_mnist(self):
     # https://keras.io/examples/vision/mnist_convnet/

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 import unittest
+import pytest
 import numpy as np
+from utils.import_facade import torch
 from tinygrad.nn import *
-import torch
 
 class TestNN(unittest.TestCase):
+  @pytest.mark.torch
   def test_batchnorm2d(self):
     sz = 4
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1,9 +1,10 @@
 import os
-import torch
 import numpy as np
 import unittest
+import pytest
 import timeit
 import functools
+from utils.import_facade import torch
 from tinygrad.tensor import Tensor, GPU
 
 def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, gpu=False, forward_only=False):
@@ -37,6 +38,7 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0
 
   print("testing %30r   torch/tinygrad fp: %.2f / %.2f ms  bp: %.2f / %.2f ms" % (shps, torch_fp, tinygrad_fp, torch_fbp-torch_fp, tinygrad_fbp-tinygrad_fp))
 
+@pytest.mark.torch
 class TestOps(unittest.TestCase):
   gpu = False
   def test_add(self):

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,6 +1,7 @@
 import numpy as np
-import torch
 import unittest
+import pytest
+from utils.import_facade import torch
 from tinygrad.tensor import Tensor
 from tinygrad.optim import Adam, SGD, RMSprop
 
@@ -51,6 +52,7 @@ class TorchNet():
     return out
 
 
+@pytest.mark.torch
 class TestOptim(unittest.TestCase):
   def test_adam(self):
     for x,y in zip(step_tinygrad(Adam),

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,6 +1,7 @@
 import numpy as np
-import torch
 import unittest
+import pytest
+from utils.import_facade import torch
 from tinygrad.tensor import Tensor
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 
@@ -9,6 +10,7 @@ W_init = np.random.randn(3,3).astype(np.float32)
 m_init = np.random.randn(1,3).astype(np.float32)
 
 class TestTinygrad(unittest.TestCase):
+  @pytest.mark.torch
   def test_backward_pass(self):
     def test_tinygrad():
       x = Tensor(x_init)
@@ -33,6 +35,7 @@ class TestTinygrad(unittest.TestCase):
     for x,y in zip(test_tinygrad(), test_pytorch()):
       np.testing.assert_allclose(x, y, atol=1e-5)
 
+  @pytest.mark.torch
   def test_jacobian(self):
     W = np.random.RandomState(1337).random((10, 5))
     x = np.random.RandomState(7331).random((1, 10)) - 0.5

--- a/test/utils/import_facade.py
+++ b/test/utils/import_facade.py
@@ -1,0 +1,5 @@
+try:
+  import torch
+except ImportError:
+  # PyTorch unavailable for running tests - prevents ImportError when dependent tests deselected.
+  torch = None


### PR DESCRIPTION
Addresses dependency issue mentioned in #139.

Adds a pytest marker to denote unit tests that depend on PyTorch - adding the convenience of running all tests _except_ those marked via: `python3 -m pytest -m "not torch"`

#### Some quick validation:
Without PyTorch installed:

![image](https://user-images.githubusercontent.com/19844878/101265623-f5a4ef00-3715-11eb-9226-8e5bd46d6ab4.png)

With PyTorch installed (i.e unaltered from before):

![image](https://user-images.githubusercontent.com/19844878/101265716-998e9a80-3716-11eb-8382-9b72b0706175.png)



