### PR TITLE
layer norm support in onnx

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -37,6 +37,12 @@ def BatchNormalization(X, scale, B, input_mean, input_var, epsilon=1e-05, moment
   else:
     invstd = (input_var + epsilon)**-0.5
     return X.batchnorm(scale, B, input_mean, invstd)
+  
+def LayerNormalization(x: Tensor, scale, bias, axis=-1, epsilon=9.999999747378752e-06, stash_type=1):
+  assert stash_type == 1, "only float32 is supported"
+  axis = tuple(i for i in range(axis if axis >= 0 else len(x.shape) + axis, len(x.shape)))
+  mean = x.mean(axis=axis, keepdim=True)
+  return x.layernorm(axis, epsilon).mul(scale).add(bias), mean, (x.sub(mean)).pow(2).mean(axis=axis, keepdim=True).add(epsilon).sqrt().reciprocal()
 
 def _padding(pads=None, auto_pad="NOTSET"):
   assert auto_pad == "NOTSET"  # TODO: write this

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -38,7 +38,7 @@ def BatchNormalization(X, scale, B, input_mean, input_var, epsilon=1e-05, moment
     invstd = (input_var + epsilon)**-0.5
     return X.batchnorm(scale, B, input_mean, invstd)
   
-def LayerNormalization(x: Tensor, scale, bias, axis=-1, epsilon=9.999999747378752e-06, stash_type=1):
+def LayerNormalization(x: Tensor, scale, bias, axis=-1, epsilon=1e-05, stash_type=1):
   assert stash_type == 1, "only float32 is supported"
   axis = tuple(i for i in range(axis if axis >= 0 else len(x.shape) + axis, len(x.shape)))
   mean = x.mean(axis=axis, keepdim=True)


### PR DESCRIPTION
Passing all tests except for the ones that use the Cast opt

onnx expects the return to be layernorm, mean, invstddev