### PR TITLE
fix mypy compile shape file not found

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-mypyc --check-untyped-defs --explicit-package-bases --warn-unreachable tinygrad/shape/__init__.py tinygrad/shape/symbolic.py \
+mypyc --check-untyped-defs --explicit-package-bases --warn-unreachable tinygrad/shape/shapetracker.py tinygrad/shape/symbolic.py \
   tinygrad/nn/__init__.py tinygrad/helpers.py tinygrad/mlops.py tinygrad/tensor.py tinygrad/graph.py \
   #tinygrad/codegen/ast.py tinygrad/codegen/gpu.py tinygrad/ops.py tinygrad/runtime/ops_metal.py
   #tinygrad/runtime/ops_metal.py tinygrad/shape/__init__.py tinygrad/ops.py tinygrad/codegen/ast.py \


### PR DESCRIPTION
fix `compile.sh`   
`mypy: can't read file 'tinygrad/shape/__init__.py': No such file or directory ` error
it was moved to shapetracker.py in https://github.com/geohot/tinygrad/commit/01f39b19dcde3a0ebb701ee405e746146fef90e6