### PR TITLE
HIP backend

### DIFF
--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -441,22 +441,6 @@ def hipGetDeviceProperties(deviceId: int):
   return device_properties
 
 
-# Memory types:
-hipMemoryTypeHost = 1
-hipMemoryTypeDevice = 2
-hipMemoryTypeArray = 3
-hipMemoryTypeUnified = 4  # Not used currently
-
-
-class hipPointerAttributes(ctypes.Structure):
-  _fields_ = [
-    ('memoryType', ctypes.c_int),
-    ('device', ctypes.c_int),
-    ('devicePointer', ctypes.c_void_p),
-    ('hostPointer', ctypes.c_void_p)
-  ]
-
-
 _libhip.hipModuleLoadData.restype = int
 _libhip.hipModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p),  # Module
                                       ctypes.c_void_p]                 # Image

--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -1,0 +1,612 @@
+import ctypes
+import sys
+
+try:
+  _libhip = ctypes.cdll.LoadLibrary('libamdhip64.so')
+except:
+  raise OSError('cant find libamdhip64.so.')
+
+try:
+  _libhiprtc = ctypes.cdll.LoadLibrary('libhiprtc.so')
+except:
+  raise OSError('cant find libhiprtc.so.')
+
+def POINTER(obj):
+  p = ctypes.POINTER(obj)
+  if not isinstance(p.from_param, classmethod):
+    def from_param(cls, x):
+      if x is None:
+        return cls()
+      else:
+        return x
+    p.from_param = classmethod(from_param)
+  return p
+
+
+def hipCheckStatus(status):
+  if status != 0:
+    raise RuntimeError('HIP error %s' % status)
+
+_libhip.hipDeviceSynchronize.restype = int
+_libhip.hipDeviceSynchronize.argtypes = []
+
+
+def hipDeviceSynchronize():
+  status = _libhip.hipDeviceSynchronize()
+  hipCheckStatus(status)
+
+
+_libhip.hipEventCreate.restype = int
+_libhip.hipEventCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+
+
+def hipEventCreate():
+  ptr = ctypes.c_void_p()
+  status = _libhip.hipEventCreate(ctypes.byref(ptr))
+  hipCheckStatus(status)
+  return ptr
+
+
+_libhip.hipEventRecord.restype = int
+_libhip.hipEventRecord.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+
+def hipEventRecord(event, stream=None):
+  status = _libhip.hipEventRecord(event, stream)
+  hipCheckStatus(status)
+
+
+_libhip.hipEventDestroy.restype = int
+_libhip.hipEventDestroy.argtypes = [ctypes.c_void_p]
+
+
+def hipEventDestroy(event):
+  status = _libhip.hipEventDestroy(event)
+  hipCheckStatus(status)
+
+
+_libhip.hipEventSynchronize.restype = int
+_libhip.hipEventSynchronize.argtypes = [ctypes.c_void_p]
+
+
+def hipEventSynchronize(event):
+  status = _libhip.hipEventSynchronize(event)
+  hipCheckStatus(status)
+
+
+_libhip.hipEventElapsedTime.restype = int
+_libhip.hipEventElapsedTime.argtypes = [ctypes.POINTER(
+    ctypes.c_float), ctypes.c_void_p, ctypes.c_void_p]
+
+
+def hipEventElapsedTime(start, stop):
+  t = ctypes.c_float()
+  status = _libhip.hipEventElapsedTime(ctypes.byref(t), start, stop)
+  hipCheckStatus(status)
+  return t.value
+
+
+_libhip.hipMalloc.restype = int
+_libhip.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p),
+                              ctypes.c_size_t]
+
+
+def hipMalloc(count, ctype=None):
+  ptr = ctypes.c_void_p()
+  status = _libhip.hipMalloc(ctypes.byref(ptr), count)
+  hipCheckStatus(status)
+  if ctype is not None:
+    ptr = ctypes.cast(ptr, ctypes.POINTER(ctype))
+  return ptr
+
+
+_libhip.hipFree.restype = int
+_libhip.hipFree.argtypes = [ctypes.c_void_p]
+
+
+def hipFree(ptr):
+  status = _libhip.hipFree(ptr)
+  hipCheckStatus(status)
+
+
+# Memory copy modes:
+hipMemcpyHostToHost = 0
+hipMemcpyHostToDevice = 1
+hipMemcpyDeviceToHost = 2
+hipMemcpyDeviceToDevice = 3
+hipMemcpyDefault = 4
+
+_libhip.hipMemcpy.restype = int
+_libhip.hipMemcpy.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+
+
+def hipMemcpy_htod(dst, src, count):
+  status = _libhip.hipMemcpy(dst, src, ctypes.c_size_t(count), hipMemcpyHostToDevice)
+  hipCheckStatus(status)
+
+
+def hipMemcpy_dtoh(dst, src, count):
+  status = _libhip.hipMemcpy(dst, src, ctypes.c_size_t(count), hipMemcpyDeviceToHost)
+  hipCheckStatus(status)
+
+
+_libhip.hipMemcpyAsync.restype = int
+_libhip.hipMemcpyAsync.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                   ctypes.c_size_t, ctypes.c_int, ctypes.c_void_p]
+
+
+def hipMemcpyAsync_htod(dst, src, count, stream):
+  status = _libhip.hipMemcpyAsync(dst, src, ctypes.c_size_t(count), hipMemcpyHostToDevice, stream)
+  hipCheckStatus(status)
+
+
+def hipMemcpyAsync_dtoh(dst, src, count, stream):
+  status = _libhip.hipMemcpyAsync(dst, src, ctypes.c_size_t(count), hipMemcpyDeviceToHost, stream)
+  hipCheckStatus(status)
+
+
+def hipMemcpyAsync(dst, src, count, direction, stream):
+  status = _libhip.hipMemcpyAsync(dst, src, ctypes.c_size_t(count), direction, stream)
+  hipCheckStatus(status)
+
+
+_libhip.hipMemGetInfo.restype = int
+_libhip.hipMemGetInfo.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+
+def hipMemGetInfo():
+  free = ctypes.c_size_t()
+  total = ctypes.c_size_t()
+  status = _libhip.hipMemGetInfo(ctypes.byref(free), ctypes.byref(total))
+  hipCheckStatus(status)
+  return free.value, total.value
+
+
+_libhip.hipSetDevice.restype = int
+_libhip.hipSetDevice.argtypes = [ctypes.c_int]
+
+
+def hipSetDevice(dev):
+  status = _libhip.hipSetDevice(dev)
+  hipCheckStatus(status)
+
+
+_libhip.hipGetDevice.restype = int
+_libhip.hipGetDevice.argtypes = [ctypes.POINTER(ctypes.c_int)]
+
+
+def hipGetDevice():
+  dev = ctypes.c_int()
+  status = _libhip.hipGetDevice(ctypes.byref(dev))
+  hipCheckStatus(status)
+  return dev.value
+
+
+class hipDeviceArch(ctypes.Structure):
+  _fields_ = [
+    # *32-bit Atomics*
+    # 32-bit integer atomics for global memory.
+    ('hasGlobalInt32Atomics', ctypes.c_uint, 1),
+
+    # 32-bit float atomic exch for global memory.
+    ('hasGlobalFloatAtomicExch', ctypes.c_uint, 1),
+
+    # 32-bit integer atomics for shared memory.
+    ('hasSharedInt32Atomics', ctypes.c_uint, 1),
+
+    # 32-bit float atomic exch for shared memory.
+    ('hasSharedFloatAtomicExch', ctypes.c_uint, 1),
+
+    # 32-bit float atomic add in global and shared memory.
+    ('hasFloatAtomicAdd', ctypes.c_uint, 1),
+
+    # *64-bit Atomics*
+    # 64-bit integer atomics for global memory.
+    ('hasGlobalInt64Atomics', ctypes.c_uint, 1),
+
+    # 64-bit integer atomics for shared memory.
+    ('hasSharedInt64Atomics', ctypes.c_uint, 1),
+
+    # *Doubles*
+    # Double-precision floating point.
+    ('hasDoubles', ctypes.c_uint, 1),
+
+    # *Warp cross-lane operations*
+    # Warp vote instructions (__any, __all).
+    ('hasWarpVote', ctypes.c_uint, 1),
+
+    # Warp ballot instructions (__ballot).
+    ('hasWarpBallot', ctypes.c_uint, 1),
+
+    # Warp shuffle operations. (__shfl_*).
+    ('hasWarpShuffle', ctypes.c_uint, 1),
+
+    # Funnel two words into one with shift&mask caps.
+    ('hasFunnelShift', ctypes.c_uint, 1),
+
+    # *Sync*
+    # __threadfence_system.
+    ('hasThreadFenceSystem', ctypes.c_uint, 1),
+
+    # __syncthreads_count, syncthreads_and, syncthreads_or.
+    ('hasSyncThreadsExt', ctypes.c_uint, 1),
+
+    # *Misc*
+    # Surface functions.
+    ('hasSurfaceFuncs', ctypes.c_uint, 1),
+
+    # Grid and group dims are 3D (rather than 2D).
+    ('has3dGrid', ctypes.c_uint, 1),
+
+    # Dynamic parallelism.
+    ('hasDynamicParallelism', ctypes.c_uint, 1),
+  ]
+
+
+class hipDeviceProperties(ctypes.Structure):
+  _fields_ = [
+    # Device name
+    ('_name', ctypes.c_char * 256),
+
+    # Size of global memory region (in bytes)
+    ('totalGlobalMem', ctypes.c_size_t),
+
+    # Size of shared memory region (in bytes).
+    ('sharedMemPerBlock', ctypes.c_size_t),
+
+    # Registers per block.
+    ('regsPerBlock', ctypes.c_int),
+
+    # Warp size.
+    ('warpSize', ctypes.c_int),
+
+    # Max work items per work group or workgroup max size.
+    ('maxThreadsPerBlock', ctypes.c_int),
+
+    # Max number of threads in each dimension (XYZ) of a block.
+    ('maxThreadsDim', ctypes.c_int * 3),
+
+    # Max grid dimensions (XYZ).
+    ('maxGridSize', ctypes.c_int * 3),
+
+    # Max clock frequency of the multiProcessors in khz.
+    ('clockRate', ctypes.c_int),
+
+    # Max global memory clock frequency in khz.
+    ('memoryClockRate', ctypes.c_int),
+
+    # Global memory bus width in bits.
+    ('memoryBusWidth', ctypes.c_int),
+
+    # Size of shared memory region (in bytes).
+    ('totalConstMem', ctypes.c_size_t),
+
+    # Major compute capability.  On HCC, this is an approximation and features may
+    # differ from CUDA CC.  See the arch feature flags for portable ways to query
+    # feature caps.
+    ('major', ctypes.c_int),
+
+    # Minor compute capability.  On HCC, this is an approximation and features may
+    # differ from CUDA CC.  See the arch feature flags for portable ways to query
+    # feature caps.
+    ('minor', ctypes.c_int),
+
+    # Number of multi-processors (compute units).
+    ('multiProcessorCount', ctypes.c_int),
+
+    # L2 cache size.
+    ('l2CacheSize', ctypes.c_int),
+
+    # Maximum resident threads per multi-processor.
+    ('maxThreadsPerMultiProcessor', ctypes.c_int),
+
+    # Compute mode.
+    ('computeMode', ctypes.c_int),
+
+    # Frequency in khz of the timer used by the device-side "clock*"
+    # instructions.  New for HIP.
+    ('clockInstructionRate', ctypes.c_int),
+
+    # Architectural feature flags.  New for HIP.
+    ('arch', hipDeviceArch),
+
+    # Device can possibly execute multiple kernels concurrently.
+    ('concurrentKernels', ctypes.c_int),
+
+    # PCI Domain ID
+    ('pciDomainID', ctypes.c_int),
+
+    # PCI Bus ID.
+    ('pciBusID', ctypes.c_int),
+
+    # PCI Device ID.
+    ('pciDeviceID', ctypes.c_int),
+
+    # Maximum Shared Memory Per Multiprocessor.
+    ('maxSharedMemoryPerMultiProcessor', ctypes.c_size_t),
+
+    # 1 if device is on a multi-GPU board, 0 if not.
+    ('isMultiGpuBoard', ctypes.c_int),
+
+    # Check whether HIP can map host memory
+    ('canMapHostMemory', ctypes.c_int),
+
+    # DEPRECATED: use gcnArchName instead
+    ('gcnArch', ctypes.c_int),
+
+    # AMD GCN Arch Name.
+    ('_gcnArchName', ctypes.c_char * 256),
+
+    # APU vs dGPU
+    ('integrated', ctypes.c_int),
+
+    # HIP device supports cooperative launch
+    ('cooperativeLaunch', ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple devices
+    ('cooperativeMultiDeviceLaunch', ctypes.c_int),
+
+    # Maximum size for 1D textures bound to linear memory
+    ('maxTexture1DLinear', ctypes.c_int),
+
+    # Maximum number of elements in 1D images
+    ('maxTexture1D', ctypes.c_int),
+
+    # Maximum dimensions (width, height) of 2D images, in image elements
+    ('maxTexture2D', ctypes.c_int * 2),
+
+    # Maximum dimensions (width, height, depth) of 3D images, in image elements
+    ('maxTexture3D', ctypes.c_int * 3),
+
+    # Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
+    ('hdpMemFlushCntl', POINTER(ctypes.c_uint)),
+
+    # Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
+    ('hdpRegFlushCntl', POINTER(ctypes.c_uint)),
+
+    # Maximum pitch in bytes allowed by memory copies
+    ('memPitch', ctypes.c_size_t),
+
+    # Alignment requirement for textures
+    ('textureAlignment', ctypes.c_size_t),
+
+    # Pitch alignment requirement for texture references bound to pitched memory
+    ('texturePitchAlignment', ctypes.c_size_t),
+
+    # Run time limit for kernels executed on the device
+    ('kernelExecTimeoutEnabled', ctypes.c_int),
+
+    # Device has ECC support enabled
+    ('ECCEnabled', ctypes.c_int),
+
+    # 1:If device is Tesla device using TCC driver, else 0
+    ('tccDriver', ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched functions
+    ('cooperativeMultiDeviceUnmatchedFunc', ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched grid dimensions
+    ('cooperativeMultiDeviceUnmatchedGridDim', ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched block dimensions
+    ('cooperativeMultiDeviceUnmatchedBlockDim', ctypes.c_int),
+
+    # HIP device supports cooperative launch on multiple
+    # devices with unmatched shared memories
+    ('cooperativeMultiDeviceUnmatchedSharedMem', ctypes.c_int),
+
+    # 1: if it is a large PCI bar device, else 0
+    ('isLargeBar', ctypes.c_int),
+
+    # Revision of the GPU in this device
+    ('asicRevision', ctypes.c_int),
+
+    # Device supports allocating managed memory on this system
+    ('managedMemory', ctypes.c_int),
+
+    # Host can directly access managed memory on the device without migration
+    ('directManagedMemAccessFromHost', ctypes.c_int),
+
+    # Device can coherently access managed memory concurrently with the CPU
+    ('concurrentManagedAccess', ctypes.c_int),
+
+    # Device supports coherently accessing pageable memory
+    # without calling hipHostRegister on it
+    ('pageableMemoryAccess', ctypes.c_int),
+
+    # Device accesses pageable memory via the host's page tables
+    ('pageableMemoryAccessUsesHostPageTables', ctypes.c_int),
+  ]
+
+  @property
+  def name(self):
+    return self._name.decode('utf-8')
+
+  @property
+  def gcnArchName(self):
+    return self._gcnArchName.decode('utf-8')
+
+
+_libhip.hipGetDeviceProperties.restype = int
+_libhip.hipGetDeviceProperties.argtypes = [POINTER(hipDeviceProperties), ctypes.c_int]
+
+
+def hipGetDeviceProperties(deviceId: int):
+  device_properties = hipDeviceProperties()
+  status = _libhip.hipGetDeviceProperties(ctypes.pointer(device_properties), deviceId)
+  hipCheckStatus(status)
+  return device_properties
+
+
+# Memory types:
+hipMemoryTypeHost = 1
+hipMemoryTypeDevice = 2
+hipMemoryTypeArray = 3
+hipMemoryTypeUnified = 4  # Not used currently
+
+
+class hipPointerAttributes(ctypes.Structure):
+  _fields_ = [
+    ('memoryType', ctypes.c_int),
+    ('device', ctypes.c_int),
+    ('devicePointer', ctypes.c_void_p),
+    ('hostPointer', ctypes.c_void_p)
+  ]
+
+
+_libhip.hipModuleLoadData.restype = int
+_libhip.hipModuleLoadData.argtypes = [ctypes.POINTER(ctypes.c_void_p),  # Module
+                                      ctypes.c_void_p]                 # Image
+
+
+def hipModuleLoadData(data):
+  module = ctypes.c_void_p()
+  status = _libhip.hipModuleLoadData(ctypes.byref(module), data)
+  hipCheckStatus(status)
+  return module
+
+
+_libhip.hipModuleGetFunction.restype = int
+_libhip.hipModuleGetFunction.argtypes = [ctypes.POINTER(ctypes.c_void_p),  # Kernel
+                                         ctypes.c_void_p,                    # Module
+                                         ctypes.POINTER(ctypes.c_char)]      # kernel name
+
+
+def hipModuleGetFunction(module, func_name):
+  e_func_name = func_name.encode('utf-8')
+  kernel = ctypes.c_void_p()
+  status = _libhip.hipModuleGetFunction(ctypes.byref(kernel), module, e_func_name)
+  hipCheckStatus(status)
+  return kernel
+
+
+_libhip.hipModuleUnload.restype = int
+_libhip.hipModuleUnload.argtypes = [ctypes.c_void_p]
+
+
+def hipModuleUnload(module):
+  status = _libhip.hipModuleUnload(module)
+  hipCheckStatus(status)
+
+
+_libhip.hipModuleLaunchKernel.restype = int
+_libhip.hipModuleLaunchKernel.argtypes = [ctypes.c_void_p,                 # kernel
+                                          ctypes.c_uint,                   # block x
+                                          ctypes.c_uint,                   # block y
+                                          ctypes.c_uint,                   # block z
+                                          ctypes.c_uint,                   # thread x
+                                          ctypes.c_uint,                   # thread y
+                                          ctypes.c_uint,                   # thread z
+                                          ctypes.c_uint,                   # shared mem
+                                          ctypes.c_void_p,                 # stream
+                                          # kernel params
+                                          ctypes.POINTER(ctypes.c_void_p),
+                                          ctypes.POINTER(ctypes.c_void_p)]  # extra
+
+
+def hipModuleLaunchKernel(kernel, bx, by, bz, tx, ty, tz, shared, stream, struct):
+  c_bx = ctypes.c_uint(bx)
+  c_by = ctypes.c_uint(by)
+  c_bz = ctypes.c_uint(bz)
+  c_tx = ctypes.c_uint(tx)
+  c_ty = ctypes.c_uint(ty)
+  c_tz = ctypes.c_uint(tz)
+  c_shared = ctypes.c_uint(shared)
+
+  ctypes.sizeof(struct)
+  hip_launch_param_buffer_ptr = ctypes.c_void_p(1)
+  hip_launch_param_buffer_size = ctypes.c_void_p(2)
+  hip_launch_param_buffer_end = ctypes.c_void_p(0)
+  hip_launch_param_buffer_end = ctypes.c_void_p(3)
+  size = ctypes.c_size_t(ctypes.sizeof(struct))
+  p_size = ctypes.c_void_p(ctypes.addressof(size))
+  p_struct = ctypes.c_void_p(ctypes.addressof(struct))
+  config = (ctypes.c_void_p * 5)(hip_launch_param_buffer_ptr, p_struct,
+                                 hip_launch_param_buffer_size, p_size, hip_launch_param_buffer_end)
+  nullptr = ctypes.POINTER(ctypes.c_void_p)(ctypes.c_void_p(0))
+
+  status = _libhip.hipModuleLaunchKernel(
+      kernel, c_bx, c_by, c_bz, c_tx, c_ty, c_tz, c_shared, stream, None, config)
+  hipCheckStatus(status)
+
+
+_libhiprtc.hiprtcCreateProgram.restype = int
+_libhiprtc.hiprtcCreateProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p),  # hiprtcProgram
+                                           ctypes.POINTER(
+                                               ctypes.c_char),   # Source
+                                           ctypes.POINTER(
+                                               ctypes.c_char),   # Name
+                                           ctypes.c_int,                    # numberOfHeaders
+                                           ctypes.POINTER(
+                                               ctypes.c_char_p),  # header
+                                           ctypes.POINTER(ctypes.c_char_p)]  # headerNames
+
+
+def hiprtcCreateProgram(source, name, header_names, header_sources):
+  e_source = source.encode('utf-8')
+  e_name = name.encode('utf-8')
+  e_header_names = list()
+  e_header_sources = list()
+  for header_name in header_names:
+    e_header_name = header_name.encode('utf-8')
+    e_header_names.append(e_header_name)
+  for header_source in header_sources:
+    e_header_source = header_source.encode('utf-8')
+    e_header_sources.append(e_header_source)
+
+  prog = ctypes.c_void_p()
+  c_header_names = (ctypes.c_char_p * len(e_header_names))()
+  c_header_names[:] = e_header_names
+  c_header_sources = (ctypes.c_char_p * len(e_header_sources))()
+  c_header_sources[:] = e_header_sources
+  status = _libhiprtc.hiprtcCreateProgram(ctypes.byref(
+    prog), e_source, e_name, len(e_header_names), c_header_sources, c_header_names)
+  hipCheckStatus(status)
+  return prog
+
+
+_libhiprtc.hiprtcDestroyProgram.restype = int
+_libhiprtc.hiprtcDestroyProgram.argtypes = [ctypes.POINTER(ctypes.c_void_p)]  # hiprtcProgram
+
+
+def hiprtcDestroyProgram(prog):
+  status = _libhiprtc.hiprtcDestroyProgram(ctypes.byref(prog))
+  hipCheckStatus(status)
+
+
+_libhiprtc.hiprtcCompileProgram.restype = int
+_libhiprtc.hiprtcCompileProgram.argtypes = [ctypes.c_void_p,                 # hiprtcProgram
+                                            ctypes.c_int,                    # num of options
+                                            ctypes.POINTER(ctypes.c_char_p)]  # options
+
+
+def hiprtcCompileProgram(prog, options):
+  e_options = list()
+  for option in options:
+    e_options.append(option.encode('utf-8'))
+  c_options = (ctypes.c_char_p * len(e_options))()
+  c_options[:] = e_options
+  status = _libhiprtc.hiprtcCompileProgram(prog, len(c_options), c_options)
+  hipCheckStatus(status)
+
+
+_libhiprtc.hiprtcGetCodeSize.restype = int
+_libhiprtc.hiprtcGetCodeSize.argtypes = [ctypes.c_void_p,                 # hiprtcProgram
+                                         ctypes.POINTER(ctypes.c_size_t)]  # Size of log
+_libhiprtc.hiprtcGetCode.restype = int
+_libhiprtc.hiprtcGetCode.argtypes = [ctypes.c_void_p,               # hiprtcProgram
+                                     ctypes.POINTER(ctypes.c_char)]  # log
+
+
+def hiprtcGetCode(prog):
+  code_size = ctypes.c_size_t()
+  status = _libhiprtc.hiprtcGetCodeSize(prog, ctypes.byref(code_size))
+  hipCheckStatus(status)
+  code = "0" * code_size.value
+  e_code = code.encode('utf-8')
+  status = _libhiprtc.hiprtcGetCode(prog, e_code)
+  hipCheckStatus(status)
+  return e_code

--- a/extra/hip_wrapper.py
+++ b/extra/hip_wrapper.py
@@ -11,17 +11,6 @@ try:
 except:
   raise OSError('cant find libhiprtc.so.')
 
-def POINTER(obj):
-  p = ctypes.POINTER(obj)
-  if not isinstance(p.from_param, classmethod):
-    def from_param(cls, x):
-      if x is None:
-        return cls()
-      else:
-        return x
-    p.from_param = classmethod(from_param)
-  return p
-
 
 def hipCheckStatus(status):
   if status != 0:
@@ -91,12 +80,10 @@ _libhip.hipMalloc.argtypes = [ctypes.POINTER(ctypes.c_void_p),
                               ctypes.c_size_t]
 
 
-def hipMalloc(count, ctype=None):
+def hipMalloc(count):
   ptr = ctypes.c_void_p()
   status = _libhip.hipMalloc(ctypes.byref(ptr), count)
   hipCheckStatus(status)
-  if ctype is not None:
-    ptr = ctypes.cast(ptr, ctypes.POINTER(ctype))
   return ptr
 
 
@@ -359,10 +346,10 @@ class hipDeviceProperties(ctypes.Structure):
     ('maxTexture3D', ctypes.c_int * 3),
 
     # Addres of HDP_MEM_COHERENCY_FLUSH_CNTL register
-    ('hdpMemFlushCntl', POINTER(ctypes.c_uint)),
+    ('hdpMemFlushCntl', ctypes.POINTER(ctypes.c_uint)),
 
     # Addres of HDP_REG_COHERENCY_FLUSH_CNTL register
-    ('hdpRegFlushCntl', POINTER(ctypes.c_uint)),
+    ('hdpRegFlushCntl', ctypes.POINTER(ctypes.c_uint)),
 
     # Maximum pitch in bytes allowed by memory copies
     ('memPitch', ctypes.c_size_t),
@@ -431,7 +418,7 @@ class hipDeviceProperties(ctypes.Structure):
 
 
 _libhip.hipGetDeviceProperties.restype = int
-_libhip.hipGetDeviceProperties.argtypes = [POINTER(hipDeviceProperties), ctypes.c_int]
+_libhip.hipGetDeviceProperties.argtypes = [ctypes.POINTER(hipDeviceProperties), ctypes.c_int]
 
 
 def hipGetDeviceProperties(deviceId: int):

--- a/tinygrad/jit.py
+++ b/tinygrad/jit.py
@@ -18,7 +18,7 @@ class TinyJit:
   def __get__(self, obj, objtype): return functools.partial(self.__call__, obj)
 
   def __call__(self, *args, **kwargs) -> Any:
-    if Device.DEFAULT not in ["GPU", "CLANG", "METAL", "CUDA"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
+    if Device.DEFAULT not in ["GPU", "CLANG", "METAL", "CUDA", "HIP"]: return self.fxn(*args, **kwargs)  # only jit on the GPU codegen
     # NOTE: this cast is needed since although we know realize will create a ".realized" DeviceBuffer, the type checker doesn't
     input_rawbuffers: Dict[Union[int, str], RawBuffer] = {cast(Union[int, str], k):cast(RawBuffer, v.realize().lazydata.realized) for k,v in itertools.chain(enumerate(args), kwargs.items()) if isinstance(v, Tensor)}
     assert len(input_rawbuffers) != 0, "no inputs to JIT"

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -292,7 +292,7 @@ class _Device:
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def __getitem__(self, x:str) -> Union[Interpreted, Compiled]: return [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._buffers][0]
   def _default_device(self) -> str:
-    for device in ["METAL", "CUDA", "GPU", "HIP"]:
+    for device in ["METAL", "CUDA", "HIP", "GPU"]:
       try:
         if self[device]: return device
       except Exception: pass

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -292,7 +292,7 @@ class _Device:
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def __getitem__(self, x:str) -> Union[Interpreted, Compiled]: return [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._buffers][0]
   def _default_device(self) -> str:
-    for device in ["METAL", "CUDA", "GPU"]:
+    for device in ["METAL", "CUDA", "GPU", "HIP"]:
       try:
         if self[device]: return device
       except Exception: pass

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,6 +1,6 @@
 import numpy as np
 import ctypes
-from pyhip import hip, hiprtc # type: ignore
+import extra.hip_wrapper as hip
 from tinygrad.helpers import DEBUG
 from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawBufferCopyInOut
@@ -19,11 +19,11 @@ class HIPProgram:
   def __init__(self, name:str, prg:str, binary=False):
     try:
       if not binary:
-        prog = hiprtc.hiprtcCreateProgram(prg, name, [], [])
+        prog = hip.hiprtcCreateProgram(prg, name, [], [])
         device_properties = hip.hipGetDeviceProperties(0)
-        hiprtc.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
-        prg = hiprtc.hiprtcGetCode(prog)
-    except hip.hipError as e:
+        hip.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
+        prg = hip.hiprtcGetCode(prog)
+    except Exception as e:
       if DEBUG >= 3: print("FAILED TO BUILD", prg)
       raise e
     if DEBUG >= 5: print(prg)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -8,8 +8,8 @@ from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 
 class RawHIPBuffer(RawBufferCopyInOut):
   def __init__(self, size, dtype):
-    super().__init__(size, dtype, hip.hipMalloc(size * dtype.itemsize))
     self.buf_sz = size * dtype.itemsize
+    super().__init__(size, dtype, hip.hipMalloc(self.buf_sz))
   def _copyin(self, x:np.ndarray): hip.hipMemcpyAsync_htod(self._buf, x.ctypes.data, self.buf_sz, 0)
   def _copyout(self, x:np.ndarray): hip.hipMemcpyAsync_dtoh(x.ctypes.data, self._buf, self.buf_sz, 0)
 
@@ -48,7 +48,7 @@ class HIPProgram:
 class HIPCodegen(CStyleCodegen):
   lang = CStyleLanguage(
     kernel_prefix = "#define INFINITY (__builtin_inff())\nextern \"C\" __global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
-    half_prekernel = "#include <cuda_fp16.h>",
+    half_prekernel = "",
     gid = [f'blockDim.{chr(120+i)}*blockIdx.{chr(120+i)}+threadIdx.{chr(120+i)}' for i in range(3)],
     lid = [f'threadIdx.{chr(120+i)}' for i in range(3)])
 

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -6,6 +6,8 @@ from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawBufferCopyInOut
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 
+# The default HIP stream is used for everything.
+
 class RawHIPBuffer(RawBufferCopyInOut):
   def __init__(self, size, dtype):
     self.buf_sz = size * dtype.itemsize
@@ -52,4 +54,4 @@ class HIPCodegen(CStyleCodegen):
     gid = [f'blockDim.{chr(120+i)}*blockIdx.{chr(120+i)}+threadIdx.{chr(120+i)}' for i in range(3)],
     lid = [f'threadIdx.{chr(120+i)}' for i in range(3)])
 
-HIPBuffer = Compiled(RawHIPBuffer, HIPCodegen, HIPProgram)
+HIPBuffer = Compiled(RawHIPBuffer, HIPCodegen, HIPProgram, hip.hipDeviceSynchronize)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,0 +1,62 @@
+from typing import Optional
+import numpy as np
+import ctypes
+from pyhip import hip, hiprtc # type: ignore
+from tinygrad.helpers import DEBUG
+from tinygrad.ops import Compiled
+from tinygrad.runtime.lib import RawBufferCopyInOut
+from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
+
+class RawHIPBuffer(RawBufferCopyInOut):
+  def __init__(self, size, dtype):
+    super().__init__(size, dtype, hip.hipMalloc(size * dtype.itemsize))
+    self.buf_sz = size * dtype.itemsize
+  def _copyin(self, x:np.ndarray): hip.hipMemcpy_htod(self._buf, x.ctypes.data, self.buf_sz)
+  def _copyout(self, x:np.ndarray): hip.hipMemcpy_dtoh(x.ctypes.data, self._buf, self.buf_sz)
+
+class HIPProgram:
+  def __init__(self, name:str, prg:str, binary=False):
+    try:
+      if not binary:
+        prog = hiprtc.hiprtcCreateProgram(prg, name, [], [])
+        device_properties = hip.hipGetDeviceProperties(0)
+        hiprtc.hiprtcCompileProgram(prog, [f'--offload-arch={device_properties.gcnArchName}'])
+        prg = hiprtc.hiprtcGetCode(prog)
+    except hip.hipError as e:
+      if DEBUG >= 3: print("FAILED TO BUILD", prg)
+      raise e
+    if DEBUG >= 5: print(prg)
+    module = hip.hipModuleLoadData(prg)
+
+    self.prg = hip.hipModuleGetFunction(module, name)
+
+  @staticmethod
+  def numpy_to_ctypes_struct_field(idx, data):
+    assert type(data) == RawHIPBuffer, "Data type error " + str(type(data))
+    return (f'field{idx}', ctypes.c_void_p)
+
+  def __call__(self, global_size, local_size, *args, wait=False):
+    local_size = (local_size + [1] * (3 - len(local_size))) if local_size is not None else (1,1,1)
+    global_size = global_size + [1] * (3 - len(global_size))
+    assert all(x%y == 0 for x,y in zip(global_size, local_size)), f"local:{local_size} must divide global:{global_size}"
+    global_size = [x//y for x,y in zip(global_size, local_size)]
+    if wait:
+      start, end = hip.hipEventCreate(), hip.hipEventCreate()
+      hip.hipEventRecord(start)
+    class PackageStruct(ctypes.Structure):
+      _fields_ = [HIPProgram.numpy_to_ctypes_struct_field(idx, data) for idx, data in enumerate(args)]
+    struct = PackageStruct(*[data._buf for data in args])
+    hip.hipModuleLaunchKernel(self.prg, global_size[0], global_size[1], global_size[2], local_size[0], local_size[1], local_size[2], 0, 0, struct)
+    if wait:
+      hip.hipEventRecord(end)
+      hip.hipEventSynchronize(end)
+      return hip.hipEventElapsedTime(start, end)*1e-3
+
+class HIPCodegen(CStyleCodegen):
+  lang = CStyleLanguage(
+    kernel_prefix = "#define INFINITY (__builtin_inff())\nextern \"C\" __global__", smem_prefix = "__shared__ ", barrier = "__syncthreads();", float4 = "make_float4",
+    half_prekernel = "#include <cuda_fp16.h>",
+    gid = [f'blockDim.{chr(120+i)}*blockIdx.{chr(120+i)}+threadIdx.{chr(120+i)}' for i in range(3)],
+    lid = [f'threadIdx.{chr(120+i)}' for i in range(3)])
+
+HIPBuffer = Compiled(RawHIPBuffer, HIPCodegen, HIPProgram)

--- a/tinygrad/runtime/ops_hip.py
+++ b/tinygrad/runtime/ops_hip.py
@@ -1,4 +1,3 @@
-from typing import Optional
 import numpy as np
 import ctypes
 from pyhip import hip, hiprtc # type: ignore


### PR DESCRIPTION
### How it works
Reply on PyHIP, a thin python wrapper for libamdhip64.so, to access ROCm HIP runtime API.
[https://github.com/jatinx/PyHIP](https://github.com/jatinx/PyHIP)

### How to run
PYTHONPATH=/path/to/PyHIP HIP=1 python3 examples/llama.py

### Speed test results on Ubuntu server 22.04, with RX7900XTX and ROCm 5.4.3.
Pytorch was running on CPU in this case.
Attempted running pytorch on GPU but failed due to this issue:
[https://discord.com/channels/1068976834382925865/1083520343169319042/1097708353536397372](https://discord.com/channels/1068976834382925865/1083520343169319042/1097708353536397372)
```
nanami@nanami-ai:~/tinygrad$ HIP=1 OPTLOCAL=1 JIT=1 python3.10 test/test_speed_v_torch.py
 add                               1x   1    0.00 ms (    0.00 GFLOPS     0.00 GB/s) in torch,    0.17 ms (    0.00 GFLOPS     0.00 GB/s) in tinygrad,   44.55x slower    0.00 MOPS    0.00 MB
 add                            1024x1024    0.31 ms (    3.37 GFLOPS    40.40 GB/s) in torch,    0.19 ms (    5.54 GFLOPS    66.43 GB/s) in tinygrad,    0.61x faster    1.05 MOPS   12.58 MB
 add                            4096x4096   13.45 ms (    1.25 GFLOPS    14.96 GB/s) in torch,    0.42 ms (   39.98 GFLOPS   479.72 GB/s) in tinygrad,    0.03x faster   16.78 MOPS  201.33 MB
.add_constant                   4096x4096   12.32 ms (    1.36 GFLOPS    10.89 GB/s) in torch,    0.30 ms (   56.03 GFLOPS   448.27 GB/s) in tinygrad,    0.02x faster   16.78 MOPS  134.22 MB
.add_sq                         4096x4096   40.41 ms (    1.25 GFLOPS     4.98 GB/s) in torch,    0.46 ms (  109.12 GFLOPS   436.48 GB/s) in tinygrad,    0.01x faster   50.33 MOPS  201.33 MB
.array_packing                  2048x2048    1.09 ms (    3.83 GFLOPS    30.65 GB/s) in torch,    0.20 ms (   20.90 GFLOPS   167.21 GB/s) in tinygrad,    0.18x faster    4.19 MOPS   33.55 MB
.conv bs: 32 chans:  4 ->  32                0.62 ms (  121.54 GFLOPS     7.71 GB/s) in torch,    0.18 ms (  412.10 GFLOPS    26.15 GB/s) in tinygrad,    0.29x faster   75.50 MOPS    4.79 MB
 conv bs: 32 chans: 16 ->  32                1.95 ms (  155.20 GFLOPS     3.38 GB/s) in torch,    0.20 ms ( 1520.79 GFLOPS    33.14 GB/s) in tinygrad,    0.10x faster  301.99 MOPS    6.58 MB
 conv bs: 32 chans: 64 ->  32                7.34 ms (  164.66 GFLOPS     1.87 GB/s) in torch,    0.27 ms ( 4443.94 GFLOPS    50.54 GB/s) in tinygrad,    0.04x faster 1207.96 MOPS   13.74 MB
.double_permute (64, 64, 64, 64)            16.50 ms (    1.02 GFLOPS     8.14 GB/s) in torch,    0.36 ms (   47.01 GFLOPS   376.12 GB/s) in tinygrad,    0.02x faster   16.78 MOPS  134.22 MB
.exp                            2048x2048    1.18 ms (    3.55 GFLOPS    28.38 GB/s) in torch,    0.21 ms (   20.00 GFLOPS   160.00 GB/s) in tinygrad,    0.18x faster    4.19 MOPS   33.55 MB
.gemm                           1024x1024   11.97 ms (  179.40 GFLOPS     1.05 GB/s) in torch,    0.36 ms ( 5942.29 GFLOPS    34.82 GB/s) in tinygrad,    0.03x faster 2147.48 MOPS   12.58 MB
.gemm                            256x 256    0.21 ms (  157.99 GFLOPS     3.70 GB/s) in torch,    0.22 ms (  152.48 GFLOPS     3.57 GB/s) in tinygrad,    1.04x slower   33.55 MOPS    0.79 MB
.gemm_unrolled                   512x 512    1.55 ms (  173.63 GFLOPS     2.03 GB/s) in torch,    0.21 ms ( 1288.91 GFLOPS    15.10 GB/s) in tinygrad,    0.13x faster  268.44 MOPS    3.15 MB
.gemm_unrolled_permute_l         512x 512    1.55 ms (  173.28 GFLOPS     2.03 GB/s) in torch,    0.24 ms ( 1128.33 GFLOPS    13.22 GB/s) in tinygrad,    0.15x faster  268.44 MOPS    3.15 MB
.gemm_unrolled_permute_lr        512x 512    1.54 ms (  174.24 GFLOPS     2.04 GB/s) in torch,    0.25 ms ( 1077.17 GFLOPS    12.62 GB/s) in tinygrad,    0.16x faster  268.44 MOPS    3.15 MB
.gemm_unrolled_permute_r         512x 512    1.53 ms (  175.22 GFLOPS     2.05 GB/s) in torch,    0.24 ms ( 1130.78 GFLOPS    13.25 GB/s) in tinygrad,    0.15x faster  268.44 MOPS    3.15 MB
.max                            4096x4096    3.08 ms (    5.45 GFLOPS    21.78 GB/s) in torch,    3.58 ms (    4.69 GFLOPS    18.75 GB/s) in tinygrad,    1.16x slower   16.78 MOPS   67.11 MB
.mul_sum                        4096x4096   16.38 ms (    2.05 GFLOPS     8.19 GB/s) in torch,    6.76 ms (    4.96 GFLOPS    19.85 GB/s) in tinygrad,    0.41x faster   33.55 MOPS  134.22 MB
.neg                            4096x4096   12.25 ms (    1.37 GFLOPS    10.95 GB/s) in torch,    0.29 ms (   57.10 GFLOPS   456.76 GB/s) in tinygrad,    0.02x faster   16.78 MOPS  134.22 MB
.conv bs:  1 chans: 12 ->  32                0.35 ms (  162.17 GFLOPS     4.17 GB/s) in torch,    0.20 ms (  289.27 GFLOPS     7.44 GB/s) in tinygrad,    0.56x faster   56.62 MOPS    1.46 MB
.partial_sum                    4096x4096    2.30 ms (    7.28 GFLOPS    29.12 GB/s) in torch,    0.36 ms (   46.91 GFLOPS   187.64 GB/s) in tinygrad,    0.16x faster   16.78 MOPS   67.11 MB
.permute                        1024x1024    0.54 ms (    1.93 GFLOPS    15.41 GB/s) in torch,    0.19 ms (    5.39 GFLOPS    43.14 GB/s) in tinygrad,    0.36x faster    1.05 MOPS    8.39 MB
 permute                        4096x4096   21.06 ms (    0.80 GFLOPS     6.37 GB/s) in torch,    0.57 ms (   29.42 GFLOPS   235.34 GB/s) in tinygrad,    0.03x faster   16.78 MOPS  134.22 MB
.pow                            2048x2048   11.93 ms (    0.35 GFLOPS     4.22 GB/s) in torch,    0.28 ms (   14.98 GFLOPS   179.77 GB/s) in tinygrad,    0.02x faster    4.19 MOPS   50.33 MB
.relu                           4096x4096   12.28 ms (    1.37 GFLOPS    10.93 GB/s) in torch,    0.29 ms (   56.96 GFLOPS   455.65 GB/s) in tinygrad,    0.02x faster   16.78 MOPS  134.22 MB
.sub                            4096x4096   13.71 ms (    1.22 GFLOPS    14.68 GB/s) in torch,    0.45 ms (   37.07 GFLOPS   444.80 GB/s) in tinygrad,    0.03x faster   16.78 MOPS  201.33 MB
.sum                            2048x2048    0.57 ms (    7.36 GFLOPS    29.43 GB/s) in torch,    1.04 ms (    4.04 GFLOPS    16.17 GB/s) in tinygrad,    1.82x slower    4.19 MOPS   16.78 MB
 sum                            4096x4096    2.24 ms (    7.48 GFLOPS    29.93 GB/s) in torch,    3.62 ms (    4.63 GFLOPS    18.52 GB/s) in tinygrad,    1.62x slower   16.78 MOPS   67.11 MB
.
----------------------------------------------------------------------
Ran 23 tests in 13.851s
```
### LLaMA can run,  though both weight loading and inference are much slower than OpenCL backend on the same RX7900XTX GPU.
```
nanami@nanami-ai:~/tinygrad$ HIP=1 OPTLOCAL=1 JIT=1 python3.10 examples/llama.py --timing --prompt "Hi"
using HIP backend
loading 288 ram used: 13.48 GB: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 323/323 [00:08<00:00, 38.28it/s]
loaded weights in 8457.51 ms, 13.48 GB loaded at 1.59 GB/s
Hi
ran model in 2251.48 ms
sync in 406.44 ms
,
ran model in 1852.02 ms
sync in 3.11 ms
 I
ran model in 676.95 ms
sync in 6.11 ms
'
ran model in 681.73 ms
sync in 2.13 ms
m
ran model in 679.61 ms
sync in 6.40 ms
 Jen
ran model in 689.06 ms
sync in 6.53 ms
ny
ran model in 684.28 ms
sync in 6.09 ms
,
ran model in 689.28 ms
sync in 2.17 ms
 and
ran model in 687.18 ms
sync in 6.42 ms
 I
ran model in 686.46 ms
sync in 6.20 ms
'
ran model in 690.50 ms
```
### TODO
Figure out why LLaMA inference is slow.