### PR TITLE
8 8.005942 hen

### DIFF
--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -119,7 +119,7 @@ def riski_unop(op):
   elif op == UnaryOps.LOG:
     regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
   elif op == UnaryOps.EXP:
-    regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -88.72, 88.72))
+    regfile[Reg.MATMUL_OUTPUT] = np.asarray([np.exp(regfile[Reg.MATMUL_INPUT][i,:]) for i in range(regfile[Reg.MATMUL_INPUT].shape[0])])
   elif op == UnaryOps.GT0:
     regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
 
@@ -149,23 +149,9 @@ def riski_mulacc():
   # riski_mul / MATMUL_ACC += Reg.MATMUL_OUTPUT
   regfile[Reg.MATMUL_ACC] += regfile[Reg.MATMUL_INPUT] * regfile[Reg.MATMUL_WEIGHTS]
 
-# from numba import njit
-# @njit
-# def _matpow(inp, wht, out):
-#   out = np.empty_like(out)
-#   for i in range(inp.shape[0]):
-#     for j in range(wht.shape[1]):
-#       for k in range(wht.shape[0]):
-#         out[i][k] = np.sign(inp[i][k]) * np.abs(inp[i][k]) ** wht[k][j]
-#   return out
-
 @count
 def riski_pow():
- # # jit function for matmul_pow, outputs array equal to what is generated below. runs about 15% slower but throws no errors for some reason. 
- # regfile[Reg.MATMUL_OUTPUT] = _matpow(regfile[Reg.MATMUL_INPUT], regfile[Reg.MATMUL_WEIGHTS], regfile[Reg.MATMUL_OUTPUT])
-  with np.errstate(divide='ignore', invalid='ignore'): # ** otional ** (ignores errors from producing nan's but predictions output the same.)
-    regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
-  regfile[Reg.MATMUL_OUTPUT][np.isnan(regfile[Reg.MATMUL_OUTPUT])] = 0 # ** otional ** (replaces nan's with zeros but prediction output is the same.)
+  with np.errstate(divide='ignore', invalid='ignore'): regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
 
 @count
 def riski_reduce_sum(cnt=SZ, tgt=0, acc=False):

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -120,12 +120,10 @@ def riski_unop(op):
     regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
   elif op == UnaryOps.EXP:
     # np.clip() clips the output to a threshhold. 88.72 is the max param for 32bit.
-    # effnet b2 passes the gigachicken and b2 confidence is nearly the same as b0. tested 5 others images and predictions are same as b0.
+    # effnet b2 passes gigachicken and b2 confidence is nearly the same as b0. tested 5 others images and predictions are same as b0.
     # with clip seems to benchmark in the same amount of time as without np.clip() (+/- blessed windows antivirus).
-    # errors fixed out of 4 total:
-      # 2. np.exp() overflow
-      # 3. MATMUL "invalid value"
-		regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -88.72, 88.72))
+    # errors fixed np.exp() overflow, MATMUL "invalid value"
+    regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -88.72, 88.72))
   elif op == UnaryOps.GT0:
     regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
 

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -130,19 +130,20 @@ def soft_clip(n):
     lim = limit * sign
   scale = lim - threshold
   compressed = scale * np.sin((amplitude - threshold) / scale)
-  if n >= limit:
-    print(n)
   return (threshold + int(compressed)) * sign
 
 ### get indexes of input greater than f32 limit ###
 exp_count = 0
 def check_index(inp):
-  global exp_count
-  for i in range(inp.shape[0]):
-    for j in range(inp.shape[1]):
-      if inp[i][j] > limit:
-        print(i, j)
-        print(exp_count)
+	global exp_count
+	exp_count += 1
+	for i in range(inp.shape[0]):
+		for j in range(inp.shape[1]):
+			if inp[i][j] > limit:
+				print('EXP op number:', exp_count)
+				print(f'row: {i}  column: {j}')
+				print('value:', inp[i][j])
+        print()
 
 # *** instructions ***
 @count
@@ -152,10 +153,7 @@ def riski_unop(op):
   elif op == UnaryOps.LOG:
     regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
   elif op == UnaryOps.EXP:
-
-    check_index(regfile[Reg.MATMUL_INPUT])
-    global exp_count
-    exp_count += 1
+#     check_index(regfile[Reg.MATMUL_INPUT])
 
     # easiest implementation and fastest run time
     regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -limit, limit))

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -135,15 +135,15 @@ def soft_clip(n):
 ### get indexes of input greater than f32 limit ###
 exp_count = 0
 def check_index(inp):
-	global exp_count
-	exp_count += 1
-	for i in range(inp.shape[0]):
-		for j in range(inp.shape[1]):
-			if inp[i][j] > limit:
-				print('EXP op number:', exp_count)
-				print(f'row: {i}  column: {j}')
-				print('value:', inp[i][j])
-        print()
+  global exp_count
+  exp_count += 1
+    for i in range(inp.shape[0]):
+      for j in range(inp.shape[1]):
+        if inp[i][j] > limit:
+          print('EXP op number:', exp_count)
+          print(f'row: {i}  column: {j}')
+          print('value:', inp[i][j])
+          print()
 
 # *** instructions ***
 @count

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -149,10 +149,23 @@ def riski_mulacc():
   # riski_mul / MATMUL_ACC += Reg.MATMUL_OUTPUT
   regfile[Reg.MATMUL_ACC] += regfile[Reg.MATMUL_INPUT] * regfile[Reg.MATMUL_WEIGHTS]
 
+# from numba import njit
+# @njit
+# def _matpow(inp, wht, out):
+# 	out = np.empty_like(out)
+# 	for i in range(inp.shape[0]):
+# 		for j in range(wht.shape[1]):
+# 			for k in range(wht.shape[0]):
+# 				out[i][k] = np.sign(inp[i][k]) * np.abs(inp[i][k]) ** wht[k][j]
+# 	return out
+
 @count
 def riski_pow():
-  regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0] = np.abs(regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0]) +.00000001
-  regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
+ # # jit function for matmul_pow, outputs array equal to what is generated below. runs about 15% slower but throws no errors for some reason. 
+ # regfile[Reg.MATMUL_OUTPUT] = _matpow(regfile[Reg.MATMUL_INPUT], regfile[Reg.MATMUL_WEIGHTS], regfile[Reg.MATMUL_OUTPUT])
+  with np.errstate(divide='ignore', invalid='ignore'): # ** otional ** (ignores errors from producing nan's but predictions output the same.)
+    regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
+  regfile[Reg.MATMUL_OUTPUT][np.isnan(regfile[Reg.MATMUL_OUTPUT])] = 0 # ** otional ** (replaces nan's with zeros but prediction output is the same.)
 
 @count
 def riski_reduce_sum(cnt=SZ, tgt=0, acc=False):

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -119,10 +119,6 @@ def riski_unop(op):
   elif op == UnaryOps.LOG:
     regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
   elif op == UnaryOps.EXP:
-    # np.clip() clips the output to a threshhold. 88.72 is the max param for 32bit.
-    # effnet b2 passes gigachicken and b2 confidence is nearly the same as b0. tested 5 others images and predictions are same as b0.
-    # with clip seems to benchmark in the same amount of time as without np.clip() (+/- blessed windows antivirus).
-    # errors fixed np.exp() overflow, MATMUL "invalid value"
     regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -88.72, 88.72))
   elif op == UnaryOps.GT0:
     regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
@@ -155,8 +151,6 @@ def riski_mulacc():
 
 @count
 def riski_pow():
-  # this is due to my noobness. it clears the 'power' and 'div by zero' warnings but effnet outputs the same -
-    # - confidence and prediction with or without but i dont know enough to understand the consequences of inverting the negative outputs.
   regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0] = np.abs(regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0]) +.00000001
   regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
 

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -119,7 +119,13 @@ def riski_unop(op):
   elif op == UnaryOps.LOG:
     regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
   elif op == UnaryOps.EXP:
-    regfile[Reg.MATMUL_OUTPUT] = np.exp(regfile[Reg.MATMUL_INPUT])
+    # np.clip() clips the output to a threshhold. 88.72 is the max param for 32bit.
+    # effnet b2 passes the gigachicken and b2 confidence is nearly the same as b0. tested 5 others images and predictions are same as b0.
+    # with clip seems to benchmark in the same amount of time as without np.clip() (+/- blessed windows antivirus).
+    # errors fixed out of 4 total:
+      # 2. np.exp() overflow
+      # 3. MATMUL "invalid value"
+		regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -88.72, 88.72))
   elif op == UnaryOps.GT0:
     regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
 
@@ -151,6 +157,9 @@ def riski_mulacc():
 
 @count
 def riski_pow():
+  # this is due to my noobness. it clears the 'power' and 'div by zero' warnings but effnet outputs the same -
+    # - confidence and prediction with or without but i dont know enough to understand the consequences of inverting the negative outputs.
+  regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0] = np.abs(regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] <= 0]) +.00000001
   regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] ** regfile[Reg.MATMUL_WEIGHTS]
 
 @count

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -152,12 +152,12 @@ def riski_mulacc():
 # from numba import njit
 # @njit
 # def _matpow(inp, wht, out):
-# 	out = np.empty_like(out)
-# 	for i in range(inp.shape[0]):
-# 		for j in range(wht.shape[1]):
-# 			for k in range(wht.shape[0]):
-# 				out[i][k] = np.sign(inp[i][k]) * np.abs(inp[i][k]) ** wht[k][j]
-# 	return out
+#   out = np.empty_like(out)
+#   for i in range(inp.shape[0]):
+#     for j in range(wht.shape[1]):
+#       for k in range(wht.shape[0]):
+#         out[i][k] = np.sign(inp[i][k]) * np.abs(inp[i][k]) ** wht[k][j]
+#   return out
 
 @count
 def riski_pow():

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -111,8 +111,9 @@ def cherry_regdump():
   print(regfile[Reg.MATMUL_OUTPUT])
 
 
-f32 = 3.4028237 * 10**38 # max 32 bit flaoting point value
+f32 = 3.4028237 * 10**38 # max 32 bit floating point value
 limit = np.log(f32) # 88.72283912072155
+limit = round(limit, 4)) # -0.00003912072155 # max limit still causes overflow
 
 ### soft clipping ###
 threshold = limit*0.99

--- a/extra/cherry.py
+++ b/extra/cherry.py
@@ -110,19 +110,70 @@ def cherry_regdump():
   print(regfile[Reg.MATMUL_WEIGHTS])
   print(regfile[Reg.MATMUL_OUTPUT])
 
-# *** instructions ***
 
+f32 = 3.4028237 * 10**38 # max 32 bit flaoting point value
+limit = np.log(f32) # 88.72283912072155
+
+### soft clipping ###
+threshold = limit*0.99
+from numba import njit
+@njit('float32(float32)', cache=True)
+def soft_clip(n):
+	if np.isnan(n):
+		return 0
+	amplitude = np.abs(n)
+	sign = 1 if n >= 0 else -1
+	if amplitude < threshold:
+		return n
+	if amplitude >= threshold:
+		lim = limit * sign
+	scale = lim - threshold
+	compressed = scale * np.sin((amplitude - threshold) / scale)
+	if n >= limit:
+		print(n)
+	return (threshold + int(compressed)) * sign
+
+### get indexes of input greater than f32 limit ###
+exp_count = 0
+def check_index(inp):
+	global exp_count
+	for i in range(inp.shape[0]):
+		for j in range(inp.shape[1]):
+			if inp[i][j] > limit:
+				print(i, j)
+				print(exp_count)
+
+# *** instructions ***
 @count
 def riski_unop(op):
-  if op == UnaryOps.RELU:
-    regfile[Reg.MATMUL_OUTPUT] = np.maximum(regfile[Reg.MATMUL_INPUT], 0)
-  elif op == UnaryOps.LOG:
-    regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
-  elif op == UnaryOps.EXP:
-    regfile[Reg.MATMUL_OUTPUT] = np.asarray([np.exp(regfile[Reg.MATMUL_INPUT][i,:]) for i in range(regfile[Reg.MATMUL_INPUT].shape[0])])
-  elif op == UnaryOps.GT0:
-    regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
+	if op == UnaryOps.RELU:
+		regfile[Reg.MATMUL_OUTPUT] = np.maximum(regfile[Reg.MATMUL_INPUT], 0)
+	elif op == UnaryOps.LOG:
+		regfile[Reg.MATMUL_OUTPUT] = np.log(regfile[Reg.MATMUL_INPUT])
+	elif op == UnaryOps.EXP:
+    ### get naughty index
+		check_index(regfile[Reg.MATMUL_INPUT])
+		global exp_count
+		exp_count += 1
 
+		# easiest and fastest run time
+		regfile[Reg.MATMUL_OUTPUT] = np.exp(np.clip(regfile[Reg.MATMUL_INPUT], -limit, limit))
+
+# 		#### this is essentially the same as above .clip() ####
+# 		regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] > limit] = limit
+# 		regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] < -limit] = -limit
+# 		regfile[Reg.MATMUL_OUTPUT] = np.exp(regfile[Reg.MATMUL_INPUT])
+
+# 		# soft clipping (redudant compared to clipping)
+# 		if regfile[Reg.MATMUL_INPUT][regfile[Reg.MATMUL_INPUT] >= limit].any():
+# 			x = np.array([np.exp(np.fromiter(map(soft_clip, regfile[Reg.MATMUL_INPUT][i]), dtype=np.float32)) for i in range(regfile[Reg.MATMUL_INPUT].shape[0])])
+# 			regfile[Reg.MATMUL_OUTPUT] = x
+# 			# regfile[Reg.MATMUL_OUTPUT] = np.array([np.exp(np.fromiter(map(soft_clip, regfile[Reg.MATMUL_INPUT][i]), dtype=np.float32)) for i in range(regfile[Reg.MATMUL_INPUT].shape[0])])
+# 		else:
+# 			regfile[Reg.MATMUL_OUTPUT] = np.exp(regfile[Reg.MATMUL_INPUT])
+
+	elif op == UnaryOps.GT0:
+		regfile[Reg.MATMUL_OUTPUT] = (regfile[Reg.MATMUL_INPUT] >= 0)
 @count
 def riski_add():
   regfile[Reg.MATMUL_OUTPUT] = regfile[Reg.MATMUL_INPUT] + regfile[Reg.MATMUL_WEIGHTS]


### PR DESCRIPTION
No idea if these are helpful but effnet b2 sees hen.

np.clip() limits the output to a floor/ceiling - 88.72 max param for 32bit.
b2 confidence nearly the same as b0. tested 5 other images and predictions are same as b0.
warnings fixed: exp 'overflow', MATMUL 'invalid value'

abs(POW) is due to my noobness. it clears the 'power' and 'div by zero' warnings but effnet outputs the same confidence & prediction with or without it. and I dont know enough to understand the consequences of inverting the negative outputs.