### PR TITLE
All devices are equal!

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ tinygrad supports GPUs through PyOpenCL.
 
 ```python
 from tinygrad.tensor import Tensor
-(Tensor.ones(4,4).cuda() + Tensor.ones(4,4).cuda()).cpu()
+(Tensor.ones(4,4).gpu() + Tensor.ones(4,4).gpu()).cpu()
 ```
 
 ### ANE Support?!

--- a/extra/training.py
+++ b/extra/training.py
@@ -5,7 +5,7 @@ from extra.utils import get_parameters
 from tinygrad.tensor import Tensor, GPU, DeviceTypes
 
 def train(model, X_train, Y_train, optim, steps, num_classes=None, BS=128, device=DeviceTypes.CPU, lossfn = lambda out,y: out.mul(y).mean()):
-  if device == DeviceTypes.GPU: [x.cuda_() for x in get_parameters([model, optim])]
+  if device == DeviceTypes.GPU: [x.gpu_() for x in get_parameters([model, optim])]
   if num_classes is None: num_classes = Y_train.max().astype(int)+1
   losses, accuracies = [], []
   for i in (t := trange(steps, disable=os.getenv('CI') is not None)):

--- a/extra/training.py
+++ b/extra/training.py
@@ -2,10 +2,10 @@ import os
 import numpy as np
 from tqdm import trange
 from extra.utils import get_parameters
-from tinygrad.tensor import Tensor, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, GPU, Device
 
-def train(model, X_train, Y_train, optim, steps, num_classes=None, BS=128, device=DeviceTypes.CPU, lossfn = lambda out,y: out.mul(y).mean()):
-  if device == DeviceTypes.GPU: [x.gpu_() for x in get_parameters([model, optim])]
+def train(model, X_train, Y_train, optim, steps, num_classes=None, BS=128, device=Device.CPU, lossfn = lambda out,y: out.mul(y).mean()):
+  if device == Device.GPU: [x.gpu_() for x in get_parameters([model, optim])]
   if num_classes is None: num_classes = Y_train.max().astype(int)+1
   losses, accuracies = [], []
   for i in (t := trange(steps, disable=os.getenv('CI') is not None)):
@@ -36,7 +36,7 @@ def train(model, X_train, Y_train, optim, steps, num_classes=None, BS=128, devic
     accuracies.append(accuracy)
     t.set_description("loss %.2f accuracy %.2f" % (loss, accuracy))
 
-def evaluate(model, X_test, Y_test, num_classes=None, device=DeviceTypes.CPU, BS=128):
+def evaluate(model, X_test, Y_test, num_classes=None, device=Device.CPU, BS=128):
   def numpy_eval(num_classes):
     Y_test_preds_out = np.zeros((len(Y_test),num_classes))
     for i in trange(len(Y_test)//BS, disable=os.getenv('CI') is not None):

--- a/extra/training.py
+++ b/extra/training.py
@@ -6,6 +6,7 @@ from tinygrad.tensor import Tensor, GPU, Device
 
 def train(model, X_train, Y_train, optim, steps, num_classes=None, BS=128, device=Device.CPU, lossfn = lambda out,y: out.mul(y).mean()):
   if device == Device.GPU: [x.gpu_() for x in get_parameters([model, optim])]
+  elif device == Device.ANE: [x.ane_() for x in get_parameters([model, optim])]
   if num_classes is None: num_classes = Y_train.max().astype(int)+1
   losses, accuracies = [], []
   for i in (t := trange(steps, disable=os.getenv('CI') is not None)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 numpy
 pyopencl==2020.2.2
 # util deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-six
 numpy
 pyopencl==2020.2.2
 # util deps

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='tinygrad',
       install_requires=['numpy', 'requests'],
       python_requires='>=3.8',
       extras_require={
-        'gpu': ["pyopencl"],
+        'gpu': ["pyopencl", "six"],
         'testing': [
             "pytest",
             "torch",

--- a/test/config.py
+++ b/test/config.py
@@ -1,0 +1,3 @@
+import os
+
+ANE = os.environ.get('ANE', False)

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 import gc
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 
 def tensors_allocated():
   return sum([isinstance(x, Tensor) for x in gc.get_objects()])
     
 class TestGC(unittest.TestCase):
-  device = DeviceTypes.CPU
+  device = Device.CPU
 
   def test_gc(self):
     a = Tensor.zeros(4,4, device=self.device)
@@ -35,11 +35,11 @@ class TestGC(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestGCGPU(TestGC):
-  device = DeviceTypes.GPU 
+  device = Device.GPU 
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestGCANE(TestGC):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python
 import gc
 import unittest
-from tinygrad.tensor import Tensor, GPU
+from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
 
 def tensors_allocated():
   return sum([isinstance(x, Tensor) for x in gc.get_objects()])
     
 class TestGC(unittest.TestCase):
-  gpu = False
+  device = DeviceTypes.CPU
 
   def test_gc(self):
-    a = Tensor.zeros(4,4, gpu=self.gpu)
-    b = Tensor.zeros(4,4, gpu=self.gpu)
+    a = Tensor.zeros(4,4, device=self.device)
+    b = Tensor.zeros(4,4, device=self.device)
     (a*b).mean().backward()
     assert(tensors_allocated() > 0)
     del a,b
     assert(tensors_allocated() == 0)
 
   def test_gc_complex(self):
-    a = Tensor.zeros(4,4, gpu=self.gpu)
-    b = Tensor.zeros(4,4, gpu=self.gpu)
+    a = Tensor.zeros(4,4, device=self.device)
+    b = Tensor.zeros(4,4, device=self.device)
     assert(tensors_allocated() == 2)
     (a*b).mean().backward()
     assert(tensors_allocated() == 4)
     del b
     assert(tensors_allocated() == 2)
-    b = Tensor.zeros(4,4, gpu=self.gpu)
+    b = Tensor.zeros(4,4, device=self.device)
     print(tensors_allocated())
     (a*b).mean().backward()
     print(tensors_allocated())
@@ -33,11 +33,13 @@ class TestGC(unittest.TestCase):
     del b
     assert(tensors_allocated() == 2)
 
-    
+@unittest.skipUnless(GPU, "Requires GPU")
+class TestGCGPU(TestGC):
+  device = DeviceTypes.GPU 
 
-if GPU:
-  class TestGCGPU(TestGC):
-    gpu = True
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestGCANE(TestGC):
+  device=DeviceTypes.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_gc.py
+++ b/test/test_gc.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import gc
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
+from .config import ANE
 
 def tensors_allocated():
   return sum([isinstance(x, Tensor) for x in gc.get_objects()])

--- a/test/test_mnist.py
+++ b/test/test_mnist.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 import numpy as np
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 import tinygrad.optim as optim
 from extra.training import train, evaluate
 from extra.utils import fetch, get_parameters
@@ -55,7 +55,7 @@ class TinyConvNet:
     return x.dot(self.l1).logsoftmax()
 
 class TestMNIST(unittest.TestCase):
-  device = DeviceTypes.CPU
+  device = Device.CPU
 
   def test_conv(self):
     np.random.seed(1337)
@@ -80,11 +80,11 @@ class TestMNIST(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestMNISTGPU(TestMNIST):
-  device = DeviceTypes.GPU
+  device = Device.GPU
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestMNISTANE(TestMNIST):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_mnist.py
+++ b/test/test_mnist.py
@@ -2,10 +2,11 @@
 import os
 import unittest
 import numpy as np
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
 import tinygrad.optim as optim
 from extra.training import train, evaluate
 from extra.utils import fetch, get_parameters
+from .config import ANE
 
 # mnist loader
 def fetch_mnist():

--- a/test/test_mnist.py
+++ b/test/test_mnist.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 import numpy as np
-from tinygrad.tensor import Tensor, GPU
+from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
 import tinygrad.optim as optim
 from extra.training import train, evaluate
 from extra.utils import fetch, get_parameters
@@ -55,32 +55,36 @@ class TinyConvNet:
     return x.dot(self.l1).logsoftmax()
 
 class TestMNIST(unittest.TestCase):
-  gpu=False
+  device = DeviceTypes.CPU
 
   def test_conv(self):
     np.random.seed(1337)
     model = TinyConvNet()
     optimizer = optim.Adam(model.parameters(), lr=0.001)
-    train(model, X_train, Y_train, optimizer, steps=200, gpu=self.gpu)
-    assert evaluate(model, X_test, Y_test, gpu=self.gpu) > 0.95
+    train(model, X_train, Y_train, optimizer, steps=200, device=self.device)
+    assert evaluate(model, X_test, Y_test, device=self.device) > 0.95
 
   def test_sgd(self):
     np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.SGD(model.parameters(), lr=0.001)
-    train(model, X_train, Y_train, optimizer, steps=1000, gpu=self.gpu)
-    assert evaluate(model, X_test, Y_test, gpu=self.gpu) > 0.95
+    train(model, X_train, Y_train, optimizer, steps=1000, device=self.device)
+    assert evaluate(model, X_test, Y_test, device=self.device) > 0.95
 
   def test_rmsprop(self):
     np.random.seed(1337)
     model = TinyBobNet()
     optimizer = optim.RMSprop(model.parameters(), lr=0.0002)
-    train(model,  X_train, Y_train, optimizer, steps=1000, gpu=self.gpu)
-    assert evaluate(model, X_test, Y_test, gpu=self.gpu) > 0.95
+    train(model,  X_train, Y_train, optimizer, steps=1000, device=self.device)
+    assert evaluate(model, X_test, Y_test, device=self.device) > 0.95
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestMNISTGPU(TestMNIST):
-    gpu = True
+  device = DeviceTypes.GPU
+
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestMNISTANE(TestMNIST):
+  device=DeviceTypes.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -4,7 +4,7 @@ import cProfile
 import pstats
 import unittest
 import torch
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 
 def start_profile():
   import time
@@ -20,7 +20,7 @@ def stop_profile(pr, sort='cumtime'):
   ps.print_stats(0.2)
 
 class TestConvSpeed(unittest.TestCase):
-  device= DeviceTypes.CPU
+  device= Device.CPU
 
   def test_mnist(self):
     # https://keras.io/examples/vision/mnist_convnet/
@@ -95,11 +95,11 @@ class TestConvSpeed(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestConvSpeedGPU(TestConvSpeed):
-  device = DeviceTypes.GPU
+  device = Device.GPU
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestConvSpeedANE(TestConvSpeed):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 
 if __name__ == '__main__':

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -4,7 +4,7 @@ import cProfile
 import pstats
 import unittest
 import torch
-from tinygrad.tensor import Tensor
+from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
 
 def start_profile():
   import time
@@ -20,6 +20,8 @@ def stop_profile(pr, sort='cumtime'):
   ps.print_stats(0.2)
 
 class TestConvSpeed(unittest.TestCase):
+  device= DeviceTypes.CPU
+
   def test_mnist(self):
     # https://keras.io/examples/vision/mnist_convnet/
     conv = 3
@@ -62,15 +64,15 @@ class TestConvSpeed(unittest.TestCase):
 
     # ****** tinygrad compare *******
 
-    c1 = Tensor(c1.detach().numpy())
-    c2 = Tensor(c2.detach().numpy())
-    l1 = Tensor(l1.detach().numpy())
+    c1 = Tensor(c1.detach().numpy(), device=self.device)
+    c2 = Tensor(c2.detach().numpy(), device=self.device)
+    l1 = Tensor(l1.detach().numpy(), device=self.device)
 
     cnt = 5
     fpt, bpt = 0.0, 0.0
     for i in range(1+cnt):
       et0 = time.time()
-      x = Tensor.randn(128, 1, 28, 28)
+      x = Tensor.randn(128, 1, 28, 28, device=self.device)
       x = x.conv2d(c1).relu().avg_pool2d()
       x = x.conv2d(c2).relu().max_pool2d()
       x = x.reshape(shape=(x.shape[0], -1))
@@ -90,6 +92,14 @@ class TestConvSpeed(unittest.TestCase):
     bpt = (bpt*1000/cnt)
     print("forward pass:  %.3f ms, %.2fx off baseline %.3f ms" % (fpt, fpt/fpt_baseline, fpt_baseline))
     print("backward pass: %.3f ms, %.2fx off baseline %.3f ms" % (bpt, bpt/bpt_baseline, bpt_baseline))
+
+@unittest.skipUnless(GPU, "Requires GPU")
+class TestConvSpeedGPU(TestConvSpeed):
+  device = DeviceTypes.GPU
+
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestConvSpeedANE(TestConvSpeed):
+  device=DeviceTypes.ANE
 
 
 if __name__ == '__main__':

--- a/test/test_net_speed.py
+++ b/test/test_net_speed.py
@@ -4,7 +4,8 @@ import cProfile
 import pstats
 import unittest
 import torch
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
+from .config import ANE
 
 def start_profile():
   import time

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -20,7 +20,7 @@ class TestNN(unittest.TestCase):
     bn.running_var = Tensor.randn(sz)
     bn.running_var.data[bn.running_var.data < 0] = 0
 
-    if self.device==DeviceTypes.GPU: [x.cuda_() for x in get_parameters(bn)]
+    if self.device==DeviceTypes.GPU: [x.gpu_() for x in get_parameters(bn)]
     elif self.device==DeviceTypes.ANE: [x.ane_() for x in get_parameters(bn)]
 
     # create in torch

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
-from tinygrad.tensor import ANE, GPU, Device
+from tinygrad.tensor import GPU, Device
 from tinygrad.nn import *
 from extra.utils import get_parameters
 import torch
+from .config import ANE
 
 class TestNN(unittest.TestCase):
   device = Device.CPU

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+from tinygrad.tensor import ANE, GPU, DeviceTypes
 from tinygrad.nn import *
+from extra.utils import get_parameters
 import torch
 
 class TestNN(unittest.TestCase):
+  device = DeviceTypes.CPU
+
   def test_batchnorm2d(self, training=False):
     sz = 4
 
@@ -15,6 +19,9 @@ class TestNN(unittest.TestCase):
     bn.running_mean = Tensor.randn(sz)
     bn.running_var = Tensor.randn(sz)
     bn.running_var.data[bn.running_var.data < 0] = 0
+
+    if self.device==DeviceTypes.GPU: [x.cuda_() for x in get_parameters(bn)]
+    elif self.device==DeviceTypes.ANE: [x.ane_() for x in get_parameters(bn)]
 
     # create in torch
     with torch.no_grad():
@@ -29,24 +36,32 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(bn.running_var.data, tbn.running_var.detach().numpy(), rtol=1e-5)
 
     # trial
-    inn = Tensor.randn(2, sz, 3, 3)
+    inn = Tensor.randn(2, sz, 3, 3, device=self.device)
 
     # in tinygrad
     outt = bn(inn)
 
     # in torch
-    toutt = tbn(torch.tensor(inn.data))
+    toutt = tbn(torch.tensor(inn.cpu().data))
 
     # close
-    np.testing.assert_allclose(outt.data, toutt.detach().numpy(), rtol=5e-5)
+    np.testing.assert_allclose(outt.cpu().data, toutt.detach().numpy(), rtol=5e-5)
 
-    np.testing.assert_allclose(bn.running_mean.data, tbn.running_mean.detach().numpy(), rtol=1e-5)
+    np.testing.assert_allclose(bn.running_mean.cpu().data, tbn.running_mean.detach().numpy(), rtol=1e-5)
 
     # TODO: this is failing
     #np.testing.assert_allclose(bn.running_var.data, tbn.running_var.detach().numpy(), rtol=1e-5)
 
   def test_batchnorm2d_training(self):
     self.test_batchnorm2d(True)
+
+@unittest.skipUnless(GPU, "Requires GPU")
+class TestNNGPU(TestNN):
+  device = DeviceTypes.GPU
+
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestNNANE(TestNN):
+  device=DeviceTypes.ANE
 
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
-from tinygrad.tensor import ANE, GPU, DeviceTypes
+from tinygrad.tensor import ANE, GPU, Device
 from tinygrad.nn import *
 from extra.utils import get_parameters
 import torch
 
 class TestNN(unittest.TestCase):
-  device = DeviceTypes.CPU
+  device = Device.CPU
 
   def test_batchnorm2d(self, training=False):
     sz = 4
@@ -20,8 +20,8 @@ class TestNN(unittest.TestCase):
     bn.running_var = Tensor.randn(sz)
     bn.running_var.data[bn.running_var.data < 0] = 0
 
-    if self.device==DeviceTypes.GPU: [x.gpu_() for x in get_parameters(bn)]
-    elif self.device==DeviceTypes.ANE: [x.ane_() for x in get_parameters(bn)]
+    if self.device==Device.GPU: [x.gpu_() for x in get_parameters(bn)]
+    elif self.device==Device.ANE: [x.ane_() for x in get_parameters(bn)]
 
     # create in torch
     with torch.no_grad():
@@ -57,11 +57,11 @@ class TestNN(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestNNGPU(TestNN):
-  device = DeviceTypes.GPU
+  device = Device.GPU
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestNNANE(TestNN):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -20,9 +20,6 @@ class TestNN(unittest.TestCase):
     bn.running_var = Tensor.randn(sz)
     bn.running_var.data[bn.running_var.data < 0] = 0
 
-    if self.device==Device.GPU: [x.gpu_() for x in get_parameters(bn)]
-    elif self.device==Device.ANE: [x.ane_() for x in get_parameters(bn)]
-
     # create in torch
     with torch.no_grad():
       tbn = torch.nn.BatchNorm2d(sz).eval()
@@ -45,9 +42,9 @@ class TestNN(unittest.TestCase):
     toutt = tbn(torch.tensor(inn.cpu().data))
 
     # close
-    np.testing.assert_allclose(outt.cpu().data, toutt.detach().numpy(), rtol=5e-5)
+    np.testing.assert_allclose(outt.data, toutt.detach().numpy(), rtol=5e-5)
 
-    np.testing.assert_allclose(bn.running_mean.cpu().data, tbn.running_mean.detach().numpy(), rtol=1e-5)
+    np.testing.assert_allclose(bn.running_mean.data, tbn.running_mean.detach().numpy(), rtol=1e-5)
 
     # TODO: this is failing
     #np.testing.assert_allclose(bn.running_var.data, tbn.running_var.detach().numpy(), rtol=1e-5)
@@ -59,9 +56,22 @@ class TestNN(unittest.TestCase):
 class TestNNGPU(TestNN):
   device = Device.GPU
 
+  @unittest.skip("Tests not added")
+  def test_batchnorm2d(self): pass
+
+  @unittest.skip("Tests not added")
+  def test_batchnorm2d_training(self): pass
+
+
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestNNANE(TestNN):
   device=Device.ANE
+
+  @unittest.skip("Tests not added")
+  def test_batchnorm2d(self): pass
+
+  @unittest.skip("Tests not added")
+  def test_batchnorm2d_training(self): pass
 
 
 if __name__ == '__main__':

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -25,7 +25,7 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0
     ret.mean().backward()
 
     for t, tt in zip(ts, tst):
-      np.testing.assert_allclose(t.grad, tt.grad.cpu().data, atol=grad_atol, rtol=grad_rtol)
+      np.testing.assert_allclose(t.grad, tt.cpu().grad.data, atol=grad_atol, rtol=grad_rtol)
 
   # speed
   torch_fp = timeit.Timer(functools.partial(torch_fxn, *ts)).timeit(5) * 1000/5

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,15 +4,15 @@ import numpy as np
 import unittest
 import timeit
 import functools
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 
-def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, device=DeviceTypes.CPU, forward_only=False):
+def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, device=Device.CPU, forward_only=False):
   torch.manual_seed(0)
   ts = [torch.rand(x, requires_grad=True) for x in shps]
   tst = [Tensor(x.detach().numpy()) for x in ts]
-  if device==DeviceTypes.GPU:
+  if device==Device.GPU:
     tst = [x.gpu() for x in tst]
-  elif device==DeviceTypes.ANE:
+  elif device==Device.ANE:
     tst = [x.ane() for x in tst]
 
   out = torch_fxn(*ts)
@@ -40,7 +40,7 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0
   print("testing %30r   torch/tinygrad fp: %.2f / %.2f ms  bp: %.2f / %.2f ms" % (shps, torch_fp, tinygrad_fp, torch_fbp-torch_fp, tinygrad_fbp-tinygrad_fp))
 
 class TestOps(unittest.TestCase):
-  device=DeviceTypes.CPU
+  device=Device.CPU
 
   def test_add(self):
     helper_test_op([(45,65), (45,65)], lambda x,y: x+y, Tensor.add, device=self.device)
@@ -102,7 +102,7 @@ class TestOps(unittest.TestCase):
                      ((4,1), (4,5)), ((1,4), (5,4))]:
         with self.subTest(op=torch_op.__name__, shapes=shapes):
           # NOTE: ANE backwards?
-          helper_test_op(shapes, torch_op, tinygrad_op, device=self.device, forward_only=self.device!=DeviceTypes.CPU)
+          helper_test_op(shapes, torch_op, tinygrad_op, device=self.device, forward_only=self.device!=Device.CPU)
 
   def test_pad2d(self):
     helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)), lambda x: x.pad2d(padding=(1,2,3,4)), device=self.device)
@@ -155,11 +155,11 @@ class TestOps(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestOpsGPU(TestOps):
-  device=DeviceTypes.GPU
+  device=Device.GPU
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestOpsANE(TestOps):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,7 +4,8 @@ import numpy as np
 import unittest
 import timeit
 import functools
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
+from .config import ANE
 
 def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, device=Device.CPU, forward_only=False):
   torch.manual_seed(0)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -4,14 +4,16 @@ import numpy as np
 import unittest
 import timeit
 import functools
-from tinygrad.tensor import Tensor, GPU
+from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
 
-def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, gpu=False, forward_only=False):
+def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0, grad_rtol=1e-6, device=DeviceTypes.CPU, forward_only=False):
   torch.manual_seed(0)
   ts = [torch.rand(x, requires_grad=True) for x in shps]
   tst = [Tensor(x.detach().numpy()) for x in ts]
-  if gpu:
+  if device==DeviceTypes.GPU:
     tst = [x.cuda() for x in tst]
+  elif device==DeviceTypes.ANE:
+    tst = [x.ane() for x in tst]
 
   out = torch_fxn(*ts)
   ret = tinygrad_fxn(*tst)
@@ -38,58 +40,59 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0
   print("testing %30r   torch/tinygrad fp: %.2f / %.2f ms  bp: %.2f / %.2f ms" % (shps, torch_fp, tinygrad_fp, torch_fbp-torch_fp, tinygrad_fbp-tinygrad_fp))
 
 class TestOps(unittest.TestCase):
-  gpu = False
+  device=DeviceTypes.CPU
+
   def test_add(self):
-    helper_test_op([(45,65), (45,65)], lambda x,y: x+y, Tensor.add, gpu=self.gpu)
+    helper_test_op([(45,65), (45,65)], lambda x,y: x+y, Tensor.add, device=self.device)
   def test_sub(self):
-    helper_test_op([(45,65), (45,65)], lambda x,y: x-y, Tensor.sub, gpu=self.gpu)
+    helper_test_op([(45,65), (45,65)], lambda x,y: x-y, Tensor.sub, device=self.device)
   def test_mul(self):
-    helper_test_op([(45,65), (45,65)], lambda x,y: x*y, Tensor.mul, gpu=self.gpu)
+    helper_test_op([(45,65), (45,65)], lambda x,y: x*y, Tensor.mul, device=self.device)
   def test_div(self):
-    helper_test_op([(45,65), (45,65)], lambda x,y: x/y, Tensor.div, gpu=self.gpu)
+    helper_test_op([(45,65), (45,65)], lambda x,y: x/y, Tensor.div, device=self.device)
   def test_pow(self):
-    helper_test_op([(45,65), (45,65)], lambda x,y: x**y, Tensor.pow, gpu=self.gpu)
+    helper_test_op([(45,65), (45,65)], lambda x,y: x**y, Tensor.pow, device=self.device)
   def test_sqrt(self):
-    helper_test_op([(45,65)], lambda x: x.sqrt(), Tensor.sqrt, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x.sqrt(), Tensor.sqrt, device=self.device)
   def test_relu(self):
-    helper_test_op([(45,65)], lambda x: x.relu(), Tensor.relu, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x.relu(), Tensor.relu, device=self.device)
   def test_leakyrelu(self):
-    helper_test_op([(45,65)], lambda x: torch.nn.functional.leaky_relu(x,0.01), Tensor.leakyrelu, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: torch.nn.functional.leaky_relu(x,0.01), Tensor.leakyrelu, device=self.device)
   def test_abs(self):
-    helper_test_op([(45,65)], lambda x: torch.abs(x), Tensor.abs, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: torch.abs(x), Tensor.abs, device=self.device)
   def test_sigmoid(self):
-    helper_test_op([(45,65)], lambda x: x.sigmoid(), Tensor.sigmoid, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x.sigmoid(), Tensor.sigmoid, device=self.device)
   def test_dot(self):
-    helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, gpu=self.gpu)
+    helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, device=self.device)
   def test_sum(self):
-    helper_test_op([(45,3)], lambda x: x.sum(), Tensor.sum, gpu=self.gpu)
+    helper_test_op([(45,3)], lambda x: x.sum(), Tensor.sum, device=self.device)
   def test_sum_axis(self):
-    helper_test_op([(3,4,5,6)], lambda x: x.sum(axis=(1,2)), lambda x: Tensor.sum(x, axis=(1,2)), gpu=self.gpu)
+    helper_test_op([(3,4,5,6)], lambda x: x.sum(axis=(1,2)), lambda x: Tensor.sum(x, axis=(1,2)), device=self.device)
   def test_mean_axis(self):
-    helper_test_op([(3,4,5,6)], lambda x: x.mean(axis=(1,2)), lambda x: Tensor.mean(x, axis=(1,2)), gpu=self.gpu)
+    helper_test_op([(3,4,5,6)], lambda x: x.mean(axis=(1,2)), lambda x: Tensor.mean(x, axis=(1,2)), device=self.device)
   def test_logsoftmax(self):
-    helper_test_op([(45,65)], lambda x: torch.nn.LogSoftmax(dim=1)(x), Tensor.logsoftmax, atol=1e-7, grad_atol=1e-7, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: torch.nn.LogSoftmax(dim=1)(x), Tensor.logsoftmax, atol=1e-7, grad_atol=1e-7, device=self.device)
   def test_tanh(self):
-    helper_test_op([(45,65)], lambda x: x.tanh(), Tensor.tanh, atol=1e-6, grad_atol=1e-6, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x.tanh(), Tensor.tanh, atol=1e-6, grad_atol=1e-6, device=self.device)
   def test_topo_sort(self):
-    helper_test_op([(45,65)], lambda x: (x+x)*x, lambda x: x.add(x).mul(x), atol=1e-6, grad_atol=1e-6, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: (x+x)*x, lambda x: x.add(x).mul(x), atol=1e-6, grad_atol=1e-6, device=self.device)
 
   def test_scalar_mul(self):
-    helper_test_op([(45,65)], lambda x: x*2, lambda x: x*2, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x*2, lambda x: x*2, device=self.device)
   def test_scalar_rmul(self):
-    helper_test_op([(45,65)], lambda x: 2*x, lambda x: 2*x, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: 2*x, lambda x: 2*x, device=self.device)
 
   def test_scalar_sub(self):
-    helper_test_op([(45,65)], lambda x: x-2, lambda x: x-2, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: x-2, lambda x: x-2, device=self.device)
   def test_scalar_rsub(self):
-    helper_test_op([(45,65)], lambda x: 2-x, lambda x: 2-x, gpu=self.gpu)
+    helper_test_op([(45,65)], lambda x: 2-x, lambda x: 2-x, device=self.device)
 
   def test_broadcast_full(self):
     for torch_op, tinygrad_op in [(torch.add, Tensor.add), (torch.sub, Tensor.sub), (torch.mul, Tensor.mul),
                                   (torch.div, Tensor.div), (torch.pow, Tensor.pow)]:
       for shapes in [((5,13,24,16), (5,1,24,1)), ((1,3,1,7,1), (2,1,5,1,8))]:
         with self.subTest(op=torch_op.__name__, shapes=shapes):
-          helper_test_op(shapes, torch_op, tinygrad_op, gpu=self.gpu)
+          helper_test_op(shapes, torch_op, tinygrad_op, device=self.device)
 
 
   def test_broadcast_partial(self):
@@ -98,17 +101,18 @@ class TestOps(unittest.TestCase):
       for shapes in [((1,32,32,32), (1,32,1,1)), ((5,13,24,16,2), (1,13,24,1,1)),
                      ((4,1), (4,5)), ((1,4), (5,4))]:
         with self.subTest(op=torch_op.__name__, shapes=shapes):
-          helper_test_op(shapes, torch_op, tinygrad_op, gpu=self.gpu, forward_only=self.gpu)
+          # NOTE: ANE backwards?
+          helper_test_op(shapes, torch_op, tinygrad_op, device=self.device, forward_only=self.device!=DeviceTypes.CPU)
 
   def test_pad2d(self):
-    helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)), lambda x: x.pad2d(padding=(1,2,3,4)), gpu=self.gpu)
+    helper_test_op([(3,3,3,3)], lambda x: torch.nn.functional.pad(x, (1,2,3,4)), lambda x: x.pad2d(padding=(1,2,3,4)), device=self.device)
 
   def test_reshape(self):
-    helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)), gpu=self.gpu)
-    helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,1,6,6)), lambda x: x.reshape(shape=(-1,1,6,6)), gpu=self.gpu)
+    helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,3,6,6)), lambda x: x.reshape(shape=(-1,3,6,6)), device=self.device)
+    helper_test_op([(4,3,6,6)], lambda x: torch.reshape(x, (-1,1,6,6)), lambda x: x.reshape(shape=(-1,1,6,6)), device=self.device)
 
   def test_detach(self):
-    helper_test_op([(4,3,6,6)], lambda x: x.detach(), lambda x: x.detach(), gpu=self.gpu, forward_only=True)
+    helper_test_op([(4,3,6,6)], lambda x: x.detach(), lambda x: x.detach(), device=self.device, forward_only=True)
 
   def test_conv2d(self):
     for bs in [1,8]:
@@ -119,7 +123,7 @@ class TestOps(unittest.TestCase):
               with self.subTest(batch_size=bs, channels=cin, groups=groups, height=H, width=W):
                 helper_test_op([(bs,cin,11,28), (6,cin//groups,H,W)],
                   lambda x,w: torch.nn.functional.conv2d(x,w,groups=groups).relu(),
-                  lambda x,w: Tensor.conv2d(x,w,groups=groups).relu(), gpu=self.gpu, grad_rtol=1e-5)
+                  lambda x,w: Tensor.conv2d(x,w,groups=groups).relu(), device=self.device, grad_rtol=1e-5)
 
   def test_strided_conv2d(self):
     bs = 4
@@ -128,18 +132,18 @@ class TestOps(unittest.TestCase):
     with self.subTest(stride := 2):
       helper_test_op([(bs,cin,11,28), (4,cin,H,W)],
         lambda x,w: torch.nn.functional.conv2d(x,w,stride=2).relu(),
-        lambda x,w: Tensor.conv2d(x,w,stride=stride).relu(), gpu=self.gpu)
+        lambda x,w: Tensor.conv2d(x,w,stride=stride).relu(), device=self.device)
     with self.subTest(stride := (2,1)):
       helper_test_op([(bs,cin,11,28), (4,cin,H,W)],
         lambda x,w: torch.nn.functional.conv2d(x,w,stride=stride).relu(),
-        lambda x,w: Tensor.conv2d(x,w,stride=(2,1)).relu(), gpu=self.gpu)
+        lambda x,w: Tensor.conv2d(x,w,stride=(2,1)).relu(), device=self.device)
 
   def test_maxpool2d(self):
     for ksz in [(2,2), (3,3), (3,2), (5,5), (5,1)]:
       with self.subTest(kernel_size=ksz):
         helper_test_op([(32,2,110,28)],
           lambda x: torch.nn.functional.max_pool2d(x, kernel_size=ksz),
-          lambda x: Tensor.max_pool2d(x, kernel_size=ksz), gpu=self.gpu)
+          lambda x: Tensor.max_pool2d(x, kernel_size=ksz), device=self.device)
 
   def test_avgpool2d(self):
     shape = (32,2,111,28)
@@ -147,11 +151,15 @@ class TestOps(unittest.TestCase):
       with self.subTest(kernel_size=ksz):
         helper_test_op([shape],
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=ksz),
-          lambda x: Tensor.avg_pool2d(x, kernel_size=ksz), gpu=self.gpu)
+          lambda x: Tensor.avg_pool2d(x, kernel_size=ksz), device=self.device)
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestOpsGPU(TestOps):
-  gpu = True
+  device=DeviceTypes.GPU
+
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestOpsANE(TestOps):
+  device=DeviceTypes.ANE
 
 if __name__ == '__main__':
   unittest.main(verbosity=2)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -11,7 +11,7 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn, atol=0, rtol=1e-6, grad_atol=0
   ts = [torch.rand(x, requires_grad=True) for x in shps]
   tst = [Tensor(x.detach().numpy()) for x in ts]
   if device==DeviceTypes.GPU:
-    tst = [x.cuda() for x in tst]
+    tst = [x.gpu() for x in tst]
   elif device==DeviceTypes.ANE:
     tst = [x.ane() for x in tst]
 

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -12,7 +12,7 @@ m_init = np.random.randn(1,3).astype(np.float32)
 def step_tinygrad(optim, kwargs={}, device=DeviceTypes.CPU):
   net = TinyNet()
   optim = optim([net.x, net.W], **kwargs)
-  if device==DeviceTypes.GPU: [x.cuda_() for x in get_parameters([net, optim])]
+  if device==DeviceTypes.GPU: [x.gpu_() for x in get_parameters([net, optim])]
   elif device==DeviceTypes.ANE: [x.ane_() for x in get_parameters([net, optim])]
   out = net.forward()
   out.backward()

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 from tinygrad.optim import Adam, SGD, RMSprop
 from extra.utils import get_parameters
 
@@ -9,11 +9,11 @@ x_init = np.random.randn(1,3).astype(np.float32)
 W_init = np.random.randn(3,3).astype(np.float32)
 m_init = np.random.randn(1,3).astype(np.float32)
 
-def step_tinygrad(optim, kwargs={}, device=DeviceTypes.CPU):
+def step_tinygrad(optim, kwargs={}, device=Device.CPU):
   net = TinyNet()
   optim = optim([net.x, net.W], **kwargs)
-  if device==DeviceTypes.GPU: [x.gpu_() for x in get_parameters([net, optim])]
-  elif device==DeviceTypes.ANE: [x.ane_() for x in get_parameters([net, optim])]
+  if device==Device.GPU: [x.gpu_() for x in get_parameters([net, optim])]
+  elif device==Device.ANE: [x.ane_() for x in get_parameters([net, optim])]
   out = net.forward()
   out.backward()
   optim.step()
@@ -55,7 +55,7 @@ class TorchNet():
 
 
 class TestOptim(unittest.TestCase):
-  device = DeviceTypes.CPU
+  device = Device.CPU
 
   def test_adam(self):
     for x,y in zip(step_tinygrad(Adam, device=self.device),
@@ -76,11 +76,11 @@ class TestOptim(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestOptimGPU(TestOptim):
-  device = DeviceTypes.GPU
+  device = Device.GPU
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestOptimANE(TestOptim):
-  device = DeviceTypes.ANE
+  device = Device.ANE
 
 
 if __name__ == '__main__':

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,9 +1,10 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
 from tinygrad.optim import Adam, SGD, RMSprop
 from extra.utils import get_parameters
+from .config import ANE
 
 x_init = np.random.randn(1,3).astype(np.float32)
 W_init = np.random.randn(3,3).astype(np.float32)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
+from tinygrad.tensor import Tensor, ANE, GPU, Device
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 
 x_init = np.random.randn(1,3).astype(np.float32)
@@ -11,7 +11,7 @@ W_init = np.random.randn(3,3).astype(np.float32)
 m_init = np.random.randn(1,3).astype(np.float32)
 
 class TestTinygrad(unittest.TestCase):
-  device = DeviceTypes.CPU
+  device = Device.CPU
 
   def test_backward_pass(self):
     def test_tinygrad():
@@ -100,7 +100,7 @@ class TestTinygrad(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestTinygradGPU(TestTinygrad):
-  device = DeviceTypes.GPU
+  device = Device.GPU
 
   @unittest.skip("float64 not supported on GPU")
   def test_jacobian(self): pass
@@ -110,7 +110,7 @@ class TestTinygradGPU(TestTinygrad):
 
 @unittest.skipUnless(ANE, "Requires ANE")
 class TestOpsANE(TestTinygrad):
-  device=DeviceTypes.ANE
+  device=Device.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,8 +1,10 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad.tensor import Tensor, ANE, GPU, Device
+from tinygrad.tensor import Tensor, GPU, Device
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
+from .config import ANE
+
 
 x_init = np.random.randn(1,3).astype(np.float32)
 U_init = np.random.randn(3,3).astype(np.float32)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -48,8 +48,7 @@ class TestTinygrad(unittest.TestCase):
       out = out.logsoftmax()
       out = out.sum()
       out.backward()
-      out = out.cpu()
-      return out.data, u.grad.data, v.grad.data, w.grad.data
+      return out.cpu().data, u.cpu().grad.data, v.cpu().grad.data, w.cpu().grad.data
 
     def test_pytorch():
       u = torch.tensor(U_init, requires_grad=True)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 import unittest
-from tinygrad.tensor import Tensor, GPU
+from tinygrad.tensor import Tensor, ANE, GPU, DeviceTypes
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 
 x_init = np.random.randn(1,3).astype(np.float32)
@@ -11,13 +11,13 @@ W_init = np.random.randn(3,3).astype(np.float32)
 m_init = np.random.randn(1,3).astype(np.float32)
 
 class TestTinygrad(unittest.TestCase):
-  gpu = False
+  device = DeviceTypes.CPU
 
   def test_backward_pass(self):
     def test_tinygrad():
-      x = Tensor(x_init, gpu=self.gpu)
-      W = Tensor(W_init, gpu=self.gpu)
-      m = Tensor(m_init, gpu=self.gpu)
+      x = Tensor(x_init, device=self.device)
+      W = Tensor(W_init, device=self.device)
+      m = Tensor(m_init, device=self.device)
       out = x.dot(W).relu()
       out = out.logsoftmax()
       out = out.mul(m).add(m).sum()
@@ -39,15 +39,16 @@ class TestTinygrad(unittest.TestCase):
 
   def test_backward_pass_diamond_model(self):
     def test_tinygrad():
-      u = Tensor(U_init)
-      v = Tensor(V_init)
-      w = Tensor(W_init)
+      u = Tensor(U_init, device=self.device)
+      v = Tensor(V_init, device=self.device)
+      w = Tensor(W_init, device=self.device)
       x = u.mul(v).relu()
       y = u.mul(w).relu()
       out = x.add(y).mul(y).relu()
       out = out.logsoftmax()
       out = out.sum()
       out.backward()
+      out = out.cpu()
       return out.data, u.grad.data, v.grad.data, w.grad.data
 
     def test_pytorch():
@@ -74,8 +75,8 @@ class TestTinygrad(unittest.TestCase):
     torch_func = lambda x: torch.nn.functional.log_softmax(x.matmul(torch_W).relu(), dim=1)
     PJ = torch.autograd.functional.jacobian(torch_func, torch_x).squeeze().numpy()
 
-    tiny_x = Tensor(x, gpu=self.gpu)
-    tiny_W = Tensor(W, gpu=self.gpu)
+    tiny_x = Tensor(x, device=self.device)
+    tiny_W = Tensor(W, device=self.device)
     tiny_func = lambda x: x.dot(tiny_W).relu().logsoftmax()
     J = jacobian(tiny_func, tiny_x)
     NJ = numerical_jacobian(tiny_func, tiny_x)
@@ -87,8 +88,8 @@ class TestTinygrad(unittest.TestCase):
     W = np.random.RandomState(1337).random((10, 5))
     x = np.random.RandomState(7331).random((1, 10)) - 0.5
 
-    tiny_x = Tensor(x, gpu=self.gpu)
-    tiny_W = Tensor(W, gpu=self.gpu)
+    tiny_x = Tensor(x, device=self.device)
+    tiny_W = Tensor(W, device=self.device)
     tiny_func = lambda x: x.dot(tiny_W).relu().logsoftmax()
 
     self.assertTrue(gradcheck(tiny_func, tiny_x))
@@ -99,7 +100,7 @@ class TestTinygrad(unittest.TestCase):
 
 @unittest.skipUnless(GPU, "Requires GPU")
 class TestTinygradGPU(TestTinygrad):
-  gpu = True
+  device = DeviceTypes.GPU
 
   @unittest.skip("float64 not supported on GPU")
   def test_jacobian(self): pass
@@ -107,6 +108,9 @@ class TestTinygradGPU(TestTinygrad):
   @unittest.skip("float64 not supported on GPU")
   def test_gradcheck(self): pass
 
+@unittest.skipUnless(ANE, "Requires ANE")
+class TestOpsANE(TestTinygrad):
+  device=DeviceTypes.ANE
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/ops_gpu.py
+++ b/tinygrad/ops_gpu.py
@@ -1,5 +1,5 @@
 import numpy as np
-from .tensor import Function, register, GPUBuffer, Tensor, DeviceTypes
+from .tensor import Function, register, GPUBuffer, Tensor, Device
 import pyopencl as cl
 import functools
 
@@ -178,7 +178,7 @@ class Add(Function):
     grad_x, grad_y = grad_output, grad_output
     shape_x, shape_y = ctx.saved_tensors
     return unbroadcast(ctx, grad_x, shape_x), unbroadcast(ctx, grad_y, shape_y),
-register('add', Add, device=DeviceTypes.GPU)
+register('add', Add, device=Device.GPU)
 
 class Sub(Function):
   @staticmethod
@@ -191,7 +191,7 @@ class Sub(Function):
     grad_x, grad_y = grad_output, unary_op(ctx, '-a', grad_output)
     shape_x, shape_y = ctx.saved_tensors
     return unbroadcast(ctx, grad_x, shape_x), unbroadcast(ctx, grad_y, shape_y),
-register('sub', Sub, device=DeviceTypes.GPU)
+register('sub', Sub, device=Device.GPU)
 
 class Mul(Function):
   @staticmethod
@@ -205,7 +205,7 @@ class Mul(Function):
     grad_x = binary_op(ctx, 'a*b', y, grad_output)
     grad_y = binary_op(ctx, 'a*b', x, grad_output)
     return unbroadcast(ctx, grad_x, x.shape), unbroadcast(ctx, grad_y, y.shape),
-register('mul', Mul, device=DeviceTypes.GPU)
+register('mul', Mul, device=Device.GPU)
 
 class Pow(Function):
   @staticmethod
@@ -221,7 +221,7 @@ class Pow(Function):
     grad_y = binary_op(ctx, 'a*b', grad_output,
                       binary_op(ctx, 'pow(a, (float)b) * log(a);', x, y))
     return unbroadcast(ctx, grad_x, x.shape), unbroadcast(ctx, grad_y, y.shape),
-register('pow', Pow, device=DeviceTypes.GPU)
+register('pow', Pow, device=Device.GPU)
 
 class Sum(Function):
   @staticmethod
@@ -238,7 +238,7 @@ class Sum(Function):
     shape = [1 if axis is None or i in axis else input.shape[i] for i in range(len(input.shape))]
     output = GPUBuffer(shape, hostbuf=grad_output)
     return binary_op(ctx, 'a+b', output, buffer_new(ctx, input.shape))
-register('sum', Sum, device=DeviceTypes.GPU)
+register('sum', Sum, device=Device.GPU)
 
 class Dot(Function):
   @staticmethod
@@ -289,7 +289,7 @@ class Dot(Function):
       i32(1), msize, isize, i32(1), osize, osize)
 
     return grad_input, grad_weight
-register('dot', Dot, device=DeviceTypes.GPU)
+register('dot', Dot, device=Device.GPU)
 
 # ************* simple ops *************
 
@@ -332,7 +332,7 @@ class Pad2D(Function):
               i32(oy), i32(ox), i32(iy), i32(ix)
              )
     return ret
-register('pad2d', Pad2D, device=DeviceTypes.GPU)
+register('pad2d', Pad2D, device=Device.GPU)
 
 class Reshape(Function):
   @staticmethod
@@ -347,7 +347,7 @@ class Reshape(Function):
   def backward(ctx, grad_output):
     in_shape, = ctx.saved_tensors
     return GPUBuffer(in_shape, hostbuf=grad_output)
-register('reshape', Reshape, device=DeviceTypes.GPU)
+register('reshape', Reshape, device=Device.GPU)
 
 # ************* activation ops *************
 
@@ -361,7 +361,7 @@ class ReLU(Function):
   def backward(ctx, grad_output):
     input, = ctx.saved_tensors
     return binary_op(ctx, 'a * (b >= 0)', grad_output, input)
-register('relu', ReLU, device=DeviceTypes.GPU)
+register('relu', ReLU, device=Device.GPU)
 
 class Sigmoid(Function):
   @staticmethod
@@ -374,7 +374,7 @@ class Sigmoid(Function):
   def backward(ctx, grad_output):
     ret, = ctx.saved_tensors
     return binary_op(ctx, 'a * (b * (1 - b));', grad_output, ret)
-register('sigmoid', Sigmoid, device=DeviceTypes.GPU)
+register('sigmoid', Sigmoid, device=Device.GPU)
 
 class AvgPool2D(Function):
   @staticmethod
@@ -389,7 +389,7 @@ class AvgPool2D(Function):
     orig_shape, = ctx.saved_tensors
     return supersample_op(ctx, grad_output, orig_shape, ctx.kernel_size,
       result_op="input[iid] / (ksz.x * ksz.y)")
-register('avg_pool2d', AvgPool2D, device=DeviceTypes.GPU)
+register('avg_pool2d', AvgPool2D, device=Device.GPU)
 
 class MaxPool2D(Function):
   @staticmethod
@@ -409,7 +409,7 @@ class MaxPool2D(Function):
       result_op="(maxidx == kernidx) * input[iid]",
       decls="int maxidx=((__global float*)input2)[iid]; int kernidx=(gid.x%ksz.x) + ksz.x*(gid.y%ksz.y)",
       input2=idxs)
-register('max_pool2d', MaxPool2D, device=DeviceTypes.GPU)
+register('max_pool2d', MaxPool2D, device=Device.GPU)
 
 class LogSoftmax(Function):
   @staticmethod
@@ -426,7 +426,7 @@ class LogSoftmax(Function):
     lsum = reduce_op(ctx, "out += a", "out", grad_output, axis=[1])
     texp = binary_op(ctx, "exp(a) * b", output, lsum)
     return binary_op(ctx, "a - b", grad_output, texp)
-register('logsoftmax', LogSoftmax, device=DeviceTypes.GPU)
+register('logsoftmax', LogSoftmax, device=Device.GPU)
 
 # ************* conv ops *************
 
@@ -553,4 +553,4 @@ class Conv2D(Function):
     convw(ctx.cl_queue, [ctx.groups*rcout*cin, H, W], None, x.cl, grad_output.cl, dw.cl, *conv_args)
     convx(ctx.cl_queue, [bs, ctx.groups, cin], None, w.cl, grad_output.cl, dx.cl, *conv_args)
     return dx, dw
-register('conv2d', Conv2D, device=DeviceTypes.GPU)
+register('conv2d', Conv2D, device=Device.GPU)

--- a/tinygrad/ops_gpu.py
+++ b/tinygrad/ops_gpu.py
@@ -237,7 +237,7 @@ class Sum(Function):
     input, axis = ctx.saved_tensors
     shape = [1 if axis is None or i in axis else input.shape[i] for i in range(len(input.shape))]
     output = GPUBuffer(shape, hostbuf=grad_output)
-    return binary_op(ctx, 'a+b', output, buffer_new(ctx, input.shape))
+    return binary_op(ctx, 'a+b', output, buffer_new(ctx, input.shape, zero=True))
 register('sum', Sum, device=Device.GPU)
 
 class Dot(Function):

--- a/tinygrad/optim.py
+++ b/tinygrad/optim.py
@@ -25,7 +25,7 @@ class RMSprop(Optimizer):
     super(RMSprop, self).__init__(params)
     self.lr, self.decay, self.eps = lr, decay, eps
 
-    self.v = [Tensor(np.zeros(t.shape, dtype=np.float32), gpu=params[0].gpu, requires_grad=False) for t in self.params]
+    self.v = [Tensor(np.zeros(t.shape, dtype=np.float32), device=params[0].device, requires_grad=False) for t in self.params]
 
   def step(self):
     for i, t in enumerate(self.params):
@@ -37,8 +37,8 @@ class Adam(Optimizer):
     super(Adam, self).__init__(params)
     self.lr, self.b1, self.b2, self.eps, self.t = lr, b1, b2, eps, 0
 
-    self.m = [Tensor(np.zeros(t.shape, dtype=np.float32), gpu=params[0].gpu, requires_grad=False) for t in self.params]
-    self.v = [Tensor(np.zeros(t.shape, dtype=np.float32), gpu=params[0].gpu, requires_grad=False) for t in self.params]
+    self.m = [Tensor(np.zeros(t.shape, dtype=np.float32), device=params[0].device, requires_grad=False) for t in self.params]
+    self.v = [Tensor(np.zeros(t.shape, dtype=np.float32), device=params[0].device, requires_grad=False) for t in self.params]
 
   def step(self):
     self.t = self.t + 1

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -204,7 +204,7 @@ class Tensor:
     self.change_device(DeviceTypes.GPU)
 
   def cuda(self):
-    ret = Tensor(self.data_to_device(self.data, device=DeviceTypes.GPU), device=DeviceTypes.GPU)
+    ret = Tensor(self.data, device=DeviceTypes.GPU)
     if self.grad:
       ret.grad = self.grad.cuda()
     return ret
@@ -214,7 +214,7 @@ class Tensor:
 
   def ane(self):
     # NOTE: This does not convert grad to ANE?
-    ret = Tensor(self.data_to_device(self.data, device=DeviceTypes.ANE), device=DeviceTypes.ANE)
+    ret = Tensor(self.data, device=DeviceTypes.ANE)
     if self.grad:
       ret.grad = self.grad.ane()
     return ret

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -59,13 +59,11 @@ class GPUBuffer:
 # **** ANE functions ****
 
 ane = None
-ANE = False
 def require_init_ane():
   global ane
   if ane is None:
     import ane.lib.ane, tinygrad.ops_ane
     ane = ane.lib.ane.ANE()
-    ANE = True
 
 # **** start with two base classes, Tensor and Function ****
 


### PR DESCRIPTION
This PR aims to resolve 4 issues:
1. No tests for ANE
2. Device to device conversion
3. Failure to run GPU Tests
4. Failing GPU tests

__Sorry, but this will be long.__

### 1. No tests for ANE
Test calls have been added for the ANE device which will envoke ANE tensors when running tests. Same as GPU
``` python
@unittest.skipUnless(ANE, "Requires ANE")
class TestNNANE(TestNN):
  device=DeviceTypes.ANE
```
### 2. Device to device conversion
To be able to support ANE in tests, it is required that ANE support the same conversion as CPU->GPU and GPU->CPU. 
I have created a universal any to any converter. This function accepts any of the accepted datatypes (GPUBuffer, ane.tensor and any np.ndarray compatible data) and returns the converted data.
``` python
@staticmethod
def data_to_device(data, device=DeviceTypes.CPU):
```

### 3. Failure to run GPU Tests
CI tests have not been run since [1a1c63a](https://github.com/geohot/tinygrad/commit/1a1c63a08b713e8b491e2dd23f0fa92646f5af38). This appears to have been caused by a missing `six` dependency that was thrown inside the try except for importing `pyopencl`, therefore defaulting `GPU=False`

### 4. Failing GPU tests
GPU tests are failing. Don't think I caused it as it is accuracy asserts being raised, but not 100%:
i.e.
```
>         np.testing.assert_allclose(t.grad, tt.grad.cpu().data, atol=grad_atol, rtol=grad_rtol)
E         AssertionError: 
E         Not equal to tolerance rtol=1e-06, atol=1e-06
E         
E         Mismatched elements: 2925 / 2925 (100%)
```
Potentially a change since OpenCL tests last passed. 
