### PR TITLE
Fix triton illegal memory accesses and memory leak

### DIFF
--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import hashlib
+from weakref import WeakValueDictionary
 from torch import float32
 import numpy as np
 # import pycuda.autoinit # type: ignore # pylint: disable=unused-import # noqa: F401
@@ -9,7 +10,7 @@ import pycuda.driver as cuda # type: ignore
 import triton # type: ignore # noqa: F401
 import triton.language as tl  # type: ignore # noqa: F401
 
-from typing import Union, Tuple, Optional, Dict, Any
+from typing import Union, Tuple, Optional, Dict
 from tinygrad.ops import MovementOps, UnaryOps, BinaryOps, ReduceOps, LazyOp, Op, ExplicitExecAST, DEBUG, GlobalCounters
 from tinygrad.shape import ShapeTracker
 from tinygrad.helpers import prod
@@ -59,7 +60,7 @@ class TritonASTKernel(ASTKernel):
     if len(values) == 2: code = code.replace("B", values[1])
     return code
 
-  func_cache : Dict[Any, Any] = {}
+  func_cache: WeakValueDictionary = WeakValueDictionary()
   def codegen(self):
     if self.key in self.func_cache: return self.func_cache[self.key]
 

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -4,7 +4,6 @@ import hashlib
 import numpy as np
 
 import triton # noqa: F401
-import triton.language as tl # noqa: F401
 
 from typing import Union, Tuple, Optional, Dict, Any
 from tinygrad.ops import UnaryOps, BinaryOps, ReduceOps, LazyOp, Op, ExplicitExecAST, DEBUG, GlobalCounters

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -48,7 +48,7 @@ class TritonASTKernel(ASTKernel):
       if buf_index not in self.loaded:
         idx, valid = self.compute_buf_index_symbolic(self.bufs[buf_index].st, buf_index)
         valid_expr = str(valid).replace("&&", "*1*")
-        self.kernel.append(self.kernel_prefix + f"  val{buf_index} = tl.where({valid_expr}, tl.load(data{buf_index} + {idx}), 0.0)")
+        self.kernel.append(self.kernel_prefix + f"  val{buf_index} = tl.where({valid_expr}, tl.load(data{buf_index} + {idx}, mask={valid_expr}), 0.0)")
         self.loaded.add(buf_index)
       return f"val{buf_index}"
     if isinstance(x.op, ReduceOps) and not do_reduce: return acc

--- a/accel/triton/ops_triton.py
+++ b/accel/triton/ops_triton.py
@@ -3,7 +3,7 @@ import torch
 import hashlib
 import numpy as np
 
-import triton # noqa: F401
+import triton # type: ignore # noqa: F401
 
 from typing import Union, Tuple, Optional, Dict, Any
 from tinygrad.ops import UnaryOps, BinaryOps, ReduceOps, LazyOp, Op, ExplicitExecAST, DEBUG, GlobalCounters

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='tinygrad',
         'gpu': ["pyopencl", "six"],
         'llvm': ["llvmlite"],
         'cuda': ["pycuda"],
+        'triton': ["triton>=2.0.0.dev20221202"],
         'testing': [
             "pytest",
             "torch~=1.11.0",


### PR DESCRIPTION
This PR fixes 3 bugs:
- A memory leak, that was caused by kernel caching, where the buffers and gpu memory allocations weren't deleted, because they were referenced by the kernel cache.
- An illegal memory access in efficientnet and the openpilot tests. This was really hard to find. They only appeared in complex models, but after analyzing the kernels with compute-sanitizer I could figure out that every kernel with zero padding had many of these errors, but only in a few cases it resulted in the termination of the kernel. The root cause of the error is, that data of the zero padded area is requested, even though it is not used and the 
branch of the select statement shouldn't be executed. This results in reads outside of the buffer and if these reads are in another buffer, just wrong values are returned, but (I think) if it requests unallocated memory, it terminates the kernel. This was fixed by adding the valid expression as the mask of the load function.
- Invalid kernel lauches, when the kernel grid is bigger than the maximum allowed of (2^31-1, 65535, 65535), solved for now by flattening of the kernel grid, so all kernels are launched on the x axis.

All tests pass now.
![image](https://user-images.githubusercontent.com/20306567/216133032-8ce38cd7-2697-49ae-b849-70327921f575.png)