### PR TITLE
Fix windows file permission error

### DIFF
--- a/extra/utils.py
+++ b/extra/utils.py
@@ -24,6 +24,7 @@ def download_file(url, fp, skip_if_exists=False):
   with tempfile.NamedTemporaryFile(delete=False) as f:
     for chunk in r.iter_content(chunk_size=16384):
       progress_bar.update(f.write(chunk))
+    f.close()
     os.rename(f.name, fp)
 
 def my_unpickle(fb0):


### PR DESCRIPTION
I get this error when I run on windows:

```
λ python examples\efficientnet.py https://media.istockphoto.com/photos/hen-picture-id831791190                                                                             
cuda backend not available No module named 'pycuda'                                                                                                                        
gpu backend not available No module named 'pyopencl'                                                                                                                       
llvm backend not available No module named 'llvmlite'                                                                                                                      
metal backend not available No module named 'Metal'                                                                                                                        
torch backend not available No module named 'torch'                                                                                                                        
https://github.com/lukemelas/EfficientNet-PyTorch/releases/download/1.0/efficientnet-b0-355c32eb.pth:  91%|███████████████████████▋  | 19.5M/21.4M [00:00<00:00, 59.6MB/s]T
raceback (most recent call last):                                                                                                                                          
  File "D:\COMMAI\tinygrad\examples\efficientnet.py", line 61, in <module>                                                                                                 
    model.load_from_pretrained()                                                                                                                                           
  File "d:\commai\tinygrad\models\efficientnet.py", line 147, in load_from_pretrained                                                                                      
    b0 = fake_torch_load(fetch(model_urls[self.number]))                                                                                                                   
  File "d:\commai\tinygrad\extra\utils.py", line 13, in fetch                                                                                                              
    download_file(url, fp, skip_if_exists=not getenv("NOCACHE"))                                                                                                           
  File "d:\commai\tinygrad\extra\utils.py", line 27, in download_file                                                                                                      
    os.rename(f.name, fp)                                                                                                                                                  
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\Patrick\\AppData\\Local\\Temp\\tmpvooqok9i' -> '
C:\\Users\\Patrick\\AppData\\Local\\Temp\\25a577ff33da5a86106d005c8c7beedd'                                                                                                
https://github.com/lukemelas/EfficientNet-PyTorch/releases/download/1.0/efficientnet-b0-355c32eb.pth: 100%|██████████████████████████| 21.4M/21.4M [00:00<00:00, 55.2MB/s] 
```

Simple fix is to close the file before moving it (have only tested on windows).

```
λ python --version
Python 3.9.0
```