### PR TITLE
Fix Tensor random functions determinism with same seed

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -145,5 +145,14 @@ class TestTinygrad(unittest.TestCase):
     # coarse approx. since a "big" eps and the non-linearities of the model
     self.assertFalse(gradcheck(tiny_func, tiny_x, eps = 0.1))
 
+  def test_random_fns_are_deterministic_with_seed(self):
+    for random_fn in [Tensor.randn, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform]:
+      with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
+        np.random.seed(1337)
+        a = random_fn(10,10)
+        np.random.seed(1337)
+        b = random_fn(10,10)
+        np.testing.assert_allclose(a.numpy(), b.numpy())
+
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -148,9 +148,9 @@ class TestTinygrad(unittest.TestCase):
   def test_random_fns_are_deterministic_with_seed(self):
     for random_fn in [Tensor.randn, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform]:
       with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
-        np.random.seed(1337)
+        Tensor.manual_seed(1337)
         a = random_fn(10,10)
-        np.random.seed(1337)
+        Tensor.manual_seed(1337)
         b = random_fn(10,10)
         np.testing.assert_allclose(a.numpy(), b.numpy())
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -124,7 +124,7 @@ class Tensor:
   def empty(cls, *shape, **kwargs): return cls(np.empty(shape, dtype=np.float32), **kwargs)
 
   @classmethod
-  def randn(cls, *shape, **kwargs): return cls(np.random.default_rng().standard_normal(size=shape, dtype=np.float32), **kwargs)
+  def randn(cls, *shape, **kwargs): return cls(np.random.standard_normal(size=shape).astype(np.float32), **kwargs)
 
   @classmethod
   def arange(cls, stop, start=0, **kwargs): return cls(np.arange(start=start, stop=stop, dtype=np.float32), **kwargs)
@@ -133,14 +133,14 @@ class Tensor:
   # Return random number between -1 and 1
   # NOTE: this behavior changed from depending on the shape to not
   @classmethod
-  def uniform(cls, *shape, **kwargs): return cls((np.random.default_rng().random(size=shape, dtype=np.float32) * 2 - 1), **kwargs)
+  def uniform(cls, *shape, **kwargs): return cls((np.random.random(size=shape).astype(np.float32) * 2 - 1), **kwargs)
 
   @classmethod
-  def scaled_uniform(cls, *shape, **kwargs): return cls((np.random.default_rng().random(size=shape, dtype=np.float32) * 2 - 1) * (prod(shape)**-0.5), **kwargs)
+  def scaled_uniform(cls, *shape, **kwargs): return cls((np.random.random(size=shape).astype(np.float32) * 2 - 1) * (prod(shape)**-0.5), **kwargs)
 
   @classmethod
   # https://www.tensorflow.org/api_docs/python/tf/keras/initializers/GlorotUniform
-  def glorot_uniform(cls, *shape, **kwargs): return cls((np.random.default_rng().random(size=shape, dtype=np.float32) * 2 - 1) * ((6/(shape[0]+prod(shape[1:])))**0.5), **kwargs)
+  def glorot_uniform(cls, *shape, **kwargs): return cls((np.random.random(size=shape).astype(np.float32) * 2 - 1) * ((6/(shape[0]+prod(shape[1:])))**0.5), **kwargs)
 
   @classmethod
   def eye(cls, dim, **kwargs): return cls(np.eye(dim, dtype=np.float32), **kwargs)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -35,7 +35,7 @@ import tinygrad.mlops as mlops
 
 class Tensor:
   __deletable__ = ('_ctx',)
-  _rng = np.random.default_rng()
+  _rng : ClassVar[np.random.Generator] = np.random.default_rng()
   training : ClassVar[bool] = False
   no_grad : ClassVar[bool] = False
 


### PR DESCRIPTION
Even though several examples try to be deterministic by setting `np.random.seed(1337)`, the resulting models are different for each run. Root cause is that `np.random.seed` doesn't affect random functions that use the default generator `np.random.default_rng()`