### PR TITLE
Print out the tensor using numpy().

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ y = Tensor([[2.0,0,-2.0]], requires_grad=True)
 z = y.matmul(x).sum()
 z.backward()
 
-print(x.grad)  # dz/dx
-print(y.grad)  # dz/dy
+print(x.grad.numpy())  # dz/dx
+print(y.grad.numpy())  # dz/dy
 ```
 
 ### Same example in torch


### PR DESCRIPTION
This commit resolves issue https://github.com/geohot/tinygrad/issues/453

In the example code in the README.md, when it is run, it prints for Tiny Grad the tensors as:
<Tensor <LB (3, 3) op:MovementOps.RESHAPE> with grad None> <Tensor <LB (1, 3) op:MovementOps.RESHAPE> with grad None>

But to be equivalent to the output of the Torch example, we need to use numpy() to get it to show:
[[ 2.  2.  2.]
 [ 0.  0.  0.]
 [-2. -2. -2.]]
[[1. 1. 1.]]