### PR TITLE
Show where tinygrad is faster in speed test vs torch

### DIFF
--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -20,10 +20,8 @@ IN_CHANS = [int(x) for x in getenv("IN_CHANS", "4,16,64").split(",")]
 
 torch_device = torch.device('mps' if getenv("MPS", 0) else ('cuda' if getenv("TORCHCUDA", 0) else 'cpu'))
 
-def colorize_float(x, y):
+def colorize_float(x):
   ret = f"{x:7.2f}x"
-  if y == "faster":
-    return colored(ret, 'cyan')
   if x < 0.75:
     return colored(ret, 'green')
   elif x > 1.5:
@@ -74,7 +72,7 @@ def helper_test_generic(name, f1, f2):
   desc = "faster" if et_torch > et_tinygrad else "slower"
   flops = save_ops*1e-6
   mem = save_mem*4*1e-6
-  print(f"{prefix}{name:40s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch,desc)} {desc} {flops:7.2f} MOPS {mem:7.2f} MB")
+  print(f"{prefix}{name:40s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch)} {desc} {flops:7.2f} MOPS {mem:7.2f} MB")
   prefix = " "
   np.testing.assert_allclose(val_tinygrad, val_torch, atol=1e-4, rtol=1e-3)
 

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -20,8 +20,10 @@ IN_CHANS = [int(x) for x in getenv("IN_CHANS", "4,16,64").split(",")]
 
 torch_device = torch.device('mps' if getenv("MPS", 0) else ('cuda' if getenv("TORCHCUDA", 0) else 'cpu'))
 
-def colorize_float(x):
+def colorize_float(x, y):
   ret = f"{x:7.2f}x"
+  if y == "faster":
+    return colored(ret, 'cyan')
   if x < 0.75:
     return colored(ret, 'green')
   elif x > 1.5:
@@ -69,9 +71,10 @@ def helper_test_generic(name, f1, f2):
     val_torch, et_torch = helper_test_speed(f1)
   val_tinygrad, et_tinygrad = helper_test_speed(lambda: f2().realize())
 
+  desc = "faster" if et_torch > et_tinygrad else "slower"
   flops = save_ops*1e-6
   mem = save_mem*4*1e-6
-  print(f"{prefix}{name:40s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch)} slower {flops:7.2f} MOPS {mem:7.2f} MB")
+  print(f"{prefix}{name:40s} {et_torch:7.2f} ms ({flops/et_torch:8.2f} GFLOPS {mem/et_torch:8.2f} GB/s) in torch, {et_tinygrad:7.2f} ms ({flops/et_tinygrad:8.2f} GFLOPS {mem/et_tinygrad:8.2f} GB/s) in tinygrad, {colorize_float(et_tinygrad/et_torch,desc)} {desc} {flops:7.2f} MOPS {mem:7.2f} MB")
   prefix = " "
   np.testing.assert_allclose(val_tinygrad, val_torch, atol=1e-4, rtol=1e-3)
 


### PR DESCRIPTION
With the recent refactor, tinygrad is faster than PyTorch in most test. I've updated the test to show where tinygrad is faster, and use a different color for the ratio.

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/39754370/218166648-2bcb3f87-0238-4a38-b8a7-cc35679d160e.png">
