### PR TITLE
made smoler -- and a couple of other things

### DIFF
--- a/tinygrad/nn.py
+++ b/tinygrad/nn.py
@@ -3,26 +3,19 @@ from tinygrad.tensor import Tensor
 class BatchNorm2D:
   def __init__(self, sz, eps=1e-5, track_running_stats=False, training=False, momentum=0.1):
     self.eps, self.track_running_stats, self.training, self.momentum = eps, track_running_stats, training, momentum
-
-    self.weight, self.bias = Tensor.ones(sz), Tensor.zeros(sz)
-
+    self.weight, self.bias, self.num_batches_tracked = Tensor.ones(sz), Tensor.zeros(sz), Tensor.zeros(1, requires_grad=False)
     self.running_mean, self.running_var = Tensor.zeros(sz, requires_grad=False), Tensor.ones(sz, requires_grad=False)
-    self.num_batches_tracked = Tensor.zeros(1, requires_grad=False)
 
   def __call__(self, x):
     if self.track_running_stats or self.training:
       batch_mean = x.mean(axis=(0,2,3))
       y = (x - batch_mean.reshape(shape=[1, -1, 1, 1]))
       batch_var = (y*y).mean(axis=(0,2,3))
-
     if self.track_running_stats:
       self.running_mean = (1 - self.momentum) * self.running_mean + self.momentum * batch_mean
       self.running_var = (1 - self.momentum) * self.running_var + self.momentum * batch_var
       self.num_batches_tracked += 1
-
-    if self.training:
-      return self.normalize(x, batch_mean, batch_var)
-
+    if self.training: return self.normalize(x, batch_mean, batch_var)
     return self.normalize(x, self.running_mean, self.running_var)
 
   def normalize(self, x, mean, var):

--- a/tinygrad/ops_ane.py
+++ b/tinygrad/ops_ane.py
@@ -2,11 +2,8 @@ from .tensor import Device, Function, register
 from functools import lru_cache
 
 @lru_cache
-def compile_wrapper(ane, dat):
-  return ane.compile(dat)
-
-def roundup(x, v):
-  return x + (v-x)%v
+def compile_wrapper(ane, dat): return ane.compile(dat)
+def roundup(x, v): return x + (v-x)%v
 
 @lru_cache
 def compile_relu(ane, sz):
@@ -24,8 +21,8 @@ def compile_relu(ane, sz):
 
 class ReLU(Function):
   @staticmethod
-  def forward(ctx, input):
-    ret = ctx.ane.tensor(input.shape)
-    ctx.ane.run(compile_relu(ctx.ane, input.sz), input, ret)
+  def forward(ctx, _input):
+    ret = ctx.ane.tensor(_input.shape)
+    ctx.ane.run(compile_relu(ctx.ane, _input.sz), _input, ret)
     return ret
 register('relu', ReLU, device=Device.ANE)

--- a/tinygrad/ops_cpu.py
+++ b/tinygrad/ops_cpu.py
@@ -146,7 +146,7 @@ class LogSoftmax(Function):
 
   @staticmethod
   def backward(ctx, grad_output):
-      return (lambda gout, s: gout - gout.sum(axis=1, keepdims=True)*s)(grad_output, *ctx.saved_tensors)
+    return (lambda gout, s: gout - gout.sum(axis=1, keepdims=True)*s)(grad_output, *ctx.saved_tensors)
 register('logsoftmax', LogSoftmax)
 
 

--- a/tinygrad/optim.py
+++ b/tinygrad/optim.py
@@ -8,8 +8,7 @@ class Optimizer:
     self.params = [x for x in params if x.requires_grad == True]
 
   def zero_grad(self):
-    for param in self.params:
-      param.grad = None
+    for param in self.params: param.grad = None
 
 class SGD(Optimizer):
   def __init__(self, params, lr=0.001):
@@ -17,14 +16,12 @@ class SGD(Optimizer):
     self.lr = lr
 
   def step(self):
-    for t in self.params:
-      t -= t.grad * self.lr
+    for t in self.params: t -= t.grad * self.lr
 
 class RMSprop(Optimizer):
   def __init__(self, params, lr=0.001, decay=0.9, eps=1e-8):
     super().__init__(params)
     self.lr, self.decay, self.eps = lr, decay, eps
-
     self.v = [Tensor(np.zeros(t.shape, dtype=np.float32), device=params[0].device, requires_grad=False) for t in self.params]
 
   def step(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -136,8 +136,7 @@ class Tensor:
       assert (t0.grad is not None)
       with ProfileOp(t0._ctx.__class__.__name__, [t0.grad], backward=True):
         grads = t0._ctx.backward(t0._ctx, t0.grad.data)
-      if len(t0._ctx.parents) == 1:
-        grads = [grads]
+      if len(t0._ctx.parents) == 1: grads = [grads]
       for t,g in zip(t0._ctx.parents, grads):
         if g is not None:
           assert g.shape == t.shape, \
@@ -161,8 +160,7 @@ class Tensor:
       with ProfileOp("toCPU", [data]):
         data = data.data().astype(np.float32)
 
-    if not isinstance(data, np.ndarray):
-      data = np.array(data, dtype=np.float32)
+    if not isinstance(data, np.ndarray): data = np.array(data, dtype=np.float32)
 
     if data.dtype != np.float32 and not Tensor.did_float_warning:
       # warning? float64 is actually needed for numerical jacobian
@@ -203,8 +201,7 @@ class Tensor:
 
   def mean(self, axis=None):
     out = self.sum(axis=axis)
-    coeff = np.prod(out.shape)/np.prod(self.shape)
-    return out * coeff
+    return out * (np.prod(out.shape)/np.prod(self.shape)) # out * coeff
 
   def sqrt(self):
     return self.pow(0.5)
@@ -237,6 +234,7 @@ class Function:
 
   def save_for_backward(self, *x):
     self.saved_tensors.extend(x)
+    return x
 
   def apply(self, *x, **kwargs):
     ctx = self(*x) # self - operation i.e 'add', 'sub', etc.
@@ -251,8 +249,7 @@ class Function:
     with ProfileOp(ctx.__class__.__name__, x):
       ret = Tensor(self.forward(ctx, *[t.data for t in x], **kwargs),
                    device=ctx.device, requires_grad=any([t.requires_grad for t in x]))
-    if ret.requires_grad:
-      ret._ctx = ctx
+    if ret.requires_grad: ret._ctx = ctx
     return ret
 
 def register(name, fxn, device=Device.CPU):


### PR DESCRIPTION
I should've done this in multiple branches, but here goes:
1. made the `ctx.save_for_backward` return it's params, that made it possible to cut down on lines by not having an extra line just to save the params
2. converted a bunch of the backwards into lambdas, this cut down on the lines for un-marshaling from the save
3. replaced instances of `input` with `_input` since it's a python reserved word