### PR TITLE
adding comparison operators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The autodiff stuff is all in mlops now so you can focus on the raw operations
 Buffer                                                     # class of memory on this device
 unary_op  (NOOP, NEG, NOT, EXP, LOG)                       # A -> A
 reduce_op (SUM, MAX)                                       # A -> B (smaller size, B has 1 in shape)
-binary_op (ADD, SUB, MUL, DIV, POW, CMPEQ, MAX)            # A + A -> A (all the same size)
+binary_op (ADD, SUB, MUL, DIV, POW, CMPEQ, CMPLT, MAX)            # A + A -> A (all the same size)
 movement_op (EXPAND, RESHAPE, PERMUTE, PAD, SHRINK, FLIP)  # A -> B (different size)
 fused_op [[optional]] (MULACC)                             # A * A -> B
 ```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The autodiff stuff is all in mlops now so you can focus on the raw operations
 Buffer                                                     # class of memory on this device
 unary_op  (NOOP, NEG, NOT, EXP, LOG)                       # A -> A
 reduce_op (SUM, MAX)                                       # A -> B (smaller size, B has 1 in shape)
-binary_op (ADD, SUB, MUL, DIV, POW, CMPEQ, CMPLT, MAX)            # A + A -> A (all the same size)
+binary_op (ADD, SUB, MUL, DIV, POW, CMPEQ, CMPLT, MAX)     # A + A -> A (all the same size)
 movement_op (EXPAND, RESHAPE, PERMUTE, PAD, SHRINK, FLIP)  # A -> B (different size)
 fused_op [[optional]] (MULACC)                             # A * A -> B
 ```

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -126,6 +126,12 @@ Softmax = {1: Softmax_1, 13: Softmax_13}   # Softmax default axis changed
 def LogSoftmax(input, axis=-1): return input.log_softmax(axis)
 def Clip(input, min=-3.4e38, max=3.4e38): return input.clip(min, max)
 
+def Less(x, y): return x.lt(y).numpy().astype(bool)
+def LessOrEqual(x, y): return x.lte(y).numpy().astype(bool)
+def Greater(x, y): return x.gt(y).numpy().astype(bool)
+def GreaterOrEqual(x, y): return x.gte(y).numpy().astype(bool)
+def Equal(x, y): return x.eq(y).numpy().astype(bool)
+
 def Max(*data_0): return functools.reduce(Tensor.maximum, data_0)
 def Min(*data_0): return -functools.reduce(Tensor.maximum, [-x for x in data_0])
 def Sum(*data_0): return functools.reduce(Tensor.__add__, data_0)

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -126,11 +126,11 @@ Softmax = {1: Softmax_1, 13: Softmax_13}   # Softmax default axis changed
 def LogSoftmax(input, axis=-1): return input.log_softmax(axis)
 def Clip(input, min=-3.4e38, max=3.4e38): return input.clip(min, max)
 
-def Less(x, y): return (x < y).numpy().astype(bool)
-def LessOrEqual(x, y): return (x <= y).numpy().astype(bool)
-def Greater(x, y): return (x > y).numpy().astype(bool)
-def GreaterOrEqual(x, y): return (x >= y).numpy().astype(bool)
-def Equal(x, y): return (x == y).numpy().astype(bool)
+def Less(x, y): return (x<y).numpy().astype(bool)
+def LessOrEqual(x, y): return (x<=y).numpy().astype(bool)
+def Greater(x, y): return (x>y).numpy().astype(bool)
+def GreaterOrEqual(x, y): return (x>=y).numpy().astype(bool)
+def Equal(x, y): return (x.eq(y)).numpy().astype(bool)
 
 def Max(*data_0): return functools.reduce(Tensor.maximum, data_0)
 def Min(*data_0): return -functools.reduce(Tensor.maximum, [-x for x in data_0])

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -126,11 +126,11 @@ Softmax = {1: Softmax_1, 13: Softmax_13}   # Softmax default axis changed
 def LogSoftmax(input, axis=-1): return input.log_softmax(axis)
 def Clip(input, min=-3.4e38, max=3.4e38): return input.clip(min, max)
 
-def Less(x, y): return x.lt(y).numpy().astype(bool)
-def LessOrEqual(x, y): return x.lte(y).numpy().astype(bool)
-def Greater(x, y): return x.gt(y).numpy().astype(bool)
-def GreaterOrEqual(x, y): return x.gte(y).numpy().astype(bool)
-def Equal(x, y): return x.eq(y).numpy().astype(bool)
+def Less(x, y): return (x < y).numpy().astype(bool)
+def LessOrEqual(x, y): return (x <= y).numpy().astype(bool)
+def Greater(x, y): return (x > y).numpy().astype(bool)
+def GreaterOrEqual(x, y): return (x >= y).numpy().astype(bool)
+def Equal(x, y): return (x == y).numpy().astype(bool)
 
 def Max(*data_0): return functools.reduce(Tensor.maximum, data_0)
 def Min(*data_0): return -functools.reduce(Tensor.maximum, [-x for x in data_0])

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -59,6 +59,17 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.eye(10), lambda: Tensor.eye(10), forward_only=True)
   def test_arange(self):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
+  
+  def test_eq(self):
+    helper_test_op([(45,65), (45,65)], torch.eq, lambda x,y: x==y, forward_only=True)
+  def test_gt(self):
+    helper_test_op([(45,65), (45,65)], torch.gt, lambda x,y: x>y, forward_only=True)
+  def test_gte(self):
+    helper_test_op([(45,65), (45,65)], torch.ge, lambda x,y: x>=y, forward_only=True)
+  def test_lt(self):
+    helper_test_op([(45,65), (45,65)], torch.lt, lambda x,y: x<y, forward_only=True)
+  def test_lte(self):
+    helper_test_op([(45,65), (45,65)], torch.le, lambda x,y: x<=y, forward_only=True)
 
   def test_maximum(self):
     helper_test_op([(45,65), (45,65)], torch.maximum, Tensor.maximum)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -61,15 +61,37 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
   
   def test_eq(self):
-    helper_test_op([(45,65), (45,65)], torch.eq, lambda x,y: x.eq(y), forward_only=True)
+    for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
+      helper_test_op(x, torch.eq, lambda x,y: x.eq(y), forward_only=True)
   def test_gt(self):
-    helper_test_op([(45,65), (45,65)], torch.gt, lambda x,y: x>y, forward_only=True)
+    for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
+      helper_test_op(x, torch.gt, lambda x,y: x>y, forward_only=True)
   def test_gte(self):
-    helper_test_op([(45,65), (45,65)], torch.ge, lambda x,y: x>=y, forward_only=True)
+    for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
+      helper_test_op(x, torch.ge, lambda x,y: x>=y, forward_only=True)
   def test_lt(self):
-    helper_test_op([(45,65), (45,65)], torch.lt, lambda x,y: x<y, forward_only=True)
+    for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
+      helper_test_op(x, torch.lt, lambda x,y: x<y, forward_only=True)
   def test_lte(self):
-    helper_test_op([(45,65), (45,65)], torch.le, lambda x,y: x<=y, forward_only=True)
+    for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]: 
+      helper_test_op(x, torch.le, lambda x,y: x<=y, forward_only=True)
+
+  def test_eq_backwards(self):
+    t1 = torch.ones(4, requires_grad=True)
+    t2 = torch.ones(4, requires_grad=True)
+    self.assertRaises(RuntimeError, (t1 == t2).sum().backward)
+    tt1 = Tensor.ones(4, requires_grad=True)
+    tt2 = Tensor.ones(4, requires_grad=True)
+    self.assertRaises(RuntimeError, (tt1.eq(tt2)).sum().backward)
+
+  def test_lt_backwards(self):
+    t1 = torch.ones(4, requires_grad=True)
+    t2 = torch.ones(4, requires_grad=True)
+    self.assertRaises(RuntimeError, (t1 < t2).sum().backward)
+    tt1 = Tensor.ones(4, requires_grad=True)
+    tt2 = Tensor.ones(4, requires_grad=True)
+    self.assertRaises(RuntimeError, (tt1 < tt2).sum().backward)
+
 
   def test_maximum(self):
     helper_test_op([(45,65), (45,65)], torch.maximum, Tensor.maximum)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -61,7 +61,7 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
   
   def test_eq(self):
-    helper_test_op([(45,65), (45,65)], torch.eq, lambda x,y: x==y, forward_only=True)
+    helper_test_op([(45,65), (45,65)], torch.eq, lambda x,y: x.eq(y), forward_only=True)
   def test_gt(self):
     helper_test_op([(45,65), (45,65)], torch.gt, lambda x,y: x>y, forward_only=True)
   def test_gte(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -61,18 +61,27 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
   
   def test_eq(self):
+    helper_test_op([(3, 4, 5)], lambda x: x==2, lambda x: x.eq(2), forward_only=True)
     for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(x, torch.eq, lambda x,y: x.eq(y), forward_only=True)
   def test_gt(self):
+    helper_test_op([(3, 4, 5)], lambda x: x>2, lambda x: x>2, forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: 2>x, lambda x: 2>x, forward_only=True)
     for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(x, torch.gt, lambda x,y: x>y, forward_only=True)
   def test_gte(self):
+    helper_test_op([(3, 4, 5)], lambda x: x>=2, lambda x: x>=2, forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: 2>=x, lambda x: 2>=x, forward_only=True)
     for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(x, torch.ge, lambda x,y: x>=y, forward_only=True)
   def test_lt(self):
+    helper_test_op([(3, 4, 5)], lambda x: x<2, lambda x: x<2, forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: 2<x, lambda x: 2<x, forward_only=True)
     for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]:
       helper_test_op(x, torch.lt, lambda x,y: x<y, forward_only=True)
   def test_lte(self):
+    helper_test_op([(3, 4, 5)], lambda x: x<=2, lambda x: x<=2, forward_only=True)
+    helper_test_op([(3, 4, 5)], lambda x: 2<=x, lambda x: 2<=x, forward_only=True)
     for x in [[(3,4, 5), (3, 4, 5)], [(3, 4, 5), (5,)], [(5,), (3, 4, 5)]]: 
       helper_test_op(x, torch.le, lambda x,y: x<=y, forward_only=True)
 

--- a/tinygrad/codegen/gpu.py
+++ b/tinygrad/codegen/gpu.py
@@ -36,7 +36,7 @@ class GPUCodegen(ASTKernel):
     UnaryOps.EXP: "native_exp(A)" if NATIVE_EXPLOG else "exp(A)",
     UnaryOps.LOG: "native_log(A)" if NATIVE_EXPLOG else "log(A)",
     BinaryOps.ADD: "(A+B)", BinaryOps.SUB: "(A-B)", BinaryOps.MUL: "(A*B)",
-    BinaryOps.DIV: "(A/B)", BinaryOps.POW: "pow(A,B)", BinaryOps.CMPEQ: "(A==B)",
+    BinaryOps.DIV: "(A/B)", BinaryOps.POW: "pow(A,B)", BinaryOps.CMPEQ: "(A==B)", BinaryOps.CMPLT: "(A<B)",
     BinaryOps.MAX: "max(A,B)", ReduceOps.SUM: "A=(A+B)", ReduceOps.MAX: "A=max(A,B)"
   }
   start_for_op : Final[Dict[Op, str]] = {ReduceOps.SUM: "0.0", ReduceOps.MAX: "-INFINITY"}

--- a/tinygrad/codegen/llvm.py
+++ b/tinygrad/codegen/llvm.py
@@ -32,6 +32,7 @@ class LLVMCodegen(ASTKernel):
     BinaryOps.DIV: lambda builder,x,y: builder.fdiv(x,y, flags=('fast',)),
     BinaryOps.POW: lambda builder,x,y: builder.call(builder._block.module.declare_intrinsic('llvm.pow', [ir.FloatType()]), [x,y], fastmath=('fast',)),
     BinaryOps.CMPEQ: lambda builder,x,y: builder.uitofp(builder.fcmp_ordered("==", x, y, flags=('fast',)), ir.FloatType()),
+    BinaryOps.CMPLT: lambda builder,x,y: builder.uitofp(builder.fcmp_ordered("<", x, y, flags=('fast',)), ir.FloatType()),
     BinaryOps.MAX: lambda builder,x,y: builder.select(builder.fcmp_unordered(">", x, y, flags=('fast',)), x, y, flags=('fast',))
   }
   start_for_op : ClassVar = {

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -51,6 +51,13 @@ class Max(Function):
     return max_is_amount.binary_op(BinaryOps.MUL, grad_output_expanded)
 
 # ************* binary ops *************
+class CompareLess(Function):
+  def forward(self, x, y):
+    return x.binary_op(BinaryOps.CMPLT, y)
+
+class CompareEqual(Function):
+  def forward(self, x, y):
+    return x.binary_op(BinaryOps.CMPEQ, y)
 
 class Maximum(Function):
   def forward(self, x, y):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -54,10 +54,15 @@ class Max(Function):
 class CompareLess(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPLT, y)
+  def backward(self, *args, **kwargs):
+    pass
 
 class CompareEqual(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPEQ, y)
+
+  def backward(self, *args, **kwargs):
+    pass
 
 class Maximum(Function):
   def forward(self, x, y):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -55,16 +55,10 @@ class CompareLess(Function):
   def forward(self, x, y):
     self.ret = x.binary_op(BinaryOps.CMPLT, y)
     return self.ret
-  def backward(self, grad_output):
-    return grad_output.binary_op(BinaryOps.MUL, self.ret) if self.needs_input_grad[0] else None, \
-           grad_output.binary_op(BinaryOps.MUL, self.ret.unary_op(UnaryOps.NOT)) if self.needs_input_grad[1] else None
-
+  
 class CompareEqual(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPEQ, y)
-
-  def backward(self, grad_output):
-    pass
 
 class Maximum(Function):
   def forward(self, x, y):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -53,15 +53,17 @@ class Max(Function):
 # ************* binary ops *************
 class CompareLess(Function):
   def forward(self, x, y):
-    return x.binary_op(BinaryOps.CMPLT, y)
-  def backward(self, *args, **kwargs):
-    pass
+    self.ret = x.binary_op(BinaryOps.CMPLT, y)
+    return self.ret
+  def backward(self, grad_output):
+    return grad_output.binary_op(BinaryOps.MUL, self.ret) if self.needs_input_grad[0] else None, \
+           grad_output.binary_op(BinaryOps.MUL, self.ret.unary_op(UnaryOps.NOT)) if self.needs_input_grad[1] else None
 
 class CompareEqual(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPEQ, y)
 
-  def backward(self, *args, **kwargs):
+  def backward(self, grad_output):
     pass
 
 class Maximum(Function):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -55,14 +55,10 @@ class CompareLess(Function):
   def forward(self, x, y):
     self.ret = x.binary_op(BinaryOps.CMPLT, y)
     return self.ret
-
-  def backward(self): raise RuntimeError("no grad function")
   
 class CompareEqual(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPEQ, y)
-
-  def backward(self): raise RuntimeError("no grad function")
   
 class Maximum(Function):
   def forward(self, x, y):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -55,11 +55,15 @@ class CompareLess(Function):
   def forward(self, x, y):
     self.ret = x.binary_op(BinaryOps.CMPLT, y)
     return self.ret
+
+  def backward(self): raise RuntimeError("no grad function")
   
 class CompareEqual(Function):
   def forward(self, x, y):
     return x.binary_op(BinaryOps.CMPEQ, y)
 
+  def backward(self): raise RuntimeError("no grad function")
+  
 class Maximum(Function):
   def forward(self, x, y):
     self.y, self.ret = y, x.binary_op(BinaryOps.MAX, y)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -9,7 +9,7 @@ from tinygrad.shape import ShapeTracker
 # these are the llops your accelerator must implement, along with toCpu
 # the Enum class doesn't work with mypy, this is static. sorry it's ugly
 class UnaryOps(Enum): NOOP = auto(); NEG = auto(); EXP = auto(); LOG = auto(); NOT = auto() # noqa: E702
-class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto() # noqa: E702
+class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto(); CMPLT = auto(); # noqa: E702
 class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
 class MovementOps(Enum): RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); FLIP = auto(); PAD = auto(); SHRINK = auto() # noqa: E702
 class FusedOps(Enum): MULACC = auto() # noqa: E702

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -9,7 +9,7 @@ from tinygrad.shape import ShapeTracker
 # these are the llops your accelerator must implement, along with toCpu
 # the Enum class doesn't work with mypy, this is static. sorry it's ugly
 class UnaryOps(Enum): NOOP = auto(); NEG = auto(); EXP = auto(); LOG = auto(); NOT = auto() # noqa: E702
-class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto(); CMPLT = auto(); # noqa: E702
+class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto(); CMPLT = auto() # noqa: E702
 class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
 class MovementOps(Enum): RESHAPE = auto(); PERMUTE = auto(); EXPAND = auto(); FLIP = auto(); PAD = auto(); SHRINK = auto() # noqa: E702
 class FusedOps(Enum): MULACC = auto() # noqa: E702

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -24,7 +24,7 @@ def einsum_mulacc(einsum, get_strides, expand):
 
 numpy_fxn_for_op : Dict[Op, Callable] = {**base_fxn_for_op, **{
   UnaryOps.NOOP: lambda x: np.ascontiguousarray(x), UnaryOps.EXP: lambda x: np.exp(x), UnaryOps.LOG: lambda x: np.log(x),
-  BinaryOps.MAX: np.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).astype(np.float32),
+  BinaryOps.MAX: np.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).astype(np.float32), BinaryOps.CMPLT: lambda x, y: (x<y).astype(np.float32),
   MovementOps.FLIP: lambda x, axis: np.flip(x, axis), MovementOps.PERMUTE: lambda x, order: x.transpose(order),
   MovementOps.PAD: lambda x, padding: np.pad(x, padding), MovementOps.EXPAND: lambda x, new_shape: np.broadcast_to(x, new_shape),
   FusedOps.MULACC: einsum_mulacc(lambda s,a,b: np.einsum(s, a.copy(), b.copy()), lambda x: x.strides, np.broadcast_to)

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -6,7 +6,7 @@ from tinygrad.runtime.ops_cpu import base_fxn_for_op, einsum_mulacc
 
 torch_fxn_for_op : Dict[Op, Callable] = {**base_fxn_for_op, **{
   UnaryOps.NOOP: lambda x: x.contiguous(), UnaryOps.EXP: lambda x: x.exp(), UnaryOps.LOG: lambda x: x.log(),
-  BinaryOps.MAX: torch.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).float(),
+  BinaryOps.MAX: torch.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).float(), BinaryOps.CMPLT: lambda x, y:(x<y).float(),
   MovementOps.PAD: lambda x, padding: torch.nn.functional.pad(x, [item for sublist in padding[::-1] for item in sublist]),
   FusedOps.MULACC: einsum_mulacc(torch.einsum, lambda x: x.stride(), lambda x,s: x.expand(s))
 }}

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -402,6 +402,13 @@ class Tensor:
   def maximum(self, x:Union[Tensor, float]) -> Tensor: return self._broadcasted(mlops.Maximum, x)
   def minimum(self, x:Union[Tensor, float]) -> Tensor: return -((-self).maximum(-x))
 
+  # Comparison ops
+  def lt(self, x): return self._broadcasted(mlops.CompareLess, x, False)
+  def lte(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self.eq(x))
+  def gt(self, x): return self._broadcasted(mlops.CompareLess, x, True)
+  def gte(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self.eq(x))
+  def eq(self, x): return self._broadcasted(mlops.CompareEqual, x, False)
+
   # ***** binary op wrappers (18 wasted lines to make the typechecker happy) *****
 
   # NOTE: __pow__ and friends are broken in mypyc with the ** operator

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -403,11 +403,11 @@ class Tensor:
   def minimum(self, x:Union[Tensor, float]) -> Tensor: return -((-self).maximum(-x))
 
   # Comparison ops
-  def lt(self, x): return self._broadcasted(mlops.CompareLess, x, False)
-  def lte(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self.eq(x))
-  def gt(self, x): return self._broadcasted(mlops.CompareLess, x, True)
-  def gte(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self.eq(x))
-  def eq(self, x): return self._broadcasted(mlops.CompareEqual, x, False)
+  def __lt__(self, x): return self._broadcasted(mlops.CompareLess, x, False)
+  def __le__(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self == x)
+  def __gt__(self, x): return self._broadcasted(mlops.CompareLess, x, True)
+  def __ge__(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self == x)
+  def __eq__(self, x): return self._broadcasted(mlops.CompareEqual, x, False)
 
   # ***** binary op wrappers (18 wasted lines to make the typechecker happy) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -404,10 +404,10 @@ class Tensor:
 
   # Comparison ops
   def __lt__(self, x): return self._broadcasted(mlops.CompareLess, x, False)
-  def __le__(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self == x)
+  def __le__(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self.eq(x))
   def __gt__(self, x): return self._broadcasted(mlops.CompareLess, x, True)
-  def __ge__(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self == x)
-  def __eq__(self, x): return self._broadcasted(mlops.CompareEqual, x, False)
+  def __ge__(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self.eq(x))
+  def eq(self, x): return self._broadcasted(mlops.CompareEqual, x, False) if isinstance(x, Tensor) else False
 
   # ***** binary op wrappers (18 wasted lines to make the typechecker happy) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -15,7 +15,7 @@ class Function:
     self.requires_grad = True if any(self.needs_input_grad) else (None if any(x is None for x in self.needs_input_grad) else False)
 
   def forward(self, *args, **kwargs): raise NotImplementedError(f"forward not implemented for {type(self)}")
-  def backward(self, *args, **kwargs): raise NotImplementedError(f"backward not implemented for {type(self)}")
+  def backward(self, *args, **kwargs): raise RuntimeError(f"backward not implemented for {type(self)}")
 
   @classmethod
   def apply(fxn:Type[Function], *x:Tensor, **kwargs) -> Tensor:
@@ -403,11 +403,11 @@ class Tensor:
   def minimum(self, x:Union[Tensor, float]) -> Tensor: return -((-self).maximum(-x))
 
   # Comparison ops
-  def __lt__(self, x): return self._broadcasted(mlops.CompareLess, x, False)
-  def __le__(self, x): return self._broadcasted(mlops.CompareLess, x, False).add(self.eq(x))
-  def __gt__(self, x): return self._broadcasted(mlops.CompareLess, x, True)
-  def __ge__(self, x): return self._broadcasted(mlops.CompareLess, x, True).add(self.eq(x))
-  def eq(self, x): return self._broadcasted(mlops.CompareEqual, x, False) if isinstance(x, Tensor) else False
+  def __lt__(self, x) -> Tensor: return self._broadcasted(mlops.CompareLess, x, False)
+  def __le__(self, x) -> Tensor: return self._broadcasted(mlops.CompareLess, x, False).add(self.eq(x))
+  def __gt__(self, x) -> Tensor: return self._broadcasted(mlops.CompareLess, x, True)
+  def __ge__(self, x) -> Tensor: return self._broadcasted(mlops.CompareLess, x, True).add(self.eq(x))
+  def eq(self, x) -> Tensor: return self._broadcasted(mlops.CompareEqual, x, False)
 
   # ***** binary op wrappers (18 wasted lines to make the typechecker happy) *****
 


### PR DESCRIPTION
Opening as a draft to get feedback on a couple things
- onnx expects a bool tensor to be returned so I am using .numpy().astype(bool) - hacky for now until we add types?
- created mlops functions to take advantage of the broadcast helper function in tensor - but not sure if this makes sense or if there even is a backwards pass for these operators? 

----

added comparison functions in tensor class

used mlops to take advantage of the broadcast function

tested with the following runtimes
- CPU
- GPU
- CUDA
- LLVM
- TORCH

adds onnx ops Less, LessOrEqual, Greater, GreaterOrEqual, Equal, all tests passing except for the ones that require Or operator