### PR TITLE
Fix assignment test failure with OPTLOCAL=1 option enabled

### DIFF
--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -119,7 +119,8 @@ class ASTRunner:
     MAX_WORKGROUP = self.clprg.max_work_group_size() if hasattr(self.clprg, 'max_work_group_size') else 1024
     local_dims = [[x for x in set([sz, 1, 2, 4, 8, 16, 32, 64, 128, 256, MAX_WORKGROUP]) if x<=sz] for sz in self.global_size]
     local_sizes = [list(x) for x in itertools.product(*local_dims) if prod(x) <= MAX_WORKGROUP] * 2  # try each valid size twice
-    return min([(self.timeit(bufs, local_size), local_size) for local_size in random.sample(local_sizes, len(local_sizes))])[1]
+    tmp_bufs = [b.fromCPU(b.toCPU()) for b in bufs]
+    return min([(self.timeit(tmp_bufs, local_size), local_size) for local_size in random.sample(local_sizes, len(local_sizes))])[1]
   def lower(self, bufs) -> List[RawBuffer]: return [x.raw() for i,x in enumerate(bufs) if x is not None and i not in self.bufs_to_delete]
   def __call__(self, bufs):
     if getenv("OPTLOCAL") and self.global_size is not None and self.local_size is None: self.local_size = self.optimize_local_size(bufs)


### PR DESCRIPTION
```
alex@Alexs-Air tinygrad % OPTLOCAL=1 GPU=1 python3 test/test_assign.py TestAssign.test_simple_assignment
cuda backend not available No module named 'pycuda'
F
======================================================================
FAIL: test_simple_assignment (__main__.TestAssign)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/alex/tinygrad/test/test_assign.py", line 23, in test_simple_assignment
    np.testing.assert_allclose(a.numpy(), (np.arange(N*N)*2).reshape((N,N)))
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 1527, in assert_allclose
    assert_array_compare(compare, actual, desired, err_msg=str(err_msg),
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/numpy/testing/_private/utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)
AssertionError:
Not equal to tolerance rtol=1e-07, atol=0

Mismatched elements: 39999 / 40000 (100%)
Max absolute difference: 559986.
Max relative difference: 7.
 x: array([[0.00000e+00, 1.60000e+01, 3.20000e+01, ..., 3.15200e+03,
        3.16800e+03, 3.18400e+03],
       [3.20000e+03, 3.21600e+03, 3.23200e+03, ..., 6.35200e+03,...
 y: array([[    0,     2,     4, ...,   394,   396,   398],
       [  400,   402,   404, ...,   794,   796,   798],
       [  800,   802,   804, ...,  1194,  1196,  1198],...

----------------------------------------------------------------------
Ran 1 test in 0.056s

FAILED (failures=1)

```
### Root cause
ASTRunner.optimize_local_size utilizes real bufs for optimal local size finding tests, while for inplace Tensor operator like a += b, these tests will change the target buffer (buf a) permanently.
### The fix
Use tmp bufs for optimal local size finding tests.
### Limitation
toCPU and fromCPU will lead to redundant mem copy, allocating new bufs will be better.