### PR TITLE
Remove llop symlink by using a map for llop files

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -16,13 +16,13 @@ NOCONV = getenv("NOCONV", 0)
 IMAGE = getenv("IMAGE", 0)
 LAZY = getenv("LAZY", 1)
 
-backends: Dict[str, str] = {
-  "CPU": "tinygrad.llops.ops_cpu", "GPU": "tinygrad.llops.ops_gpu", "LLVM": "tinygrad.llops.ops_llvm",
-  "TORCH": "tinygrad.llops.ops_torch", "TRITON": "accel.triton.ops_triton",
-}
-
 class _Device:
   def __init__(self) -> None:
+    backends: Dict[str, str] = {
+      "CPU": "tinygrad.llops.ops_cpu", "GPU": "tinygrad.llops.ops_gpu", "LLVM": "tinygrad.llops.ops_llvm",
+      "TORCH": "tinygrad.llops.ops_torch", "TRITON": "accel.triton.ops_triton",
+    }
+
     self.DEFAULT : str = "CPU"
     self._buffers : Dict[str, Type[DeviceBuffer]] = {}
     for name, path in backends.items():

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -16,13 +16,13 @@ NOCONV = getenv("NOCONV", 0)
 IMAGE = getenv("IMAGE", 0)
 LAZY = getenv("LAZY", 1)
 
+backends: Dict[str, str] = {
+  "CPU": "tinygrad.llops.ops_cpu", "GPU": "tinygrad.llops.ops_gpu", "LLVM": "tinygrad.llops.ops_llvm",
+  "TORCH": "tinygrad.llops.ops_torch", "TRITON": "accel.triton.ops_triton",
+}
+
 class _Device:
   def __init__(self) -> None:
-    backends: Dict[str, str] = {
-      "CPU": "tinygrad.llops.ops_cpu", "GPU": "tinygrad.llops.ops_gpu", "LLVM": "tinygrad.llops.ops_llvm",
-      "TORCH": "tinygrad.llops.ops_torch", "TRITON": "accel.triton.ops_triton",
-    }
-
     self.DEFAULT : str = "CPU"
     self._buffers : Dict[str, Type[DeviceBuffer]] = {}
     for name, path in backends.items():
@@ -31,7 +31,7 @@ class _Device:
         self._buffers[name] = [cls for cname, cls in inspect.getmembers(importlib.import_module(path), inspect.isclass) if (cname.upper() == name + "BUFFER")][0]
         self.__setattr__(name, name)
       except ImportError as e:  # NOTE: this can't be put on one line due to mypy issue
-        print(name, "backend not available", e)
+        print(name, "backend not available", e, file=sys.stderr)
 Device = _Device()
 
 # TODO: movement ops that only change shape are really nops. treat them as such

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -16,18 +16,22 @@ NOCONV = getenv("NOCONV", 0)
 IMAGE = getenv("IMAGE", 0)
 LAZY = getenv("LAZY", 1)
 
+backends: Dict[str, str] = {
+  "CPU": "tinygrad.llops.ops_cpu", "GPU": "tinygrad.llops.ops_gpu", "LLVM": "tinygrad.llops.ops_llvm",
+  "TORCH": "tinygrad.llops.ops_torch", "TRITON": "accel.triton.ops_triton",
+}
+
 class _Device:
   def __init__(self) -> None:
     self.DEFAULT : str = "CPU"
     self._buffers : Dict[str, Type[DeviceBuffer]] = {}
-    for op in [os.path.splitext(x)[0] for x in sorted(os.listdir(os.path.join(os.path.dirname(os.path.realpath(__file__)), "llops"))) if x.startswith("ops_")]:
-      name = op[len("ops_"):].upper()
+    for name, path in backends.items():
       if os.environ.get(name, 0) == "1": self.DEFAULT = name  # note: DEFAULT can be a Device that can't be imported. better than silent use of a different device
       try:
-        self._buffers[name] = [cls for cname, cls in inspect.getmembers(importlib.import_module('tinygrad.llops.'+op), inspect.isclass) if (cname.upper() == name + "BUFFER")][0]
+        self._buffers[name] = [cls for cname, cls in inspect.getmembers(importlib.import_module(path), inspect.isclass) if (cname.upper() == name + "BUFFER")][0]
         self.__setattr__(name, name)
       except ImportError as e:  # NOTE: this can't be put on one line due to mypy issue
-        print(op, "not available", e, file=sys.stderr)
+        print(name, "backend not available", e)
 Device = _Device()
 
 # TODO: movement ops that only change shape are really nops. treat them as such

--- a/tinygrad/llops/ops_triton.py
+++ b/tinygrad/llops/ops_triton.py
@@ -1,1 +1,0 @@
-../../accel/triton/ops_triton.py


### PR DESCRIPTION
Fixes #579

This also makes the way how llop's are imported a lot more clearer, by removing all the string manipulation magic. Adds 3 lines.