### PR TITLE
Permute examples

### DIFF
--- a/examples/yolo/waifu2x.py
+++ b/examples/yolo/waifu2x.py
@@ -72,7 +72,7 @@ class Conv3x3Biased:
     # Not outChannel,inChannel,Y,X.
     # Therefore, transpose it before assignment.
     # I have long since forgotten how I worked this out.
-    self.weight.assign(Tensor(layer["weight"]).reshape(shape=self.weight.shape).transpose(order=(0, 1, 3, 2)))
+    self.weight.assign(Tensor(layer["weight"]).reshape(shape=self.weight.shape).permute((0, 1, 3, 2))
     self.bias.assign(Tensor(layer["bias"]).reshape(shape=self.bias.shape))
 
 class Vgg7:

--- a/examples/yolo/waifu2x.py
+++ b/examples/yolo/waifu2x.py
@@ -72,7 +72,7 @@ class Conv3x3Biased:
     # Not outChannel,inChannel,Y,X.
     # Therefore, transpose it before assignment.
     # I have long since forgotten how I worked this out.
-    self.weight.assign(Tensor(layer["weight"]).reshape(shape=self.weight.shape).permute((0, 1, 3, 2))
+    self.weight.assign(Tensor(layer["weight"]).reshape(shape=self.weight.shape).transpose(2, 3))
     self.bias.assign(Tensor(layer["bias"]).reshape(shape=self.bias.shape))
 
 class Vgg7:

--- a/examples/yolov3.py
+++ b/examples/yolov3.py
@@ -174,8 +174,7 @@ def predict_transform(prediction, inp_dim, anchors, num_classes):
   bbox_attrs = 5 + num_classes
   num_anchors = len(anchors)
   prediction = prediction.reshape(shape=(batch_size, bbox_attrs*num_anchors, grid_size*grid_size))
-  # Original PyTorch: transpose(1, 2) -> For some reason numpy.transpose order has to be reversed?
-  prediction = prediction.permute((0,2,1))
+  prediction = prediction.transpose(1, 2)
   prediction = prediction.reshape(shape=(batch_size, grid_size*grid_size*num_anchors, bbox_attrs))
   prediction_cpu = prediction.cpu().numpy()
   for i in (0, 1, 4):

--- a/examples/yolov3.py
+++ b/examples/yolov3.py
@@ -175,7 +175,7 @@ def predict_transform(prediction, inp_dim, anchors, num_classes):
   num_anchors = len(anchors)
   prediction = prediction.reshape(shape=(batch_size, bbox_attrs*num_anchors, grid_size*grid_size))
   # Original PyTorch: transpose(1, 2) -> For some reason numpy.transpose order has to be reversed?
-  prediction = prediction.transpose(order=(0,2,1))
+  prediction = prediction.permute((0,2,1))
   prediction = prediction.reshape(shape=(batch_size, grid_size*grid_size*num_anchors, bbox_attrs))
   prediction_cpu = prediction.cpu().numpy()
   for i in (0, 1, 4):


### PR DESCRIPTION
Got an error while I was running yolov3. Looks like the implementation of transpose has been changed to match PyTorch now. So I've updated the parameters for transpose in the examples.
```
% GPU=1 python3 examples/yolov3.py                                                       [13/181]
Modules length: 107                                                                                                    
Loading weights file (237MB). This might take a while…                                                                 
running inference…                                                                                                     
Traceback (most recent call last):                                                                                     
  File "/Users/jacky/fun/tinygrad/examples/yolov3.py", line 402, in <module>                                           
    prediction = infer(model, img)                                                                                     
  File "/Users/jacky/fun/tinygrad/examples/yolov3.py", line 146, in infer                                              
    prediction = model.forward(Tensor(img.astype(np.float32)))                                                         
  File "/Users/jacky/fun/tinygrad/examples/yolov3.py", line 364, in forward                                            
    x = predict_transform(x, inp_dim, anchors, num_classes)                                                            
  File "/Users/jacky/fun/tinygrad/examples/yolov3.py", line 178, in predict_transform                                  
    prediction = prediction.transpose(order=(0,2,1))                                                                   
TypeError: Tensor.transpose() got an unexpected keyword argument 'order' 
```