### PR TITLE
add an aneccompile example in Objective-C

### DIFF
--- a/ane/2_compile/compile.m
+++ b/ane/2_compile/compile.m
@@ -2,8 +2,11 @@
 #include <os/log.h>
 #include <stdio.h>
 
+typedef unsigned int ANECStatus;
+
 int ANECCompile(NSDictionary* param_1, NSDictionary* param_2,
-    unsigned long param_3);
+    void (^param_3)(ANECStatus status,
+        NSDictionary* statusDictionary));
 
 int main(int argc, char* argv[])
 {
@@ -39,8 +42,15 @@ int main(int argc, char* argv[])
         optionsDictionary[@"OutputFileName"] = @"model.hwx";
     }
 
+    void (^simpleBlock)(ANECStatus status, NSDictionary* statusDictionary) = ^(ANECStatus status, NSDictionary* statusDictionary) {
+        NSLog(@"status = %d\n", status);
+        // when status != 0 dump the dictionary
+        if (status)
+            NSLog(@"%@", statusDictionary);
+    };
+
     printf("hello\n");
-    int ret = ANECCompile(optionsDictionary, flagsDictionary, 0);
+    int ret = ANECCompile(optionsDictionary, flagsDictionary, simpleBlock);
     printf("compile: %d\n", ret);
 
     return ret;

--- a/ane/2_compile/compile.m
+++ b/ane/2_compile/compile.m
@@ -1,0 +1,47 @@
+#import <Foundation/Foundation.h>
+#include <os/log.h>
+#include <stdio.h>
+
+int ANECCompile(NSDictionary* param_1, NSDictionary* param_2,
+    unsigned long param_3);
+
+int main(int argc, char* argv[])
+{
+    os_log(OS_LOG_DEFAULT, "start compiler");
+
+    NSDictionary* iDictionary = @ {
+        @"NetworkPlistName" : [NSString stringWithCString:argv[1]
+                                                 encoding:NSUTF8StringEncoding],
+        @"NetworkPlistPath" : @"./",
+    };
+    NSArray* plistArray = @[ iDictionary ];
+
+    NSMutableDictionary* optionsDictionary =
+        [NSMutableDictionary dictionaryWithCapacity:4];
+    NSMutableDictionary* flagsDictionary =
+        [NSMutableDictionary dictionaryWithCapacity:4];
+    optionsDictionary[@"InputNetworks"] = plistArray;
+
+    optionsDictionary[@"OutputFilePath"] = @"./";
+
+    // h11 (or anything?) works here too, and creates different outputs that don't
+    // run
+    flagsDictionary[@"TargetArchitecture"] = @"h13";
+
+    if (argc > 2) {
+        optionsDictionary[@"OutputFileName"] = @"debug/model.hwx";
+
+        flagsDictionary[@"CompileANEProgramForDebugging"] =
+            [NSNumber numberWithBool:YES];
+        int debug_mask = 0x7fffffff;
+        flagsDictionary[@"DebugMask"] = [NSNumber numberWithInt:debug_mask];
+    } else {
+        optionsDictionary[@"OutputFileName"] = @"model.hwx";
+    }
+
+    printf("hello\n");
+    int ret = ANECCompile(optionsDictionary, flagsDictionary, 0);
+    printf("compile: %d\n", ret);
+
+    return ret;
+}


### PR DESCRIPTION
add a compile.m corresponding to compile.mm

build with
```clang compile.m -F /System/Library/PrivateFrameworks/ -framework ANECompiler -framework Foundation```

CoreFoundation framework is a C library.
Foundation is an Objective-C framework.

CF data structures in CoreFoundation usually have corresponding NS data structures in Foundation, e.g.,
NSDictionary is "toll-free bridged" with its Core Foundation counterpart, CFDictionary.
See [1].

[1] https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Toll-FreeBridgin/Toll-FreeBridgin.html