### PR TITLE
Add diamond model test

### DIFF
--- a/examples/train_efficientnet.py
+++ b/examples/train_efficientnet.py
@@ -87,11 +87,10 @@ if __name__ == "__main__":
     finish_time = (time.time()-st)*1000.0
 
     # printing
-    t.set_description("loss %.2f accuracy %.2f -- %.2f + %.2f + %.2f + %.2f = %.2f -- %d" %
+    t.set_description("loss %.2f accuracy %.2f -- %.2f + %.2f + %.2f + %.2f = %.2f" %
       (loss, accuracy,
       fp_time, bp_time, opt_time, finish_time,
-      fp_time + bp_time + opt_time + finish_time,
-      Tensor.allocated))
+      fp_time + bp_time + opt_time + finish_time))
 
     del out, y, loss
 


### PR DESCRIPTION
Add a test mentioned in #165. Verified it fails if deepwalk returns duplicate nodes.

Also fix train_efficientnet example, it is referencing a removed field. 