### PR TITLE
issue 457 - llvm test failing without opt

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -149,7 +149,7 @@ class TestOps(unittest.TestCase):
   def test_tanh(self):
     helper_test_op([(45,65)], lambda x: x.tanh(), Tensor.tanh, atol=1e-6, grad_atol=1e-6)
   def test_topo_sort(self):
-    helper_test_op([(45,65)], lambda x: (x+x)*x, lambda x: x.add(x).mul(x), atol=1e-6, grad_atol=1e-6)
+    helper_test_op([(45,65)], lambda x: x*(x+x), lambda x: x.mul(x.add(x)), atol=1e-6, grad_atol=1e-6)
 
   def test_scalar_mul(self):
     helper_test_op([(45,65)], lambda x: x*2, lambda x: x*2)


### PR DESCRIPTION
After this the test runs ok with or without OPT=1 and LLVM=1
and mathematically it makes sense to do the multiplication first of the addition
```
$ OPT=1 LLVM=1 python3 test/test_ops.py TestOps.test_topo_sort
ops_triton not available No module named 'pycuda'
test_topo_sort (__main__.TestOps) ... 
testing                               [(45, 65)]   torch/tinygrad fp: 0.05 / 11.18 ms  bp: 7.61 / 11.73 ms ok

----------------------------------------------------------------------
Ran 1 test in 0.034s

OK

```
