### PR TITLE
Add missing packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='tinygrad',
       license='MIT',
       long_description=long_description,
       long_description_content_type='text/markdown',
-      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn'],
+      packages = ['tinygrad', 'tinygrad.llops', 'tinygrad.nn', 'tinygrad.runtime', 'tinygrad.shape'],
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
to be able to install from zip archive.

Though `tinygrad/llops/ops_triton.py` symlink breaks `import tinygrad` if installed from zip, I just rm ops_triton.py post install