### PR TITLE
TestZeroViewShapeTracker fix test

### DIFF
--- a/test/test_shapetracker.py
+++ b/test/test_shapetracker.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 from tinygrad.helpers import prod
-from tinygrad.shape import ShapeTracker
+from tinygrad.shape import ShapeTracker, ZeroView
 
 class DumbShapeTracker:
   def __init__(self, shape):
@@ -38,11 +38,10 @@ class DumbShapeTracker:
 
 class TestZeroViewShapeTracker(unittest.TestCase):
   def test_pad(self):
-    self.st = ShapeTracker((4, 4))
-    self.st.pad((1, 1), (1, 1))
-    assert self.st.shape == (6,6)
-    print(self.st)
-    print(self.st.expr())
+    testst = ShapeTracker((4, 4))
+    testst.pad((1, 1), (1, 1))
+    compareZv = ZeroView((4,4), ((-1,5), (-1,5)))
+    assert testst.views[1].expr == compareZv.expr
 
 class TestComplexShapeTracker(unittest.TestCase):
   def test_add_1s(self):

--- a/test/test_shapetracker.py
+++ b/test/test_shapetracker.py
@@ -40,6 +40,7 @@ class TestZeroViewShapeTracker(unittest.TestCase):
   def test_pad(self):
     self.st = ShapeTracker((4, 4))
     self.st.pad((1, 1), (1, 1))
+    assert self.st.shape == (6,6)
     compareZv = ZeroView((4,4), ((-1,5), (-1,5)))
     assert self.st.views[1].expr == compareZv.expr
 

--- a/test/test_shapetracker.py
+++ b/test/test_shapetracker.py
@@ -38,10 +38,10 @@ class DumbShapeTracker:
 
 class TestZeroViewShapeTracker(unittest.TestCase):
   def test_pad(self):
-    testst = ShapeTracker((4, 4))
-    testst.pad((1, 1), (1, 1))
+    self.st = ShapeTracker((4, 4))
+    self.st.pad((1, 1), (1, 1))
     compareZv = ZeroView((4,4), ((-1,5), (-1,5)))
-    assert testst.views[1].expr == compareZv.expr
+    assert self.st.views[1].expr == compareZv.expr
 
 class TestComplexShapeTracker(unittest.TestCase):
   def test_add_1s(self):


### PR DESCRIPTION
Hello!

This PR posits an improvement on the TestZeroViewShapeTracker test ([issue 476](https://github.com/geohot/tinygrad/issues/476)).

Previously, we were comparing the shape of the ST after the pad, without regards to the ZeroView attribute. 

I've added a simple ZeroView class which should be contained within the test shape tracker as a result of the .pad operation.

Thanks!