### PR TITLE
Add pyopencl to dependency installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Dependencies
-      run: |
-          pip install .
-          pip install -e '.[gpu]'
-          pip install -e '.[testing]'
+      run: pip install -e '.[gpu,testing]'
     - name: Run Pytest
       run: python -m pytest -s -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       with:
         python-version: 3.8
     - name: Install Dependencies
-      run: pip install -r requirements.txt
+      run: |
+          pip install .
+          pip install -e '.[gpu]'
+          pip install -e '.[testing]'
     - name: Run Pytest
       run: python -m pytest -s -v


### PR DESCRIPTION
OpenCL was not actually being tested as pyopencl was not installed.

Before:
```
=================== 46 passed, 1 xfailed in 61.57s (0:01:01) ===================
```
After:
```
============ 83 passed, 2 skipped, 5 warnings in 190.54s (0:03:10) =============
``