### PR TITLE
Refactor graph

### DIFF
--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+import unittest
+import networkx as nx  # type: ignore
+import numpy as np
+from tinygrad.graph import G, log_op, prune_graph
+from tinygrad.llops.ops_llvm import LLVMBuffer
+from tinygrad.ops import BinaryOps, GlobalCounters, LazyOp, MovementOps, ReduceOps
+
+class TestGraph(unittest.TestCase):
+  def setUp(self):
+    GlobalCounters.reset()
+    G.clear()
+
+  def helper_compare_graph(self, RG: nx.DiGraph):
+    assert nx.is_isomorphic(G, RG, node_match=lambda x,y: x["label"] == y["label"], edge_match=lambda x,y: x["label"] == y["label"] if "label" in y else True)
+
+  def test_add_graph(self):
+    a = LLVMBuffer.fromCPU(np.ones((4,4)))
+    b = LLVMBuffer.fromCPU(np.ones((4,4)))
+    ast = LazyOp(BinaryOps.ADD, (a,b))
+    ret = LLVMBuffer((4,4))
+
+    RG = nx.DiGraph()
+    RG.add_node(0, label="(4, 4)")
+    RG.add_node(1, label="(4, 4)")
+    RG.add_node(2, label="(4, 4)")
+    RG.add_edge(0, 2, label="ADD")
+    RG.add_edge(1, 2, label="ADD")
+
+    log_op(ret, ast, show_graph=True)
+    self.helper_compare_graph(RG)
+
+  def test_add_sum_graph(self):
+    a = LLVMBuffer.fromCPU(np.ones((4,4)))
+    b = LLVMBuffer.fromCPU(np.ones((1,1)))
+    op0 = LazyOp(MovementOps.RESHAPE, (b,), (4, 4))
+    op1 = LazyOp(BinaryOps.ADD, (a,op0))
+    ast = LazyOp(ReduceOps.SUM, (op1,), (1,1))
+    ret = LLVMBuffer((1,1))
+
+    RG = nx.DiGraph()
+    RG.add_node(0, label="(4, 4)")
+    RG.add_node(1, label="(1, 1)")
+    RG.add_node(2, label="{(4, 4), (1, 1)}\n(1, 1)")
+    RG.add_edge(0, 2, label="RE.AD.SU")
+    RG.add_edge(1, 2, label="RE.AD.SU")
+
+    log_op(ret, ast, show_graph=True)
+    self.helper_compare_graph(RG)
+
+  def test_add_graph_prune(self):
+    a = LLVMBuffer.fromCPU(np.ones((1,1)))
+    ast = LazyOp(MovementOps.RESHAPE, (a,), (4, 4))
+    ret = LLVMBuffer((4,4))
+    log_op(ret, ast, show_graph=True)
+
+    b = LLVMBuffer.fromCPU(np.ones((4,4)))
+    ast = LazyOp(BinaryOps.ADD, (ret,b))
+    ret = LLVMBuffer((4,4))
+    log_op(ret, ast, show_graph=True)
+    prune_graph()
+
+    RG = nx.DiGraph()
+    RG.add_node(0, label="(1, 1)")
+    RG.add_node(1, label="(4, 4)")
+    RG.add_node(2, label="(4, 4)")
+    RG.add_edge(0, 2) # edge connecting pruned nodes
+    RG.add_edge(1, 2, label="ADD")
+
+    self.helper_compare_graph(RG)
+
+if __name__ == "__main__":
+  unittest.main()

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -4,11 +4,10 @@ import networkx as nx  # type: ignore
 import numpy as np
 from tinygrad.graph import G, log_op, prune_graph
 from tinygrad.llops.ops_cpu import CPUBuffer
-from tinygrad.ops import BinaryOps, GlobalCounters, LazyOp, MovementOps, ReduceOps
+from tinygrad.ops import BinaryOps, LazyOp, MovementOps, ReduceOps
 
 class TestGraph(unittest.TestCase):
   def setUp(self):
-    GlobalCounters.reset()
     G.clear()
 
   def helper_compare_graph(self, RG: nx.DiGraph):

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -3,7 +3,7 @@ import unittest
 import networkx as nx  # type: ignore
 import numpy as np
 from tinygrad.graph import G, log_op, prune_graph
-from tinygrad.llops.ops_llvm import LLVMBuffer
+from tinygrad.llops.ops_cpu import CPUBuffer
 from tinygrad.ops import BinaryOps, GlobalCounters, LazyOp, MovementOps, ReduceOps
 
 class TestGraph(unittest.TestCase):
@@ -15,10 +15,10 @@ class TestGraph(unittest.TestCase):
     assert nx.is_isomorphic(G, RG, node_match=lambda x,y: x["label"] == y["label"], edge_match=lambda x,y: x["label"] == y["label"] if "label" in y else True)
 
   def test_add_graph(self):
-    a = LLVMBuffer.fromCPU(np.ones((4,4)))
-    b = LLVMBuffer.fromCPU(np.ones((4,4)))
+    a = CPUBuffer.fromCPU(np.ones((4,4)))
+    b = CPUBuffer.fromCPU(np.ones((4,4)))
     ast = LazyOp(BinaryOps.ADD, (a,b))
-    ret = LLVMBuffer((4,4))
+    ret = CPUBuffer(np.ones((4,4)))
 
     RG = nx.DiGraph()
     RG.add_node(0, label="(4, 4)")
@@ -31,12 +31,12 @@ class TestGraph(unittest.TestCase):
     self.helper_compare_graph(RG)
 
   def test_add_sum_graph(self):
-    a = LLVMBuffer.fromCPU(np.ones((4,4)))
-    b = LLVMBuffer.fromCPU(np.ones((1,1)))
+    a = CPUBuffer.fromCPU(np.ones((4,4)))
+    b = CPUBuffer.fromCPU(np.ones((1,1)))
     op0 = LazyOp(MovementOps.RESHAPE, (b,), (4, 4))
     op1 = LazyOp(BinaryOps.ADD, (a,op0))
     ast = LazyOp(ReduceOps.SUM, (op1,), (1,1))
-    ret = LLVMBuffer((1,1))
+    ret = CPUBuffer(np.ones((1,1)))
 
     RG = nx.DiGraph()
     RG.add_node(0, label="(4, 4)")
@@ -49,14 +49,14 @@ class TestGraph(unittest.TestCase):
     self.helper_compare_graph(RG)
 
   def test_add_graph_prune(self):
-    a = LLVMBuffer.fromCPU(np.ones((1,1)))
+    a = CPUBuffer.fromCPU(np.ones((1,1)))
     ast = LazyOp(MovementOps.RESHAPE, (a,), (4, 4))
-    ret = LLVMBuffer((4,4))
+    ret = CPUBuffer(np.ones((4,4)))
     log_op(ret, ast, show_graph=True)
 
-    b = LLVMBuffer.fromCPU(np.ones((4,4)))
+    b = CPUBuffer.fromCPU(np.ones((4,4)))
     ast = LazyOp(BinaryOps.ADD, (ret,b))
-    ret = LLVMBuffer((4,4))
+    ret = CPUBuffer(np.ones((4,4)))
     log_op(ret, ast, show_graph=True)
     prune_graph()
 

--- a/tinygrad/graph.py
+++ b/tinygrad/graph.py
@@ -4,7 +4,7 @@ import itertools
 import networkx as nx  # type: ignore
 from collections import defaultdict
 from typing import Dict, List
-from tinygrad.ops import DeviceBuffer, DEBUG, GlobalCounters, UnaryOps, BinaryOps, ReduceOps, MovementOps, ProcessingOps, LoadOps, Op, OpType, LazyOp, get_buffers, get_lazyops
+from tinygrad.ops import DeviceBuffer, DEBUG, UnaryOps, BinaryOps, ReduceOps, MovementOps, ProcessingOps, LoadOps, Op, OpType, LazyOp, get_buffers, get_lazyops
 from tinygrad.helpers import getenv
 
 GRAPH, PRUNEGRAPH, GRAPHPATH = getenv("GRAPH", 0), getenv("PRUNEGRAPH", 0), getenv("GRAPHPATH", "/tmp/net")
@@ -25,10 +25,12 @@ if GRAPH:
     os.system(f'dot -Tsvg {GRAPHPATH}.dot -o {GRAPHPATH}.svg')
   atexit.register(save_graph_exit)
 
+node_count = 0
 def nm(x):
+  global node_count
   if not hasattr(x, 'node_id'):
-    setattr(x, 'node_id', GlobalCounters.graph_node_count)
-    GlobalCounters.graph_node_count += 1
+    setattr(x, 'node_id', node_count)
+    node_count += 1
   return x.node_id
 
 def get_sop(op : List[Op]):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -84,10 +84,9 @@ class GlobalCounters:
   time_sum : ClassVar[int] = 0
   kernel_count : ClassVar[int] = 0
   mem_used : ClassVar[int] = 0   # NOTE: this is not reset
-  graph_node_count : ClassVar[int] = 0
   cache : ClassVar[Optional[list]] = None
   @staticmethod
-  def reset(): GlobalCounters.global_ops, GlobalCounters.global_mem, GlobalCounters.time_sum, GlobalCounters.kernel_count, GlobalCounters.graph_node_count, GlobalCounters.cache = 0,0,0,0,0,None
+  def reset(): GlobalCounters.global_ops, GlobalCounters.global_mem, GlobalCounters.time_sum, GlobalCounters.kernel_count, GlobalCounters.cache = 0,0,0,0,None
   @staticmethod
   def log_kernel(op_estimate:int, mem_estimate:int):
     GlobalCounters.kernel_count += 1

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -84,9 +84,10 @@ class GlobalCounters:
   time_sum : ClassVar[int] = 0
   kernel_count : ClassVar[int] = 0
   mem_used : ClassVar[int] = 0   # NOTE: this is not reset
+  graph_node_count : ClassVar[int] = 0
   cache : ClassVar[Optional[list]] = None
   @staticmethod
-  def reset(): GlobalCounters.global_ops, GlobalCounters.global_mem, GlobalCounters.time_sum, GlobalCounters.kernel_count, GlobalCounters.cache = 0,0,0,0,None
+  def reset(): GlobalCounters.global_ops, GlobalCounters.global_mem, GlobalCounters.time_sum, GlobalCounters.kernel_count, GlobalCounters.graph_node_count, GlobalCounters.cache = 0,0,0,0,0,None
   @staticmethod
   def log_kernel(op_estimate:int, mem_estimate:int):
     GlobalCounters.kernel_count += 1


### PR DESCRIPTION
Originally wanted to include the PRUNEGRAPH into the creation step of the graph, but couldn't get that working(Needed something like the AST of a DeviceBuffer).

Removes a few lines, has a few readability improvements and adds the GRAPHPATH option to set the output location and name of the graph (I like to use ./net)

Produces the same graph for the test_efficientnet.py(except adding a prunable key to the nodes).