### PR TITLE
add int64 as supported dtype from numpy

### DIFF
--- a/examples/transformer.py
+++ b/examples/transformer.py
@@ -14,7 +14,7 @@ def make_dataset():
       s = i+j
       ds.append([i//10, i%10, j//10, j%10, s//100, (s//10)%10, s%10])
   random.shuffle(ds)
-  ds = np.array(ds)
+  ds = np.array(ds).astype(np.float32)
   ds_X = ds[:, 0:6]
   ds_Y = np.copy(ds[:, 1:])
   ds_X_train, ds_X_test = ds_X[0:8000], ds_X[8000:]

--- a/extra/training.py
+++ b/extra/training.py
@@ -5,7 +5,7 @@ from tinygrad.helpers import getenv
 
 def sparse_categorical_crossentropy(out, Y):
   num_classes = out.shape[-1]
-  YY = Y.flatten()
+  YY = Y.flatten().astype(np.int32)
   y = np.zeros((YY.shape[0], num_classes), np.float32)
   # correct loss for NLL, torch NLL loss returns one per row
   y[range(y.shape[0]),YY] = -1.0*num_classes

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -37,6 +37,5 @@ class LazyNumpyArray:
 class dtypes:
   float16: Final[DType] = DType(2, "half", np.float16)
   float32: Final[DType] = DType(4, "float", np.float32)
-  int64: Final[DType] = DType(8, "int64", np.int64)
   @staticmethod
-  def from_np(x:Union[LazyNumpyArray, np.ndarray]) -> DType: return {np.dtype(np.float16): dtypes.float16, np.dtype(np.float32): dtypes.float32, np.dtype(np.int64): dtypes.int64}[np.dtype(x.dtype)]
+  def from_np(x:Union[LazyNumpyArray, np.ndarray]) -> DType: return {np.dtype(np.float16): dtypes.float16, np.dtype(np.float32): dtypes.float32}[np.dtype(x.dtype)]

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -37,5 +37,6 @@ class LazyNumpyArray:
 class dtypes:
   float16: Final[DType] = DType(2, "half", np.float16)
   float32: Final[DType] = DType(4, "float", np.float32)
+  int64: Final[DType] = DType(8, "int64", np.int64)
   @staticmethod
-  def from_np(x:Union[LazyNumpyArray, np.ndarray]) -> DType: return {np.dtype(np.float16): dtypes.float16, np.dtype(np.float32): dtypes.float32}[np.dtype(x.dtype)]
+  def from_np(x:Union[LazyNumpyArray, np.ndarray]) -> DType: return {np.dtype(np.float16): dtypes.float16, np.dtype(np.float32): dtypes.float32, np.dtype(np.int64): dtypes.int64}[np.dtype(x.dtype)]


### PR DESCRIPTION
Without this, examples/transformer.py didn't run. With this change it runs successfully.