### PR TITLE
Triton bugfixes & implementation of remaining ops

### DIFF
--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -83,7 +83,7 @@ class TritonASTKernel(ASTKernel):
       self.kernel += [f"  acc = {TritonASTKernel.start_for_op[self.reduceop.op]}"]
       self.kernel += [("  "*(i-self.first_reduce)+f"  for idx{i} in range(0, {full_shape[i]}):") for i in range(self.first_reduce, self.shape_len)]
       self.kernel_prefix =  "  "*(self.shape_len - self.first_reduce)
-      self.kernel.append("  "+self.kernel_prefix+self.ast_parse(self.ast, "acc", True))
+      self.kernel.append("  "+self.kernel_prefix+self.ast_parse(self.reduceop, "acc", True))
       self.kernel_prefix =  ""
 
     code = self.ast_parse(self.ast, "acc")

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -17,13 +17,13 @@ from tinygrad.shape.symbolic import Variable
 
 class TritonASTKernel(ASTKernel):
   code_for_op : Dict[Op, str] = {
-    UnaryOps.NOOP: "(A)", UnaryOps.NEG: "(-(A))", UnaryOps.RELU: "tl.max(A, 0.)", UnaryOps.SIGN: "tl.where(A>0,-1,1)",
+    UnaryOps.NOOP: "(A)", UnaryOps.NEG: "(-(A))", UnaryOps.RELU: "tl.maximum(A, 0.0)", UnaryOps.SIGN: "tl.where(A>0,1,0)",
     UnaryOps.EXP: "tl.exp(A)", UnaryOps.LOG: "tl.log(A)", UnaryOps.RECIPROCAL: "(1.0/A)",
     BinaryOps.ADD: "(A+B)", BinaryOps.SUB: "(A-B)", BinaryOps.MUL: "(A*B)",
-    BinaryOps.DIV: "(A/B)", BinaryOps.POW: "(A**B)", BinaryOps.CMPEQ: "(A==B)",
-    ReduceOps.SUM: "A += B", ReduceOps.MAX: "A = max(A,B)"
+    BinaryOps.DIV: "(A/B)", BinaryOps.POW: "tl.exp(tl.log(A)*B)", BinaryOps.CMPEQ: "(A==B)",
+    ReduceOps.SUM: "A += B", ReduceOps.MAX: "A = tl.maximum(A,B)"
   }
-  start_for_op = {ReduceOps.SUM: "0.0", ReduceOps.MAX: "-INFINITY"}
+  start_for_op = {ReduceOps.SUM: "0.0", ReduceOps.MAX: "float('-inf')"}
 
   # TODO: move to shapetracker
   def compute_buf_index_symbolic(self, st, buf_index, offset=0):

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -113,6 +113,7 @@ class TritonASTKernel(ASTKernel):
 class TritonBuffer(ExplicitExecAST):
   def __init__(self, shape:Union[ShapeTracker, Tuple[int, ...]], hostbuf:Optional[TritonBuffer]=None, backing:Optional[np.ndarray]=None, force_create=False):
     super().__init__(shape, hostbuf)
+    if hostbuf is not None and hostbuf._buf is None: hostbuf.torch
     self._buf : Optional[TritonBuffer] = hostbuf._buf if hostbuf is not None else None
     self._base_shape : Tuple[int, ...] = hostbuf._base_shape if hostbuf is not None else self.shape
     self._backing : Optional[np.ndarray] = hostbuf._backing if hostbuf is not None else backing

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -40,9 +40,9 @@ class TritonASTKernel(ASTKernel):
       # this is a load
       buf_index = self.bufs.index(x)
       if buf_index not in self.loaded:
-        # TODO: valid
         idx, valid = self.compute_buf_index_symbolic(self.bufs[buf_index].st, buf_index)
-        self.kernel.append(self.kernel_prefix + f"  val{buf_index} = tl.load(data{buf_index} + {idx})")
+        valid_expr = str(valid).replace("&&", "*1*")
+        self.kernel.append(self.kernel_prefix + f"  val{buf_index} = tl.where({valid_expr}, tl.load(data{buf_index} + {idx}), 0.0)")
         self.loaded.add(buf_index)
       return f"val{buf_index}"
     if isinstance(x.op, ReduceOps) and not do_reduce: return acc

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -69,6 +69,9 @@ class TestOps(unittest.TestCase):
   def test_div_const(self):
     helper_test_op([(45,65)], lambda x: x/255, lambda x: x/255)
   def test_pow(self):
+    helper_test_op([(45,65)], lambda x: x**2, lambda x: Tensor.pow(x,2), a=0)
+    helper_test_op([(45,65)], lambda x: x**3, lambda x: Tensor.pow(x,3), a=0)
+    helper_test_op([(45,65)], lambda x: x**-2, lambda x: Tensor.pow(x,-2), a=0)
     helper_test_op([(45,65), (45,65)], lambda x,y: x**y, Tensor.pow, a=0)
   def test_sqrt(self):
     helper_test_op([(45,65)], lambda x: x.sqrt(), Tensor.sqrt, a=0)


### PR DESCRIPTION
Fixes some bugs to pass all tests of test_ops.py:
![image](https://user-images.githubusercontent.com/20306567/215350274-6dace4fb-abe5-4613-ae50-7fb6ac828f03.png)

Some notes:

Padding:
Triton doesn't support python's and operator (Unsupported node: BoolOp), the only way I got it working is by replacing "&&" with "\*1\*". Using only one "*" resulted in a error (LLVM ERROR: Cannot select: 0x5582df7a81a8: i1 = mul 0x5582df7a8070, 0x5582df7a8140)

Support more ops:
- Power: trition doesn't have a pow operation built-in, a workaround is to use tl.exp(tl.log(A)*B), see [link](https://github.com/openai/triton/issues/506), there are some problems with integers, but not float's, I've added some tests to verify the mentioned edge cases work.
- Sign: already implements GT0

Allocate return buffer:
test_ops originally failed, because the return buffer wasn't connected to bufs[0].
It's handled for the GPU at [ast.py#L50](https://github.com/geohot/tinygrad/blob/bb0cdc2442591db41e63f27de66b7201e66efb89/tinygrad/ast.py#L50), but do we want accelerator specific code in ast.py?
It's the special case that a Buffer is created with a hostbuf, but hostbuf._buf is still None so that buffer isn't connected to hostbuf.

Next up:
Tensor's don't look like they are deleted properly, causing a memory leak and CUDA running out of memory when running all the tests.