### PR TITLE
Added indentation linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,15 @@ jobs:
       run: pip install -e '.[gpu,testing]'
     - name: Run Pytest
       run: python -m pytest -s -v
+
+  linter:
+      name: Indentation Linter
+      runs-on: ubuntu-latest
+
+      steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Install PyLint
+        run: sudo apt-get install pylint3
+      - name: Validate indentation is 2 lines
+        run: if [[ $(pylint --jobs=0 --indent-string='  ' * | grep "Bad indentation") ]]; then exit 1; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Install PyLint
-        run: sudo apt-get install pylint3
+        run: sudo apt-get install pylint
       - name: Validate indentation is 2 lines
         run: if [[ $(pylint --jobs=0 --indent-string='  ' * | grep "Bad indentation") ]]; then exit 1; fi


### PR DESCRIPTION
Validating every Python code's indentation is 2 spaces.

### How?

```bash
if [[ $(pylint --jobs=0 --indent-string='  ' * | grep "Bad indentation") ]]; then exit 1; fi
```

This one-liner exits with error if there is any indentation size other than `2`.

### About The Flags

- `--jobs=0` - Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the number of processors available to use.
- `--indent-string='  '` - String used as indentation unit.