### PR TITLE
don't fail when termcolor is not installed

### DIFF
--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -11,9 +11,11 @@ from tinygrad.tensor import Tensor
 from tinygrad.nn import Conv2d
 try:
   from termcolor import colored
+except ImportError:
+  colored = lambda x, _: x
+try:
   from tinygrad.llops.ops_gpu import CL
 except ImportError:
-  colored = None
   CL = None
 
 IN_CHANS = [int(x) for x in os.getenv("IN_CHANS", "4,16,64").split(",")]


### PR DESCRIPTION
Maybe we should just write the ansi escape codes by hand?