### PR TITLE
Add test for quick_gelu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='tinygrad',
         'triton': ["triton>=2.0.0.dev20221202"],
         'testing': [
             "pytest",
-            "torch~=1.11.0",
+            "torch~=1.13.0",
             "tqdm",
             "protobuf~=3.19.0",
             "onnx",

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -92,7 +92,9 @@ class TestOps(unittest.TestCase):
   def test_softplus(self):
     helper_test_op([(45,65)], lambda x: torch.nn.functional.softplus(x), Tensor.softplus, atol=1e-6, grad_atol=1e-6)
   def test_gelu(self):
-    helper_test_op([(45,65)], lambda x: 0.5 * x * (1.0 + torch.tanh(x * 0.7978845608 * (1.0 + 0.044715 * x * x))), Tensor.gelu)
+    helper_test_op([(45,65)], lambda x: torch.nn.functional.gelu(x, approximate="tanh"), Tensor.gelu)
+  def test_quick_gelu(self):
+    helper_test_op([(45,65)], lambda x: x * torch.sigmoid(1.702 * x), Tensor.quick_gelu)
   def test_elu(self):
     helper_test_op([(45,65)], lambda x: torch.nn.functional.elu(x), Tensor.elu)
     helper_test_op([(45,65)], lambda x: torch.nn.functional.elu(x, alpha=0.1), lambda x: Tensor.elu(x, alpha=0.1))


### PR DESCRIPTION
- our implementation of gelu is the tanh approximation, available in PyTorch
  - note that [by default, PyTorch doesn't approxiate gelu](https://pytorch.org/docs/stable/generated/torch.nn.GELU.html#torch.nn.GELU), do we want to match it?
- `quick_gelu` hasn't been added to PyTorch, but we have the implementation [here](https://github.com/pytorch/pytorch/issues/39853#issuecomment-858211939)