### PR TITLE
Attempt to fix `pip install tinygrad`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(directory, 'README.md'), encoding='utf-8') as f:
@@ -14,7 +14,8 @@ setup(name='tinygrad',
       license='MIT',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn'],
+      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn', 'accel', 'accel.opencl'],
+      package_data={"accel.opencl": ["*.cl"]},
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tinygrad',
       license='MIT',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      packages = ['tinygrad'],
+      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn'],
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-from setuptools import setup, find_packages
+from setuptools import setup
 
 directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(directory, 'README.md'), encoding='utf-8') as f:


### PR DESCRIPTION
Earlier today I ran `pip install tinygrad` and found the following problem:

![image](https://user-images.githubusercontent.com/287189/201440987-4b60baf9-fc9c-4381-813f-c5ca7cd51561.png)

After much tinkering (and reading how `setuptools` works) I managed to install `tinygrad` using `pip install`. I used a dummy package name ([`ccd3dedd9f0835903`](https://pypi.org/project/ccd3dedd9f0835903/)) because I needed publish rights on pypi to test it out. 

![image](https://user-images.githubusercontent.com/287189/201439781-378f5174-ad5a-4c3a-8447-75ea8cc8e6ad.png)

Let me know if supporting `pip install tinygrad` would be desireable, and I'll keep trying make stuff work via pypi distribution as I test the framework out.