### PR TITLE
NumPy-like semantics for Tensor.__getitem__

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -23,10 +23,13 @@ class TestTinygrad(unittest.TestCase):
 
   def test_slicing(self):
     x = Tensor.randn(10,10)
-    slices = [0,1,-1,None] + [np.s_[s:e] for s,e in itertools.combinations([0,1,-1,None], r=2)]
+    slices = [0,1,9,-1,-10,None] + [slice(s,e) for s,e in itertools.combinations([0,1,-1,None], r=2)] + [slice(9,11), slice(-11,-9)]
     fmt = lambda s: f'{s.start}:{s.stop}' if isinstance(s, slice) else s
     for a, b in itertools.product(slices, slices):
       np.testing.assert_equal(x.numpy()[a,b], x[a,b].numpy(), f'Test failed for slice x[{fmt(a)},{fmt(b)}]')
+    for s in [-11,10]:
+      with self.assertRaises(IndexError):
+        x[s]
 
   def test_backward_pass(self):
     def test_tinygrad():

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -24,12 +24,16 @@ class TestTinygrad(unittest.TestCase):
   def test_slicing(self):
     x = Tensor.randn(10,10)
     slices = [0,1,9,-1,-10,None] + [slice(s,e) for s,e in itertools.combinations([0,1,-1,None], r=2)] + [slice(9,11), slice(-11,-9)]
-    fmt = lambda s: f'{s.start}:{s.stop}' if isinstance(s, slice) else s
-    for a, b in itertools.product(slices, slices):
-      np.testing.assert_equal(x.numpy()[a,b], x[a,b].numpy(), f'Test failed for slice x[{fmt(a)},{fmt(b)}]')
+    fmt = lambda s: f'{s.start}:{s.stop}' if isinstance(s, slice) else str(s)
+    for s in list(itertools.product(slices, slices)) + [(None,0,None,0,None), (slice(0,2),None,None,slice(2,4),None,None)]:
+      np.testing.assert_equal(x.numpy()[s], x[s].numpy(), f'Test failed for slice x[{",".join(fmt(x) for x in s)}]')
     for s in [-11,10]:
       with self.assertRaises(IndexError):
         x[s]
+    with self.assertRaises(AssertionError):
+      x[::2]
+    with self.assertRaises(AssertionError):
+      x[0,0,0]
 
   def test_backward_pass(self):
     def test_tinygrad():

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import unittest
+import itertools
 from tinygrad.tensor import Tensor, Device
 from extra.gradcheck import numerical_jacobian, jacobian, gradcheck
 
@@ -19,6 +20,13 @@ class TestTinygrad(unittest.TestCase):
     a += b
     val2 = a.numpy()
     np.testing.assert_allclose(val1, val2)
+
+  def test_slicing(self):
+    x = Tensor.randn(10,10)
+    slices = [0,1,-1,None] + [np.s_[s:e] for s,e in itertools.combinations([0,1,-1,None], r=2)]
+    fmt = lambda s: f'{s.start}:{s.stop}' if isinstance(s, slice) else s
+    for a, b in itertools.product(slices, slices):
+      np.testing.assert_equal(x.numpy()[a,b], x[a,b].numpy(), f'Test failed for slice x[{fmt(a)},{fmt(b)}]')
 
   def test_backward_pass(self):
     def test_tinygrad():

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -3,8 +3,7 @@ import os, math, functools
 
 def dedup(x): return list(dict.fromkeys(x))   # retains list order
 def prod(x): return math.prod(x)
-def idxfix(i, sz): return sz+i if i < 0 else i
-def slcfix(i, sz, default=None): return default if i is None else max(0, min(sz, idxfix(i, sz)))
+def slcfix(i, sz, default): return default if i is None else max(0, min(sz, sz+i if i < 0 else i))
 def argfix(*x): return tuple() if len(x) == 0 else tuple(x[0]) if isinstance(x[0], tuple) or isinstance(x[0], list) else tuple(x)
 def argsort(x): return sorted(range(len(x)), key=x.__getitem__) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items): return all(x == items[0] for x in items) if len(items) > 0 else True

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -3,7 +3,6 @@ import os, math, functools
 
 def dedup(x): return list(dict.fromkeys(x))   # retains list order
 def prod(x): return math.prod(x)
-def slcfix(i, sz, default): return default if i is None else max(0, min(sz, sz+i if i < 0 else i))
 def argfix(*x): return tuple() if len(x) == 0 else tuple(x[0]) if isinstance(x[0], tuple) or isinstance(x[0], list) else tuple(x)
 def argsort(x): return sorted(range(len(x)), key=x.__getitem__) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items): return all(x == items[0] for x in items) if len(items) > 0 else True

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -3,6 +3,7 @@ import os, math, functools
 
 def dedup(x): return list(dict.fromkeys(x))   # retains list order
 def prod(x): return math.prod(x)
+def idxfix(i, sz, default=None): return default if i is None else sz+i if i < 0 else i
 def argfix(*x): return tuple() if len(x) == 0 else tuple(x[0]) if isinstance(x[0], tuple) or isinstance(x[0], list) else tuple(x)
 def argsort(x): return sorted(range(len(x)), key=x.__getitem__) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items): return all(x == items[0] for x in items) if len(items) > 0 else True

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -3,7 +3,8 @@ import os, math, functools
 
 def dedup(x): return list(dict.fromkeys(x))   # retains list order
 def prod(x): return math.prod(x)
-def idxfix(i, sz, default=None): return default if i is None else sz+i if i < 0 else i
+def idxfix(i, sz): return sz+i if i < 0 else i
+def slcfix(i, sz, default=None): return default if i is None else max(0, min(sz, idxfix(i, sz)))
 def argfix(*x): return tuple() if len(x) == 0 else tuple(x[0]) if isinstance(x[0], tuple) or isinstance(x[0], list) else tuple(x)
 def argsort(x): return sorted(range(len(x)), key=x.__getitem__) # https://stackoverflow.com/questions/3382352/equivalent-of-numpy-argsort-in-basic-python
 def all_same(items): return all(x == items[0] for x in items) if len(items) > 0 else True

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -153,6 +153,7 @@ class Tensor:
 
   # ***** non first class ops (hlops) *****
 
+  # supports positive and negative indices / slices, as well as None to add a new axis
   def __getitem__(self, val):
     new_slice, new_shape = [], []
     val = [val] if not isinstance(val, (list, tuple)) else val

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import inspect, functools, importlib, itertools
 import numpy as np
-from tinygrad.helpers import prod, argfix, make_pair, idxfix
+from tinygrad.helpers import prod, argfix, make_pair, idxfix, slcfix
 from typing import List, Callable, Optional
 from tinygrad.lazy import Device, LazyBuffer
 
@@ -157,10 +157,12 @@ class Tensor:
     new_slice, new_shape = [], []
     val = [val] if not isinstance(val, (list, tuple)) else val
     assert all(s.step is None or s.step == 1 for s in val if isinstance(val, slice))
-    for sz,s in zip(self.shape, (v for v in val if v is not None)):
-      new_slice.append((idxfix(s, sz), idxfix(s, sz)+1) if isinstance(s, int) else (idxfix(s.start, sz, 0), idxfix(s.stop, sz, sz)))
+    for i,(sz,s) in enumerate(zip(self.shape, (v for v in val if v is not None))):
+      if isinstance(s, int) and not (-sz <= s < sz):
+        raise IndexError(f"Index {s} is out of bounds for dimension {i} with size {sz}")
+      new_slice.append((idxfix(s, sz), idxfix(s, sz)+1) if isinstance(s, int) else (slcfix(s.start, sz, 0), slcfix(s.stop, sz, sz)))
     for sz, s in zip(self.shape, (v for v in val if not isinstance(v, int))):
-      new_shape.append(1 if s is None else idxfix(s.stop, sz, sz) - idxfix(s.start, sz, 0))
+      new_shape.append(1 if s is None else slcfix(s.stop, sz, sz) - slcfix(s.start, sz, 0))
     new_shape += [self.shape[i] for i in range(len(new_slice), len(self.shape))]
     new_slice += [(0,self.shape[i]) for i in range(len(new_slice), len(self.shape))]
     return self.slice(arg = new_slice).reshape(new_shape if len(new_shape) else (1,))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect, functools, importlib, itertools
 import numpy as np
 from tinygrad.helpers import prod, argfix, make_pair, idxfix, slcfix
-from typing import List, Callable, Optional
+from typing import List, Tuple, Callable, Optional
 from tinygrad.lazy import Device, LazyBuffer
 
 # **** start with two base classes, Tensor and Function ****
@@ -207,7 +207,7 @@ class Tensor:
   dot = matmul
 
   # (padding_left, padding_right, padding_top, padding_bottom)
-  def pad2d(self, padding): return self.slice(arg = [(0,self.shape[0]), (0,self.shape[1]), (-padding[2],self.shape[2]+padding[3]), (-padding[0],self.shape[3]+padding[1])])
+  def pad2d(self, padding:Tuple[int, ...]): return self.slice(arg = [(0,self.shape[0]), (0,self.shape[1]), (-padding[2],self.shape[2]+padding[3]), (-padding[0],self.shape[3]+padding[1])])  # type: ignore
   # TODO: this is totally not transpose
   def transpose(self, order=(1,0)): return self.permute(order=order)
   def flatten(self, start_dim=0): return self.reshape(shape=tuple(list(self.shape[0:start_dim]) + [-1]))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 import inspect, functools, importlib, itertools
 import numpy as np
-from tinygrad.helpers import prod, argfix, make_pair, idxfix, slcfix
+from tinygrad.helpers import prod, argfix, make_pair, slcfix
 from typing import List, Tuple, Callable, Optional
 from tinygrad.lazy import Device, LazyBuffer
 
@@ -159,8 +159,8 @@ class Tensor:
     assert all(s.step is None or s.step == 1 for s in val if isinstance(val, slice))
     for i,(sz,s) in enumerate(zip(self.shape, (v for v in val if v is not None))):
       if isinstance(s, int) and not (-sz <= s < sz):
-        raise IndexError(f"Index {s} is out of bounds for dimension {i} with size {sz}")
-      new_slice.append((idxfix(s, sz), idxfix(s, sz)+1) if isinstance(s, int) else (slcfix(s.start, sz, 0), slcfix(s.stop, sz, sz)))
+        raise IndexError(f"index {s} is out of bounds for dimension {i} with size {sz}")
+      new_slice.append((s%sz, s%sz+1) if isinstance(s, int) else (slcfix(s.start, sz, 0), slcfix(s.stop, sz, sz)))
     for sz, s in zip(self.shape, (v for v in val if not isinstance(v, int))):
       new_shape.append(1 if s is None else slcfix(s.stop, sz, sz) - slcfix(s.start, sz, 0))
     new_shape += [self.shape[i] for i in range(len(new_slice), len(self.shape))]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect, functools, importlib, itertools
 import numpy as np
 from tinygrad.helpers import prod, argfix, make_pair, idxfix
-from typing import List, Tuple, Callable, Optional
+from typing import List, Callable, Optional
 from tinygrad.lazy import Device, LazyBuffer
 
 # **** start with two base classes, Tensor and Function ****
@@ -205,7 +205,7 @@ class Tensor:
   dot = matmul
 
   # (padding_left, padding_right, padding_top, padding_bottom)
-  def pad2d(self, padding:Tuple[int, ...]): return self.slice(arg = [(0,self.shape[0]), (0,self.shape[1]), (-padding[2],self.shape[2]+padding[3]), (-padding[0],self.shape[3]+padding[1])])
+  def pad2d(self, padding): return self.slice(arg = [(0,self.shape[0]), (0,self.shape[1]), (-padding[2],self.shape[2]+padding[3]), (-padding[0],self.shape[3]+padding[1])])
   # TODO: this is totally not transpose
   def transpose(self, order=(1,0)): return self.permute(order=order)
   def flatten(self, start_dim=0): return self.reshape(shape=tuple(list(self.shape[0:start_dim]) + [-1]))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -205,7 +205,7 @@ class Tensor:
   dot = matmul
 
   # (padding_left, padding_right, padding_top, padding_bottom)
-  def pad2d(self, padding:Tuple[int, ...]): return self[:, :, -padding[2]:self.shape[2]+padding[3], -padding[0]:self.shape[3]+padding[1]]
+  def pad2d(self, padding:Tuple[int, ...]): return self.slice(arg = [(0,self.shape[0]), (0,self.shape[1]), (-padding[2],self.shape[2]+padding[3]), (-padding[0],self.shape[3]+padding[1])])
   # TODO: this is totally not transpose
   def transpose(self, order=(1,0)): return self.permute(order=order)
   def flatten(self, start_dim=0): return self.reshape(shape=tuple(list(self.shape[0:start_dim]) + [-1]))


### PR DESCRIPTION
This PR modifies the behavior of `Tensor.__getitem__` in several ways, with the goal of bringing tinygrad indexing more in line with the behavior of numpy and torch indexing. The changes in behavior are as follows:
- Indexing a tensor with a negative integer N now returns the Nth-to-last element instead of zeros.
- Slicing a tensor from a negative starting position N now slices from the Nth-to-last position instead of padding the tensor with zeros.
- Indexing a tensor with an integer not in the range [-size, size) now throws an IndexError instead of returning zeros.
- Slicing a tensor past its bounds is now equivalent to slicing with None, instead of padding the tensor with zeros.
- Indexing a tensor with None or np.newaxis along axis A now reshapes the tensor with an additional dimension at A, instead of doing nothing if None was the only argument or raising an error otherwise.