### PR TITLE
Fix missing dependency for examples/llama.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='tinygrad',
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"
       ],
-      install_requires=['numpy', 'requests', 'pillow', 'tqdm', 'networkx'],
+      install_requires=['numpy', 'requests', 'pillow', 'tqdm', 'networkx', 'sentencepiece'],
       python_requires='>=3.8',
       extras_require={
         'gpu': ["pyopencl"],


### PR DESCRIPTION
Update setup.py to include pypi dependency sentencepiece required by examples/llama.py