### PR TITLE
padding changes for onnx

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -46,7 +46,7 @@ def get_run_onnx(onnx_model):
   def attribute_parse(a):
     if a.type in [6,7]: return tuple([int(x) for x in a.ints])
     elif a.type == 4: return buffer_parse(a.t)  # TENSOR
-    elif a.type == 3: return str(a.s)
+    elif a.type == 3: return a.s.decode("utf-8")
     elif a.type == 2: return int(a.i)
     elif a.type == 1: return float(a.f)
     else: raise Exception(f"can't parse {a.type} {a}")

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass, asdict
 import os, math, functools
 import numpy as np
 from typing import Tuple, Union, List, NamedTuple, Final, Iterator, ClassVar, Optional, Callable, Any
@@ -46,12 +47,16 @@ class LazyNumpyArray:
   def copy(self): return self if callable(self.fxn) else LazyNumpyArray(self.fxn.copy(), self.shape, self.dtype)
   def astype(self, typ): return LazyNumpyArray(self.fxn, self.shape, typ)
 
+
+@dataclass
 class dtypes:
   float16: Final[DType] = DType(0, 2, "half", np.float16)
   float32: Final[DType] = DType(1, 4, "float", np.float32)
   int32: Final[DType] = DType(1, 4, "int", np.int32)
+  int64: Final[DType] = DType(2, 8, "int64", np.int64)
   @staticmethod
-  def from_np(x) -> DType: return {np.dtype(np.float16): dtypes.float16, np.dtype(np.float32): dtypes.float32, np.dtype(np.int32): dtypes.int32}[np.dtype(x)]
+  def from_np(x) -> DType: return asdict(dtypes())[np.dtype(x).name]
+
 
 class GlobalCounters:
   global_ops: ClassVar[int] = 0


### PR DESCRIPTION
Original goal was to add support for `Pad` operator of onnx.

tests for constant padding pass. overall test report: `436 failed, 297 passed` to `405 failed, 328 passed`.

i had to add int64 to dtypes, because onnx tests for constant padding directly call run_onnx with int64 ndarrays.

nd padding with non zero constants is now possible