### PR TITLE
Reenabled docker testing stage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,12 +177,13 @@ jobs:
   testdocker:
     name: Docker Test
     runs-on: ubuntu-latest
-    if: ${{ false }}
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Build Docker
-      run: docker build -t tinygrad -f test/Dockerfile .
-    - name: Test Docker
-      run: docker run --rm tinygrad /usr/bin/env python3 -c "from tinygrad.tensor import Tensor; print(Tensor.eye(3).numpy())"
+      run: docker build -t tinygrad/testing --target=testing -f test/Dockerfile .
+    - name: Run Docker Pytest
+      run: docker run -e LAZY=0 --rm tinygrad/testing python3 -m pytest -s -v
+    - name: Run Docker Pytest (lazy)
+      run: docker run -e LAZY=1 --rm tinygrad/testing python3 -m pytest -s -v

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tinygrad',
       license='MIT',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn'],
+      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn', 'tinygrad.shape', 'tinygrad.runtime'],
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,22 @@
-FROM ubuntu:20.04
-RUN apt-get update 
-RUN apt-get install -y python3-pip git
-RUN pip3 install git+https://github.com/geohot/tinygrad.git
+FROM ubuntu:20.04 AS base
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y python3-pip git wget
+
+RUN pip3 install --no-cache-dir "tinygrad @ git+https://github.com/dc-dc-dc/tinygrad.git@fix/docker"
+
+CMD ["/usr/bin/env", "python3"]
+
+FROM base AS testing
+
+RUN pip3 install --no-cache-dir "tinygrad[testing]"
+RUN wget https://raw.githubusercontent.com/protocolbuffers/protobuf/main/python/google/protobuf/internal/builder.py -O /usr/local/lib/python3.8/dist-packages/google/protobuf/internal/builder.py
+
+WORKDIR /testing
+
+COPY test ./test/
+COPY extra ./extra/
+COPY models ./models/
+COPY datasets ./datasets/
+
+ENV PYTHONPATH /testing


### PR DESCRIPTION
Created two stages in the Dockerfile
 - base - python shell with base tinygrad installed
 - testing - with testing packages installed

Reenabled docker testing stage in the workflow, just copied the same tests from CPU Tests

Had to add shape and runtime packages to setup.py to install correctly in the docker image.

Passing tests [here](https://github.com/dc-dc-dc/tinygrad/actions/runs/4069605144)

Playground image [here](https://hub.docker.com/r/cruzio/tinygrad) 