### PR TITLE
Cherry ops

### DIFF
--- a/tinygrad/ops/ops_cuda.py
+++ b/tinygrad/ops/ops_cuda.py
@@ -1,1 +1,2 @@
-../../accel/cuda/ops_cuda.py
+#../../accel/cuda/ops_cuda.py
+from accel.cuda.ops_cuda import *

--- a/tinygrad/ops/ops_metal.py
+++ b/tinygrad/ops/ops_metal.py
@@ -1,1 +1,3 @@
-../../accel/metal/ops_metal.py
+#../../accel/metal/ops_metal.py
+from accel.metal.ops_metal import *
+


### PR DESCRIPTION
I've slightly modified the backward() in Conv2D class of ops_cpu.py utilizing np.einsum_path(), which would search for the cheapest way of the operation and return it.

The test result in test_mnist.py is about 0.002 sec, while the result in test_efficientnet.py is about 0.005 to 0.01 sec on the average.

Please have a look and don't be stingy on giving comment, thanks !