### PR TITLE
refactor/softmax

### DIFF
--- a/tinygrad/ops_cpu.py
+++ b/tinygrad/ops_cpu.py
@@ -134,9 +134,13 @@ def _exp_normalize(x, axis=None):
 
 class Sigmoid(Function):
   @staticmethod
-  def forward(ctx, x):
-    xpad = np.pad(x.reshape((-1,1)), [(0,0),(1,0)], constant_values=0.)
-    ret = _exp_normalize(xpad, axis=1).take(1, axis=1).reshape(x.shape)
+  def forward(ctx, input):
+    with np.warnings.catch_warnings():
+      np.warnings.filterwarnings('ignore')
+      ret = np.where(input >= 0,
+        1/(1 + np.exp(-input)),
+        np.exp(input)/(1 + np.exp(input))
+      )
     ctx.save_for_backward(ret)
     return ret
 


### PR DESCRIPTION
Was just reading through the library and trying to understand it. Made some changes that might/might-not be worth it! Let me know what you guys think.

Generalized logsoftmax and sigmoid with softmax.

- 0.3% less lines 😊 
- fewer calculations
    - we need to calculate the gradient of logsoftmax in backward pass
    - previous impl does this by exponentiating the forward pass output -> this means the exp of a log of a exp
    - instead we can remove one of the exponentiation ops by going straight out of logspace
        - by calculating the softmax
            - taking the log for the forward pass
            - reusing the softmax in the backward pass -> since softmax is the derivative of logsumexp
- more numerically stable (log of softmax vs exp of logsumexp)
- maybe bad because more memory for sigmoid padding

References:
- https://math.stackexchange.com/a/2340848
- https://timvieira.github.io/blog/post/2014/02/11/exp-normalize-trick/
- https://blog.feedly.com/tricks-of-the-trade-logsumexp/