### PR TITLE
Switch to `perf_counter` for timing code

### DIFF
--- a/examples/benchmark_train_efficientnet.py
+++ b/examples/benchmark_train_efficientnet.py
@@ -31,13 +31,13 @@ if __name__ == "__main__":
   Tensor.no_grad = not BACKWARD
   for i in trange(CNT):
     GlobalCounters.reset()
-    cpy = time.monotonic()
+    cpy = time.perf_counter()
     x_train = Tensor.randn(BS, 3, 224, 224, requires_grad=False).realize()
     y_train = Tensor.randn(BS, 1000, requires_grad=False).realize()
 
     # TODO: replace with TinyJit
     if i < 3 or not CLCACHE:
-      st = time.monotonic()
+      st = time.perf_counter()
       out = model.forward(x_train)
       loss = out.log_softmax().mul(y_train).mean()
       if i == 2 and CLCACHE: GlobalCounters.cache = []
@@ -45,15 +45,15 @@ if __name__ == "__main__":
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
-      mt = time.monotonic()
+      mt = time.perf_counter()
       loss.realize()
       for p in parameters:
         p.realize()
-      et = time.monotonic()
+      et = time.perf_counter()
     else:
-      st = mt = time.monotonic()
+      st = mt = time.perf_counter()
       for prg, args in cl_cache: prg(*args)
-      et = time.monotonic()
+      et = time.perf_counter()
 
     if i == 2 and CLCACHE:
       cl_cache = GlobalCounters.cache
@@ -61,6 +61,6 @@ if __name__ == "__main__":
 
     mem_used = GlobalCounters.mem_used
     loss_cpu = loss.detach().numpy()[0]
-    cl = time.monotonic()
+    cl = time.perf_counter()
 
     print(f"{(st-cpy)*1000.0:7.2f} ms cpy,  {(cl-st)*1000.0:7.2f} ms run, {(mt-st)*1000.0:7.2f} ms build, {(et-mt)*1000.0:7.2f} ms realize, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss, {tensors_allocated():4d} tensors, {mem_used/1e9:.2f} GB used, {GlobalCounters.global_ops*1e-9/(cl-st):9.2f} GFLOPS")

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -73,9 +73,9 @@ if __name__ == "__main__":
       _ = cap.grab() # discard one frame to circumvent capture buffering
       ret, frame = cap.read()
       img = Image.fromarray(frame[:, :, [2,1,0]])
-      lt = time.monotonic_ns()
+      lt = time.perf_counter_ns()
       out, retimg = infer(model, img)
-      print(f"{(time.monotonic_ns()-lt)*1e-6:7.2f} ms", np.argmax(out), np.max(out), lbls[np.argmax(out)])
+      print(f"{(time.perf_counter_ns()-lt)*1e-6:7.2f} ms", np.argmax(out), np.max(out), lbls[np.argmax(out)])
       SCALE = 3
       simg = cv2.resize(retimg, (224*SCALE, 224*SCALE))
       retimg = cv2.cvtColor(simg, cv2.COLOR_RGB2BGR)

--- a/examples/efficientnet.py
+++ b/examples/efficientnet.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
       img = Image.open(io.BytesIO(fetch(url)))
     else:
       img = Image.open(url)
-    st = time.time()
+    st = time.perf_counter_ns()
     out, _ = infer(model, img)
     print(np.argmax(out), np.max(out), lbls[np.argmax(out)])
-    print(f"did inference in {(time.time()-st):2f}")
+    print(f"did inference in {(time.perf_counter_ns()-st)*1e-6:.2f} ms")

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -111,13 +111,13 @@ def train_cifar():
       correct = outs == Yt.numpy().argmin(axis=1)
       print(f"eval {sum(correct)}/{len(correct)} {sum(correct)/len(correct)*100.0:.2f}%")
     GlobalCounters.reset()
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     loss = train_step_jitted(model, optimizer, X, Y)
-    et = time.perf_counter()
+    et = time.perf_counter_ns()
     X, Y = fetch_batch(X_train, Y_train, BS=BS)  # do this here
     loss_cpu = loss.numpy()[0]
-    cl = time.perf_counter()
-    print(f"{i:3d} {(cl-st)*1000.0:7.2f} ms run, {(et-st)*1000.0:7.2f} ms python, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss, {GlobalCounters.mem_used/1e9:.2f} GB used, {GlobalCounters.global_ops*1e-9/(cl-st):9.2f} GFLOPS")
+    cl = time.perf_counter_ns()
+    print(f"{i:3d} {(cl-st)*1e-6:7.2f} ms run, {(et-st)*1e-6:7.2f} ms python, {(cl-et)*1e-6:7.2f} ms CL, {loss_cpu:7.2f} loss, {GlobalCounters.mem_used/1e9:.2f} GB used, {GlobalCounters.global_ops/(cl-st):9.2f} GFLOPS")
 
   #train(model, X, Y, optimizer, steps=X.shape[0]//BS, BS=BS)
   #evaluate(model, X_test, Y_test)

--- a/examples/hlb_cifar10.py
+++ b/examples/hlb_cifar10.py
@@ -111,12 +111,12 @@ def train_cifar():
       correct = outs == Yt.numpy().argmin(axis=1)
       print(f"eval {sum(correct)}/{len(correct)} {sum(correct)/len(correct)*100.0:.2f}%")
     GlobalCounters.reset()
-    st = time.monotonic()
+    st = time.perf_counter()
     loss = train_step_jitted(model, optimizer, X, Y)
-    et = time.monotonic()
+    et = time.perf_counter()
     X, Y = fetch_batch(X_train, Y_train, BS=BS)  # do this here
     loss_cpu = loss.numpy()[0]
-    cl = time.monotonic()
+    cl = time.perf_counter()
     print(f"{i:3d} {(cl-st)*1000.0:7.2f} ms run, {(et-st)*1000.0:7.2f} ms python, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss, {GlobalCounters.mem_used/1e9:.2f} GB used, {GlobalCounters.global_ops*1e-9/(cl-st):9.2f} GFLOPS")
 
   #train(model, X, Y, optimizer, steps=X.shape[0]//BS, BS=BS)

--- a/examples/hlb_cifar10_torch.py
+++ b/examples/hlb_cifar10_torch.py
@@ -89,12 +89,12 @@ def train_cifar():
       outs = model(Xt).detach().cpu().numpy().argmax(axis=1)
       correct = outs == Yt.detach().cpu().numpy().argmin(axis=1)
       print(f"eval {sum(correct)}/{len(correct)} {sum(correct)/len(correct)*100.0:.2f}%")
-    st = time.monotonic()
+    st = time.perf_counter()
     loss = train_step_jitted(model, optimizer, X, Y)
-    et = time.monotonic()
+    et = time.perf_counter()
     X, Y = fetch_batch(X_train, Y_train, BS=BS)  # do this here
     loss_cpu = loss.detach().cpu().item()
-    cl = time.monotonic()
+    cl = time.perf_counter()
     print(f"{i:3d} {(cl-st)*1000.0:7.2f} ms run, {(et-st)*1000.0:7.2f} ms python, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss")
 
 if __name__ == "__main__":

--- a/examples/hlb_cifar10_torch.py
+++ b/examples/hlb_cifar10_torch.py
@@ -89,13 +89,13 @@ def train_cifar():
       outs = model(Xt).detach().cpu().numpy().argmax(axis=1)
       correct = outs == Yt.detach().cpu().numpy().argmin(axis=1)
       print(f"eval {sum(correct)}/{len(correct)} {sum(correct)/len(correct)*100.0:.2f}%")
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     loss = train_step_jitted(model, optimizer, X, Y)
-    et = time.perf_counter()
+    et = time.perf_counter_ns()
     X, Y = fetch_batch(X_train, Y_train, BS=BS)  # do this here
     loss_cpu = loss.detach().cpu().item()
-    cl = time.perf_counter()
-    print(f"{i:3d} {(cl-st)*1000.0:7.2f} ms run, {(et-st)*1000.0:7.2f} ms python, {(cl-et)*1000.0:7.2f} ms CL, {loss_cpu:7.2f} loss")
+    cl = time.perf_counter_ns()
+    print(f"{i:3d} {(cl-st)*1e-6:7.2f} ms run, {(et-st)*1e-6:7.2f} ms python, {(cl-et)*1e-6:7.2f} ms CL, {loss_cpu:7.2f} loss")
 
 if __name__ == "__main__":
   train_cifar()

--- a/extra/gemm/amx.py
+++ b/extra/gemm/amx.py
@@ -168,9 +168,9 @@ cfunc = LLVM().exec(module, bufs, N**3 * 2)
 
 times = []
 for i in range(50):
-  st = time.monotonic()
+  st = time.perf_counter()
   cfunc(*[x._buf for x in bufs])
-  et = time.monotonic() - st
+  et = time.perf_counter() - st
   times.append(et)
 
 print(f"{min(times)*1000:.2f} ms min time, {np.median(times)*1000:.2f} ms median time")

--- a/extra/gemm/amx.py
+++ b/extra/gemm/amx.py
@@ -168,12 +168,12 @@ cfunc = LLVM().exec(module, bufs, N**3 * 2)
 
 times = []
 for i in range(50):
-  st = time.perf_counter()
+  st = time.perf_counter_ns()
   cfunc(*[x._buf for x in bufs])
-  et = time.perf_counter() - st
+  et = time.perf_counter_ns() - st
   times.append(et)
 
-print(f"{min(times)*1000:.2f} ms min time, {np.median(times)*1000:.2f} ms median time")
+print(f"{min(times)*1e-6:.2f} ms min time, {np.median(times)*1e-6:.2f} ms median time")
 print("%.2f GB/s" % ((N*N*4*1e-9)/min(times)))
 
 print(c.toCPU().astype(np.int64)[:sn.shape[0]])

--- a/extra/gemm/gemm.py
+++ b/extra/gemm/gemm.py
@@ -16,11 +16,11 @@ if __name__ == "__main__":
   #print(f"{flop / 1e9:.2f} GFLOP")
 
   for i in range(4):
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     C = A @ B.T
-    et = time.perf_counter()
+    et = time.perf_counter_ns()
     s = et-st
-    print(f"{flop/s * 1e-9:.2f} GFLOP/S, {s*1e3:.2f} ms")
+    print(f"{flop/s:.2f} GFLOP/S, {s*1e-6:.2f} ms")
   
   with open("/tmp/matmul", "wb") as f:
     f.write(A.data)

--- a/extra/gemm/gemm.py
+++ b/extra/gemm/gemm.py
@@ -16,9 +16,9 @@ if __name__ == "__main__":
   #print(f"{flop / 1e9:.2f} GFLOP")
 
   for i in range(4):
-    st = time.monotonic()
+    st = time.perf_counter()
     C = A @ B.T
-    et = time.monotonic()
+    et = time.perf_counter()
     s = et-st
     print(f"{flop/s * 1e-9:.2f} GFLOP/S, {s*1e3:.2f} ms")
   

--- a/extra/helpers.py
+++ b/extra/helpers.py
@@ -1,5 +1,5 @@
 import time
 
 class Timing(object):
-  def __enter__(self): self.st = time.monotonic_ns()
-  def __exit__(self, exc_type, exc_val, exc_tb): print(f"{(time.monotonic_ns()-self.st)*1e-6:.2f} ms")
+  def __enter__(self): self.st = time.perf_counter_ns()
+  def __exit__(self, exc_type, exc_val, exc_tb): print(f"{(time.perf_counter_ns()-self.st)*1e-6:.2f} ms")

--- a/extra/kernel_search.py
+++ b/extra/kernel_search.py
@@ -84,11 +84,11 @@ def run_and_time(k,cnt=3,local_override=None):
   prog = k.codegen()
   ret = []
   for i in range(cnt):
-    t1 = time.monotonic_ns()
+    t1 = time.perf_counter_ns()
     if local_override: prog.local_work_size = local_override
     e = prog(*k.bufs)
     e.wait()
-    t4 = time.monotonic_ns()
+    t4 = time.perf_counter_ns()
     t2, t3 = e.profile.start * OSX_TIMING_RATIO, e.profile.end * OSX_TIMING_RATIO
     #print(*[f"{(x-t1)*1e-3:7.2f} us" for x in [t1, t2, t3, t4]])  # TODO: this may be wrong on non OS X
     #assert t1 < t2 < t3 < t4, "timings not in order"

--- a/extra/kernel_search.py
+++ b/extra/kernel_search.py
@@ -84,11 +84,11 @@ def run_and_time(k,cnt=3,local_override=None):
   prog = k.codegen()
   ret = []
   for i in range(cnt):
-    t1 = time.perf_counter_ns()
+    t1 = time.perf_counter()
     if local_override: prog.local_work_size = local_override
     e = prog(*k.bufs)
     e.wait()
-    t4 = time.perf_counter_ns()
+    t4 = time.perf_counter()
     t2, t3 = e.profile.start * OSX_TIMING_RATIO, e.profile.end * OSX_TIMING_RATIO
     #print(*[f"{(x-t1)*1e-3:7.2f} us" for x in [t1, t2, t3, t4]])  # TODO: this may be wrong on non OS X
     #assert t1 < t2 < t3 < t4, "timings not in order"

--- a/extra/thneed.py
+++ b/extra/thneed.py
@@ -268,12 +268,12 @@ class Thneed:
 
   def run(self):
     events = []
-    st = time.monotonic()
+    st = time.perf_counter()
     for prg, args in self.cl_cache:
       events.append(prg.clprg(CL.cl_queue, *args))
-    mt = time.monotonic()
+    mt = time.perf_counter()
     CL.cl_queue.finish()
-    et = time.monotonic() - st
+    et = time.perf_counter() - st
     print(f"submit in {(mt-st)*1000.0:.2f} ms, total runtime is {et*1000.0:.2f} ms")
 
     if DEBUGCL >= 2:

--- a/extra/thneed.py
+++ b/extra/thneed.py
@@ -268,17 +268,17 @@ class Thneed:
 
   def run(self):
     events = []
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     for prg, args in self.cl_cache:
       events.append(prg.clprg(CL.cl_queue, *args))
-    mt = time.perf_counter()
+    mt = time.perf_counter_ns()
     CL.cl_queue.finish()
-    et = time.perf_counter() - st
-    print(f"submit in {(mt-st)*1000.0:.2f} ms, total runtime is {et*1000.0:.2f} ms")
+    et = time.perf_counter_ns() - st
+    print(f"submit in {(mt-st)*1e-6:.2f} ms, total runtime is {et*1e-6:.2f} ms")
 
     if DEBUGCL >= 2:
       for i, ((prg, args), e) in enumerate(zip(self.cl_cache, events)):
-        print(f"{i:3d} {prg.name:20s} " + "queued @ %5.2f ms, submit @ %5.2fms, start @ %5.2f ms, end @ %5.2f ms" % tuple((x*OSX_TIMING_RATIO - st*1e9)/1e6 for x in [e.profile.queued, e.profile.submit, e.profile.start, e.profile.end]))
+        print(f"{i:3d} {prg.name:20s} " + "queued @ %5.2f ms, submit @ %5.2fms, start @ %5.2f ms, end @ %5.2f ms" % tuple((x*OSX_TIMING_RATIO - st)*1e-6 for x in [e.profile.queued, e.profile.submit, e.profile.start, e.profile.end]))
     if DEBUGCL >= 1:
       total_runtime = 0
       for i, ((prg, args), e) in enumerate(zip(self.cl_cache, events)):
@@ -287,6 +287,6 @@ class Thneed:
         if hasattr(prg, 'prg') and ((DEBUGCL >= 2 and getenv("PRINT_KERNEL", -1) == i) or DEBUGCL >= 3):
           print(prg.prg)
         total_runtime += runtime
-      print(f"total runtime: {total_runtime/1e6:.2f} ms   wall time: {et*1000.0:.2f} ms")
+      print(f"total runtime: {total_runtime/1e6:.2f} ms   wall time: {et*1e-6:.2f} ms")
       return total_runtime/1e9
     return et

--- a/openpilot/compile.py
+++ b/openpilot/compile.py
@@ -84,7 +84,7 @@ def compile(dat, output_fn):
 
   print(f"buffers to save: {len(t.buffers_to_save)}, inputs: {list(t.inputs.keys())}, outputs: {t.outputs}")
   runtime = t.run()
-  print(f"network using {used_ops/1e9:.2f} GOPS with runtime {runtime*1e3:.2f} ms that's {used_ops/runtime*1e-9:.2f} GFLOPS")
+  print(f"network using {used_ops/1e9:.2f} GOPS with runtime {runtime*1e-6:.2f} ms that's {used_ops/runtime:.2f} GFLOPS")
 
   # confirm thneed found the right output
   thneed_out = np.empty((t.outputs[0].size//4,), dtype=np.float32).reshape(tinygrad_out.shape)

--- a/test/external/external_osx_profiling.py
+++ b/test/external/external_osx_profiling.py
@@ -12,15 +12,15 @@ prg = CLProgram("test", """__kernel void test(__global float *a, __global float 
 }""")
 prg.clprg(CL.cl_queue, [N,], None, a._cl, b._cl, c._cl)
 
-t1 = time.monotonic_ns()
+t1 = time.perf_counter_ns()
 e1 = prg.clprg(CL.cl_queue, [N,], None, a._cl, b._cl, c._cl)
 CL.cl_queue.finish()  # type: ignore
-t2 = time.monotonic_ns()
+t2 = time.perf_counter_ns()
 time.sleep(3)
-t3 = time.monotonic_ns()
+t3 = time.perf_counter_ns()
 e2 = prg.clprg(CL.cl_queue, [N,], None, a._cl, b._cl, c._cl)
 CL.cl_queue.finish()  # type: ignore
-t4 = time.monotonic_ns()
+t4 = time.perf_counter_ns()
 
 print(e1.profile.queued)
 print(e1.profile.submit)

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -41,13 +41,13 @@ class TestOnnxModel(unittest.TestCase):
 
     for _ in range(7):
       inputs = get_inputs()
-      st = time.monotonic()
+      st = time.perf_counter()
       tinygrad_out = run_onnx(inputs)['outputs']
-      mt = time.monotonic()
+      mt = time.perf_counter()
       tinygrad_out.realize()
-      mt2 = time.monotonic()
+      mt2 = time.perf_counter()
       tinygrad_out = tinygrad_out.numpy()
-      et = time.monotonic()
+      et = time.perf_counter()
       print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
 
     import cProfile
@@ -80,15 +80,15 @@ class TestOnnxModel(unittest.TestCase):
     }
     inputs = {k:v.astype(np.float32) for k,v in inputs.items()}
 
-    st = time.monotonic()
+    st = time.perf_counter()
     print("****** run onnx ******")
     tinygrad_out = run_onnx(inputs)['outputs']
-    mt = time.monotonic()
+    mt = time.perf_counter()
     print("****** realize ******")
     tinygrad_out.realize()
-    mt2 = time.monotonic()
+    mt2 = time.perf_counter()
     tinygrad_out = tinygrad_out.numpy()
-    et = time.monotonic()
+    et = time.perf_counter()
     print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
 
     Tensor.no_grad = True

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -41,14 +41,14 @@ class TestOnnxModel(unittest.TestCase):
 
     for _ in range(7):
       inputs = get_inputs()
-      st = time.perf_counter()
+      st = time.perf_counter_ns()
       tinygrad_out = run_onnx(inputs)['outputs']
-      mt = time.perf_counter()
+      mt = time.perf_counter_ns()
       tinygrad_out.realize()
-      mt2 = time.perf_counter()
+      mt2 = time.perf_counter_ns()
       tinygrad_out = tinygrad_out.numpy()
-      et = time.perf_counter()
-      print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
+      et = time.perf_counter_ns()
+      print(f"ran openpilot model in {(et-st)*1e-6:.2f} ms, waited {(mt2-mt)*1e-6:.2f} ms for realize, {(et-mt2)*1e-6:.2f} ms for GPU queue")
 
     import cProfile
     import pstats
@@ -80,16 +80,16 @@ class TestOnnxModel(unittest.TestCase):
     }
     inputs = {k:v.astype(np.float32) for k,v in inputs.items()}
 
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     print("****** run onnx ******")
     tinygrad_out = run_onnx(inputs)['outputs']
-    mt = time.perf_counter()
+    mt = time.perf_counter_ns()
     print("****** realize ******")
     tinygrad_out.realize()
-    mt2 = time.perf_counter()
+    mt2 = time.perf_counter_ns()
     tinygrad_out = tinygrad_out.numpy()
-    et = time.perf_counter()
-    print(f"ran openpilot model in {(et-st)*1000.0:.2f} ms, waited {(mt2-mt)*1000.0:.2f} ms for realize, {(et-mt2)*1000.0:.2f} ms for GPU queue")
+    et = time.perf_counter_ns()
+    print(f"ran openpilot model in {(et-st)*1e-6:.2f} ms, waited {(mt2-mt)*1e-6:.2f} ms for realize, {(et-mt2)*1e-6:.2f} ms for GPU queue")
 
     Tensor.no_grad = True
     torch_out = run_onnx_torch(onnx_model, inputs).numpy()

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -17,13 +17,13 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
 
   tst = [Tensor(x.detach().numpy(), requires_grad=not FORWARD_ONLY) for x in ts]
 
-  st = time.monotonic()
+  st = time.perf_counter()
   out = torch_fxn(*ts)
-  torch_fp = time.monotonic() - st
+  torch_fp = time.perf_counter() - st
 
-  st = time.monotonic()
+  st = time.perf_counter()
   ret = tinygrad_fxn(*tst).realize()
-  tinygrad_fp = time.monotonic() - st
+  tinygrad_fp = time.perf_counter() - st
 
   def compare(s, x,y,atol,rtol):
     if y.shape != tuple(): assert x.shape == y.shape, f"shape mismatch {x.shape} != {y.shape}"
@@ -36,14 +36,14 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
 
   torch_fbp, tinygrad_fbp = np.nan, np.nan
   if not forward_only and not FORWARD_ONLY:
-    st = time.monotonic()
+    st = time.perf_counter()
     out.square().mean().backward()
-    torch_fbp = time.monotonic() - st
+    torch_fbp = time.perf_counter() - st
 
-    st = time.monotonic()
+    st = time.perf_counter()
     ret.square().mean().backward()
     for tt in tst: tt.grad.realize()
-    tinygrad_fbp = time.monotonic() - st
+    tinygrad_fbp = time.perf_counter() - st
 
     for i, (t, tt) in enumerate(zip(ts, tst)):
       compare(f"backward pass tensor {i}", tt.grad.numpy(), t.grad.detach().numpy(), atol=grad_atol, rtol=grad_rtol)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -17,13 +17,13 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
 
   tst = [Tensor(x.detach().numpy(), requires_grad=not FORWARD_ONLY) for x in ts]
 
-  st = time.perf_counter()
+  st = time.perf_counter_ns()
   out = torch_fxn(*ts)
-  torch_fp = time.perf_counter() - st
+  torch_fp = time.perf_counter_ns() - st
 
-  st = time.perf_counter()
+  st = time.perf_counter_ns()
   ret = tinygrad_fxn(*tst).realize()
-  tinygrad_fp = time.perf_counter() - st
+  tinygrad_fp = time.perf_counter_ns() - st
 
   def compare(s, x,y,atol,rtol):
     if y.shape != tuple(): assert x.shape == y.shape, f"shape mismatch {x.shape} != {y.shape}"
@@ -36,19 +36,19 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
 
   torch_fbp, tinygrad_fbp = np.nan, np.nan
   if not forward_only and not FORWARD_ONLY:
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     out.square().mean().backward()
-    torch_fbp = time.perf_counter() - st
+    torch_fbp = time.perf_counter_ns() - st
 
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     ret.square().mean().backward()
     for tt in tst: tt.grad.realize()
-    tinygrad_fbp = time.perf_counter() - st
+    tinygrad_fbp = time.perf_counter_ns() - st
 
     for i, (t, tt) in enumerate(zip(ts, tst)):
       compare(f"backward pass tensor {i}", tt.grad.numpy(), t.grad.detach().numpy(), atol=grad_atol, rtol=grad_rtol)
 
-  print("\ntesting %40r   torch/tinygrad fp: %.2f / %.2f ms  bp: %.2f / %.2f ms " % (shps, torch_fp*1000, tinygrad_fp*1000, torch_fbp*1000, tinygrad_fbp*1000), end="")
+  print("\ntesting %40r   torch/tinygrad fp: %.2f / %.2f ms  bp: %.2f / %.2f ms " % (shps, torch_fp*1e-6, tinygrad_fp*1e-6, torch_fbp*1e-6, tinygrad_fbp*1e-6), end="")
 
 class TestOps(unittest.TestCase):
   def test_zeros(self):

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -45,12 +45,12 @@ def helper_test_speed(f1, *args):
     GlobalCounters.global_ops = 0
     GlobalCounters.global_mem = 0
     if DEBUG >= 4: print("benchmark start")
-    st = time.monotonic()
+    st = time.perf_counter()
     ret = f1(*args)
     # not ideal, it's copying (sometimes). why is this so slow in tinygrad?
     if isinstance(ret, Tensor) or str(torch_device) == "cpu": ret.numpy()
     else: ret.cpu().numpy()
-    et = (time.monotonic() - st) * 1000
+    et = (time.perf_counter() - st) * 1000
     ets.append(et)
     if DEBUG >= 4: print("benchmark stop")
     if GlobalCounters.global_ops:

--- a/test/test_speed_v_torch.py
+++ b/test/test_speed_v_torch.py
@@ -45,12 +45,12 @@ def helper_test_speed(f1, *args):
     GlobalCounters.global_ops = 0
     GlobalCounters.global_mem = 0
     if DEBUG >= 4: print("benchmark start")
-    st = time.perf_counter()
+    st = time.perf_counter_ns()
     ret = f1(*args)
     # not ideal, it's copying (sometimes). why is this so slow in tinygrad?
     if isinstance(ret, Tensor) or str(torch_device) == "cpu": ret.numpy()
     else: ret.cpu().numpy()
-    et = (time.perf_counter() - st) * 1000
+    et = (time.perf_counter_ns() - st) * 1e-6
     ets.append(et)
     if DEBUG >= 4: print("benchmark stop")
     if GlobalCounters.global_ops:

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -22,9 +22,9 @@ class ClangProgram:
     self.lib = ctypes.CDLL(fn)
     self.fxn = self.lib[name]
   def __call__(self, *args, wait=False):
-    if wait: st = time.monotonic()
+    if wait: st = time.perf_counter()
     self.fxn(*[x._buf for x in args[2:]])
-    if wait: return time.monotonic()-st
+    if wait: return time.perf_counter()-st
 
 class ClangCodegen(GPUCodegen):
   lang = GPULanguage(buffer_suffix="restrict")

--- a/tinygrad/runtime/ops_llvm.py
+++ b/tinygrad/runtime/ops_llvm.py
@@ -58,9 +58,9 @@ class LLVMProgram:
 
   def __call__(self, unused_global_size, unused_local_size, *bufs, wait=False):
     cfunc = CFUNCTYPE(ctypes.c_int, *[ctypes.POINTER(ctypes.c_float) for _ in bufs])(self.fxn)
-    if wait: st = time.monotonic()
+    if wait: st = time.perf_counter()
     cfunc(*[x._buf for x in bufs])
-    if wait: return time.monotonic()-st
+    if wait: return time.perf_counter()-st
 
 class LLVMBuffer(CompiledBuffer):
   raw_buffer_type, codegen_type, runtime_type = RawMallocBuffer, LLVMCodegen, LLVMProgram


### PR DESCRIPTION
This fixes windows getting zero time for really fast runs.
```
total runtime: 5.66 ms   wall time: 0.00 ms
```

Ref: https://www.webucator.com/article/python-clocks-explained/

Also switched all code to `perf_counter_ns` nanoseconds besides `ops_clang.py` and `ops_llvm.py` as I am not sure were they are all called from.
