### PR TITLE
Fixed two errors when running LLaMA example with CUDA=1

### DIFF
--- a/tinygrad/codegen/cstyle.py
+++ b/tinygrad/codegen/cstyle.py
@@ -116,6 +116,8 @@ def uops_to_cstyle(uops:List[UOp], bufs:List[Union[LocalBuffer,LazyBuffer]], lan
       assert newvar is not None
       if args == -math.inf:
         kk(f"{newvar.render(True)} = -INFINITY;")
+      elif newvar.ltype == LocalTypes.float4:
+        kk(f"{newvar.render(True)} = {{ {args}f, {args}f, {args}f, {args}f }};")
       else:
         kk(f"{newvar.render(True)} = {args}f;")
     elif uop == UOps.ALU:

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -32,7 +32,7 @@ class CUDAProgram:
     if wait:
       start, end = cuda.Event(), cuda.Event()
       start.record()
-    self.prg(*[x._cl for x in args], block=tuple(local_size), grid=tuple(global_size))
+    self.prg(*[x._buf for x in args], block=tuple(local_size), grid=tuple(global_size))
     if wait:
       end.record()
       end.synchronize()


### PR DESCRIPTION
Running `CUDA=1 python3 examples/llama.py --timing --prompt "Hello." --temperature=0 --tinyfake --count 1` gave errors:
```
kernel.cu(5): error: no suitable constructor exists to convert from "float" to "float4"
    float4 acc0_0 = 0.0f;
```
and
```
AttributeError: 'RawCUDABuffer' object has no attribute '_cl'
```
I know you don't like extra lines, but these two changes fixed the issues.