### PR TITLE
saving 50 LOC with automatic @staticmethod for forward and backward

### DIFF
--- a/tinygrad/ops_ane.py
+++ b/tinygrad/ops_ane.py
@@ -28,7 +28,6 @@ def compile_relu(ane, sz):
   return compile_wrapper(ane, bytes(dat))
 
 class ReLU(Function):
-  @staticmethod
   def forward(ctx, input):
     ret = ctx.ane.tensor(input.shape)
     ctx.ane.run(compile_relu(ctx.ane, input.sz), input, ret)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -293,6 +293,11 @@ class Tensor:
 
 # An instantiation of the Function is the Context
 class Function:
+  def __new__(cls, *args, **kwargs):
+    cls.forward = staticmethod(cls.forward)
+    cls.backward = staticmethod(cls.backward)
+    return super().__new__(cls)
+
   def __init__(self, *tensors):
     self.parents = tensors
     self.saved_tensors = []

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -296,7 +296,7 @@ class Function:
   def __new__(cls, *args, **kwargs):
     cls.forward = staticmethod(cls.forward)
     cls.backward = staticmethod(cls.backward)
-    return super().__new__(cls)
+    return super().__new__(cls) #
 
   def __init__(self, *tensors):
     self.parents = tensors


### PR DESCRIPTION
For all ops, the `forward` and `backward` methods should be static.
So, given that all ops inherit from `Function`, the `__new__` method in `Function` replaces `forward` and `backward` with their static version. This saves about 50 LOC in ops_cpu.py, ops_gpu.py and ops_ane.py.