### PR TITLE
ResNet: match implementation with Nvidia and PyTorch

### DIFF
--- a/examples/train_resnet.py
+++ b/examples/train_resnet.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
     lambda x: np.tile(np.expand_dims(x, 1), (1, 3, 1, 1)).astype(np.float32),
   ])
   for _ in range(10):
-    optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.9)
+    optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.875)
     train(model, X_train, Y_train, optimizer, 100, BS=32, transform=transform)
     evaluate(model, X_test, Y_test, num_classes=classes, transform=transform)
     lr /= 1.2

--- a/examples/train_resnet.py
+++ b/examples/train_resnet.py
@@ -36,8 +36,8 @@ if __name__ == "__main__":
     lambda x: x / 255.0,
     lambda x: np.tile(np.expand_dims(x, 1), (1, 3, 1, 1)).astype(np.float32),
   ])
-  for _ in range(10):
-    optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.875)
+  for _ in range(5):
+    optimizer = optim.SGD(optim.get_parameters(model), lr=lr, momentum=0.9)
     train(model, X_train, Y_train, optimizer, 100, BS=32, transform=transform)
     evaluate(model, X_test, Y_test, num_classes=classes, transform=transform)
     lr /= 1.2

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -27,6 +27,7 @@ class BasicBlock:
 
 
 class Bottleneck:
+  # NOTE: the original implementation places stride at the first convolution (self.conv1), this is the v1.5 variant
   expansion = 4
 
   def __init__(self, in_planes, planes, stride=1):
@@ -34,7 +35,7 @@ class Bottleneck:
     self.bn1 = nn.BatchNorm2d(planes)
     self.conv2 = nn.Conv2d(planes, planes, kernel_size=3, padding=1, stride=stride, bias=False)
     self.bn2 = nn.BatchNorm2d(planes)
-    self.conv3 = nn.Conv2d(planes, self.expansion *planes, kernel_size=1, bias=False)
+    self.conv3 = nn.Conv2d(planes, self.expansion*planes, kernel_size=1, bias=False)
     self.bn3 = nn.BatchNorm2d(self.expansion*planes)
     self.downsample = []
     if stride != 1 or in_planes != self.expansion*planes:
@@ -52,7 +53,6 @@ class Bottleneck:
     return out
 
 class ResNet:
-  # def __init__(self, block, num_blocks, num_classes=10, url=None):
   def __init__(self, num, num_classes):
     self.num = num
 
@@ -76,7 +76,7 @@ class ResNet:
 
     self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, bias=False, padding=3)
     self.bn1 = nn.BatchNorm2d(64)
-    self.layer1 = self._make_layer(self.block, 64, self.num_blocks[0], stride=2)
+    self.layer1 = self._make_layer(self.block, 64, self.num_blocks[0], stride=1)
     self.layer2 = self._make_layer(self.block, 128, self.num_blocks[1], stride=2)
     self.layer3 = self._make_layer(self.block, 256, self.num_blocks[2], stride=2)
     self.layer4 = self._make_layer(self.block, 512, self.num_blocks[3], stride=2)


### PR DESCRIPTION
Looks like we have ResNet v1.5 implemented for MLPerf!
The only difference I noticed is the stride in layer1. It should be 1 instead of 2.
- [torchvision implementation](https://github.com/pytorch/vision/blob/d310ce64113944ba2fef92ee783435fddc7ce0cd/torchvision/models/resnet.py#L201)
- [nvidia implementation](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/Classification/ConvNets/image_classification/models/resnet.py#L378)

With this change, I reached 97.9% test accuracy in 5 epochs. Previously, I got ~95% after 10 epochs.