### PR TITLE
Fixed OpenCL installation while running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
+    - name: Update packages
+      run: sudo apt-get update
     - name: Install OpenCL
       run: sudo apt-get install pocl-opencl-icd
     - name: Set up Python 3.8
@@ -60,6 +62,8 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
+    - name: Update packages
+      run: sudo apt-get update
     - name: Install OpenCL
       run: sudo apt-get install pocl-opencl-icd
     - name: Set up Python 3.8


### PR DESCRIPTION
This pull request fixes the OpenCL installation problem while running tests with Github actions.