### PR TITLE
small tweaks to the metal runtime

### DIFF
--- a/tinygrad/runtime/metal.py
+++ b/tinygrad/runtime/metal.py
@@ -20,11 +20,7 @@ class CLImage:
 class CLBuffer:
   def __init__(self, size): self._cl = device.newBufferWithLength_options_(size, Metal.MTLResourceStorageModeShared)
   def copyin(self, b:np.ndarray):
-    wrapper = np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32)
-    np.copyto(wrapper, b.data)
-    # print(f"attempting shape {b.shape} {b.dtype} {np.frombuffer(b.data, dtype=np.float32)} {b.size*b.itemsize}")
-    # self._cl = device.newBufferWithBytesNoCopy_length_options_deallocator_(b.data, b.size*b.itemsize, Metal.MTLResourceStorageModeShared, None)
-
+    np.copyto(np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32), b.data)
 
   def toCPU(self):
     sync()
@@ -41,7 +37,7 @@ class CLProgram:
   gid = [f"gid.{chr(120+i)}" for i in range(3)]
   def __init__(self, name:str, prg:str, op_estimate:int=0, mem_estimate:int=0):
     self.name, self.op_estimate, self.mem_estimate = name, op_estimate, mem_estimate
-    options = Metal.MTLCompileOptions.alloc().init()  
+    options = Metal.MTLCompileOptions.alloc().init()
     if DEBUG >= 4: print("Metal compile", prg)
     self.library = device.newLibraryWithSource_options_error_(prg, options, None)
     assert self.library[0] is not None, str(self.library)

--- a/tinygrad/runtime/metal.py
+++ b/tinygrad/runtime/metal.py
@@ -20,9 +20,8 @@ class CLImage:
 class CLBuffer:
   def __init__(self, size): self._cl = device.newBufferWithLength_options_(size, Metal.MTLResourceStorageModeShared)
   def copyin(self, b:np.ndarray):
-    wrapper = np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32)
-    np.copyto(wrapper, b.reshape(wrapper.shape))
-
+    self._cl = device.newBufferWithBytesNoCopy_length_options_deallocator_(b.data, b.size*4, Metal.MTLResourceStorageModeShared, None)
+    
   def toCPU(self):
     sync()
     return np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32)

--- a/tinygrad/runtime/metal.py
+++ b/tinygrad/runtime/metal.py
@@ -20,8 +20,12 @@ class CLImage:
 class CLBuffer:
   def __init__(self, size): self._cl = device.newBufferWithLength_options_(size, Metal.MTLResourceStorageModeShared)
   def copyin(self, b:np.ndarray):
-    self._cl = device.newBufferWithBytesNoCopy_length_options_deallocator_(b.data, b.size*4, Metal.MTLResourceStorageModeShared, None)
-    
+    wrapper = np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32)
+    np.copyto(wrapper, b.data)
+    # print(f"attempting shape {b.shape} {b.dtype} {np.frombuffer(b.data, dtype=np.float32)} {b.size*b.itemsize}")
+    # self._cl = device.newBufferWithBytesNoCopy_length_options_deallocator_(b.data, b.size*b.itemsize, Metal.MTLResourceStorageModeShared, None)
+
+
   def toCPU(self):
     sync()
     return np.frombuffer(self._cl.contents().as_buffer(self._cl.length()), dtype=np.float32)
@@ -37,7 +41,7 @@ class CLProgram:
   gid = [f"gid.{chr(120+i)}" for i in range(3)]
   def __init__(self, name:str, prg:str, op_estimate:int=0, mem_estimate:int=0):
     self.name, self.op_estimate, self.mem_estimate = name, op_estimate, mem_estimate
-    options = Metal.MTLCompileOptions.alloc().init()
+    options = Metal.MTLCompileOptions.alloc().init()  
     if DEBUG >= 4: print("Metal compile", prg)
     self.library = device.newLibraryWithSource_options_error_(prg, options, None)
     assert self.library[0] is not None, str(self.library)


### PR DESCRIPTION
Moved the compute pipeline creation to init

Converted the copyin function to use numpys copy, removing realloc of MTLBuffer. 

tested on an intel mac 