### PR TITLE
Fix batch_invstd none in BatchNorm2D

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -34,7 +34,7 @@ class BatchNorm2D:
     else:
       batch_mean, batch_var = self.running_mean, self.running_var
       # NOTE: this can be precomputed for static inference. if you manually update running_var, you have to reset this
-      if not hasattr(self, "batch_invstd"):
+      if not hasattr(self, "batch_invstd") or not self.batch_invstd:
         self.batch_invstd = batch_var.add(self.eps)**-0.5
       batch_invstd = self.batch_invstd
 


### PR DESCRIPTION
When running the resnet training example, I saw that batch_invstd can become none since it was set to None when previously training. This should fix it.