### PR TITLE
Fix BatchNorm2d not realizing tensors

### DIFF
--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -5,10 +5,10 @@ class BatchNorm2d:
     assert affine, "BatchNorm2d is only supported with affine"
     self.eps, self.track_running_stats, self.momentum = eps, track_running_stats, momentum
 
-    self.weight, self.bias = Tensor.ones(sz), Tensor.zeros(sz)
+    self.weight, self.bias = Tensor.ones(sz).realize(), Tensor.zeros(sz).realize()
 
-    self.running_mean, self.running_var = Tensor.zeros(sz, requires_grad=False), Tensor.ones(sz, requires_grad=False)
-    self.num_batches_tracked = Tensor.zeros(1, requires_grad=False)
+    self.running_mean, self.running_var = Tensor.zeros(sz, requires_grad=False).realize(), Tensor.ones(sz, requires_grad=False).realize()
+    self.num_batches_tracked = Tensor.zeros(1, requires_grad=False).realize()
 
   def __call__(self, x):
     if Tensor.training:
@@ -27,6 +27,10 @@ class BatchNorm2d:
         self.running_mean = (1 - self.momentum) * self.running_mean + self.momentum * batch_mean
         self.running_var = (1 - self.momentum) * self.running_var + self.momentum * batch_var
         self.num_batches_tracked += 1
+
+        self.running_mean.realize()
+        self.running_var.realize()
+        self.num_batches_tracked.realize()
     else:
       batch_mean, batch_var = self.running_mean, self.running_var
       # NOTE: this can be precomputed for static inference. if you manually update running_var, you have to reset this


### PR DESCRIPTION
seem to fix `examples/train_resnet.py` getting slower over time

In test_mnist, there's `for p in model.parameters(): p.realize()` is some cases, but no in others. Should I just remove it, or there's some reason to not realize for some cases?

https://github.com/geohot/tinygrad/blob/e68fa18c9b3a4642ec2409102a8e4d0dd2a6f5bc/test/test_mnist.py#L51

---

lazy=0 is faster though (with torch=1)

LAZY=0
training: 5.44it/s
eval: 32.21it/s

LAZY=1
training: 4.29it/s
eval: 30.78it/s
