### PR TITLE
require_init_gpu() function selects GPU as device and falls back to CPU if none are available

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -38,7 +38,7 @@ def require_init_gpu():
   if cl_queue is None:
     devices = cl.get_platforms()[0].get_devices(device_type=cl.device_type.GPU)
     if len(devices) == 0:
-      devices = cl.get_platform()[0].get_devices(device_type.cl.device_type.CPU)
+      devices = cl.get_platforms()[0].get_devices(device_type.cl.device_type.CPU)
     cl_ctx = cl.Context(devices=devices)
     # this is an in-order command queue
     cl_queue = cl.CommandQueue(cl_ctx)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -38,7 +38,7 @@ def require_init_gpu():
   if cl_queue is None:
     devices = cl.get_platforms()[0].get_devices(device_type=cl.device_type.GPU)
     if len(devices) == 0:
-      devices = cl.get_platforms()[0].get_devices(device_type.cl.device_type.CPU)
+      devices = cl.get_platforms()[0].get_devices(device_type=cl.device_type.CPU)
     cl_ctx = cl.Context(devices=devices)
     # this is an in-order command queue
     cl_queue = cl.CommandQueue(cl_ctx)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -36,7 +36,10 @@ cl_ctx, cl_queue = None, None
 def require_init_gpu():
   global cl_ctx, cl_queue
   if cl_queue is None:
-    cl_ctx = cl.create_some_context(interactive=False)
+    devices = cl.get_platforms()[0].get_devices(device_type=cl.device_type.GPU)
+    if len(devices) == 0:
+      devices = cl.get_platform()[0].get_devices(device_type.cl.device_type.CPU)
+    cl_ctx = cl.Context(devices=devices)
     # this is an in-order command queue
     cl_queue = cl.CommandQueue(cl_ctx)
 


### PR DESCRIPTION
These lines make it so that require_init_gpu() function always selects available GPUs. In previous versions, require_init_gpu() could accidentally select CPU as device.