### PR TITLE
Fix train_resnet example

### DIFF
--- a/examples/train_resnet.py
+++ b/examples/train_resnet.py
@@ -2,7 +2,7 @@
 import numpy as np
 from PIL import Image
 
-from tinygrad.nn.optim import Adam, get_parameters
+from tinygrad.nn import optim
 from tinygrad.helpers import getenv
 from extra.training import train, evaluate
 from models.resnet import ResNet
@@ -29,16 +29,16 @@ if __name__ == "__main__":
   if TRANSFER:
     model.load_from_pretrained()
 
-  lr = 5e-5
   transform = ComposeTransforms([
     lambda x: [Image.fromarray(xx, mode='L').resize((64, 64)) for xx in x],
     lambda x: np.stack([np.asarray(xx) for xx in x], 0),
     lambda x: x / 255.0,
     lambda x: np.tile(np.expand_dims(x, 1), (1, 3, 1, 1)).astype(np.float32),
   ])
+  lr = 0.005
   for _ in range(10):
-    optim = Adam(get_parameters(model), lr=lr)
-    train(model, X_train, Y_train, optim, 50, BS=32, transform=transform)
-    acc, Y_test_preds = evaluate(model, X_test, Y_test, num_classes=10, return_predict=True, transform=transform)
+    optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.9)
+    train(model, X_train, Y_train, optimizer, 100, BS=32, transform=transform)
+    evaluate(model, X_test, Y_test, num_classes=classes, transform=transform)
     lr /= 1.2
     print(f'reducing lr to {lr:.7f}')

--- a/examples/train_resnet.py
+++ b/examples/train_resnet.py
@@ -29,13 +29,13 @@ if __name__ == "__main__":
   if TRANSFER:
     model.load_from_pretrained()
 
+  lr = 5e-3
   transform = ComposeTransforms([
     lambda x: [Image.fromarray(xx, mode='L').resize((64, 64)) for xx in x],
     lambda x: np.stack([np.asarray(xx) for xx in x], 0),
     lambda x: x / 255.0,
     lambda x: np.tile(np.expand_dims(x, 1), (1, 3, 1, 1)).astype(np.float32),
   ])
-  lr = 0.005
   for _ in range(10):
     optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.9)
     train(model, X_train, Y_train, optimizer, 100, BS=32, transform=transform)

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -80,7 +80,7 @@ class ResNet:
     self.layer2 = self._make_layer(self.block, 128, self.num_blocks[1], stride=2)
     self.layer3 = self._make_layer(self.block, 256, self.num_blocks[2], stride=2)
     self.layer4 = self._make_layer(self.block, 512, self.num_blocks[3], stride=2)
-    self.fc = {"weight": Tensor.uniform(512 * self.block.expansion, num_classes), "bias": Tensor.zeros(num_classes)}
+    self.fc = {"weight": Tensor.scaled_uniform(512 * self.block.expansion, num_classes), "bias": Tensor.zeros(num_classes)}
 
   def _make_layer(self, block, planes, num_blocks, stride):
     strides = [stride] + [1] * (num_blocks-1)


### PR DESCRIPTION
Changes made:

- use `scaled_uniform` instead of `uniform`
- use SGD instead of Adam for higher test accuracy
- increase the number of steps per iteration from 50 to 100

This gives us a test accuracy of around 95%