### PR TITLE
Do not specify errors when trying to load devices.

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -292,6 +292,6 @@ class _Device:
     for device in ["METAL", "CUDA", "GPU"]:
       try:
         if self[device]: return device
-      except ImportError: pass
+      except Exception: pass
     return "CPU"
 Device = _Device()


### PR DESCRIPTION
The `ImportError` does not catch some errors from `pyopencl`, e.g.:
`pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR`.
Thus it may be more appropriate to use a trivial `Exception`.