### PR TITLE
Expand the inline loop to prevent stack overflow from `_deepwalk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,12 @@ GRAPH=1 python3 test/test_mnist.py TestMNIST.test_sgd_onestep
 
 ### Running tests
 
+For more examples on how to run the full test suite please refer to the [CI workflow](.github/workflows/test.yml).
+
 ```bash
+python3 -m pip install -e '.[testing]'
 python3 -m pytest
+python3 -m pytest -v -k TestTrain
+python3 ./test/models/test_train.py TestTrain.test_efficientnet
 ```
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -156,8 +156,9 @@ class Tensor:
     def _deepwalk(node, visited, nodes):
       visited.add(node)
       if node._ctx:
-        for i in [k for k in node._ctx.parents if k not in visited]:
-          _deepwalk(i, visited, nodes)
+        for i in node._ctx.parents:
+          if i not in visited:
+            _deepwalk(i, visited, nodes)
         nodes.append(node)
       return nodes
     return _deepwalk(self, set(), [])

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -156,7 +156,8 @@ class Tensor:
     def _deepwalk(node, visited, nodes):
       visited.add(node)
       if node._ctx:
-        [_deepwalk(i, visited, nodes) for i in node._ctx.parents if i not in visited]
+        for i in [k for k in node._ctx.parents if k not in visited]:
+          _deepwalk(i, visited, nodes)
         nodes.append(node)
       return nodes
     return _deepwalk(self, set(), [])


### PR DESCRIPTION
Fixes #637

I also added some notes to the readme testing section to help others, let me know if you want removed / changed.


Original Error:
```
test\models\test_train.py .Windows fatal exception: stack overflow

Thread 0x00002074 (most recent call first):
  File "C:\Users\Patrick\AppData\Local\Programs\Python\Python39\lib\threading.py", line 316 in wait
  File "C:\Users\Patrick\AppData\Local\Programs\Python\Python39\lib\threading.py", line 574 in wait
  File "D:\COMMAI\tinygrad\venv\lib\site-packages\tqdm\_monitor.py", line 60 in run
  File "C:\Users\Patrick\AppData\Local\Programs\Python\Python39\lib\threading.py", line 950 in _bootstrap_inner
  File "C:\Users\Patrick\AppData\Local\Programs\Python\Python39\lib\threading.py", line 908 in _bootstrap

Current thread 0x00002238 (most recent call first):
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in <listcomp>
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in _deepwalk
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in <listcomp>
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in _deepwalk
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in <listcomp>
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in _deepwalk
  File "D:\COMMAI\tinygrad\tinygrad\tensor.py", line 159 in <listcomp>
...
```