### PR TITLE
Add mlperf RNN-T model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ disassemblers/applegpu
 disassemblers/cuda_ioctl_sniffer
 *.prof
 datasets/cifar-10-python.tar.gz
+datasets/librispeech/

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -49,9 +49,9 @@ def load_wav(file):
   sample = librosa.load(file, sr=16000)[0].astype(np.float32)
   return sample, sample.shape[0]
 
-def iterate(bs=1):
+def iterate(bs=1, start=0):
   print(f"there are {len(ci)} samples in the dataset")
-  for i in range(0, len(ci), bs):
+  for i in range(start, len(ci), bs):
     samples, sample_lens = zip(*[load_wav(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]])
     samples = list(samples)
     # pad to same length

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -3,7 +3,7 @@ import pathlib
 import numpy as np
 import librosa
 
-BASEDIR = pathlib.Path("/home/woze/projects/tinygrad/datasets/librispeech")
+BASEDIR = pathlib.Path(__file__).parent.parent / "datasets/librispeech"
 ci = json.load(open(BASEDIR / "dev-clean-wav.json"))
 
 FILTER_BANK = np.expand_dims(librosa.filters.mel(sr=16000, n_fft=512, n_mels=80, fmin=0, fmax=8000), 0)

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -16,7 +16,7 @@ def feature_extract(x, x_lens):
   x = np.concatenate((np.expand_dims(x[:, 0], 1), x[:, 1:] - 0.97 * x[:, :-1]), axis=1)
 
   # stft
-  x = librosa.stft(x, n_fft=512, window="hann", hop_length=160, win_length=320, center=True)
+  x = librosa.stft(x, n_fft=512, window="hann", hop_length=160, win_length=320, center=True, pad_mode="reflect")
   x = np.stack((x.real, x.imag), axis=-1)
 
   # power spectrum
@@ -29,8 +29,13 @@ def feature_extract(x, x_lens):
   x = np.log(x + 1e-20)
 
   # feature splice
-  frames = librosa.util.frame(x, frame_length=3, hop_length=1)
-  features = np.concatenate((frames[:, :, 0], frames[:, :, 1], frames[:, :, 2]), axis=1)[:, :, ::3]
+  seq = [x]
+  for i in range(1, 3):
+    tmp = np.zeros_like(x)
+    tmp[:, :, :-i] = x[:, :, i:]
+    seq.append(tmp)
+  features = np.concatenate(seq, axis=1)[:, :, ::3]
+  print("===", features.shape)
 
   # normalize
   features_mean = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -8,8 +8,9 @@ ci = json.load(open(os.path.join(BASEDIR, "dev-clean-wav.json")))
 
 FILTER_BANK = np.expand_dims(librosa.filters.mel(sr=16000, n_fft=512, n_mels=80, fmin=0, fmax=8000), 0)
 
-def feature_extract(file):
-  x = np.expand_dims(librosa.load(file, sr=16000)[0], 0).astype(np.float32)
+def feature_extract(x, x_lens):
+  x_lens = np.ceil((x_lens / 160) / 3).astype(np.int32)
+  print(x_lens)
 
   # pre-emphasis
   x = np.concatenate((np.expand_dims(x[:, 0], 1), x[:, 1:] - 0.97 * x[:, :-1]), axis=1)
@@ -35,20 +36,32 @@ def feature_extract(file):
   features_mean = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)
   features_std = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)
   for i in range(features.shape[0]):
-    features_mean[i, :] = features[i, :, :].mean(axis=1)
-    features_std[i, :] = features[i, :, :].std(axis=1, ddof=1)
+    features_mean[i, :] = features[i, :, :x_lens[i]].mean(axis=1)
+    features_std[i, :] = features[i, :, :x_lens[i]].std(axis=1, ddof=1)
   features_std += 1e-5
   features = (features - np.expand_dims(features_mean, 2)) / np.expand_dims(features_std, 2)
 
-  return features.transpose(2, 0, 1)
+  print(features.shape)
+
+  return features.transpose(2, 0, 1), x_lens.astype(np.float32)
+
+def load_wav(file):
+  sample = librosa.load(file, sr=16000)[0].astype(np.float32)
+  return sample, sample.shape[0]
 
 def iterate(bs=1):
   print(f"there are {len(ci)} samples in the dataset")
   for i in range(0, len(ci), bs):
-    features = [feature_extract(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]]
-    transcripts = [v["transcript"] for v in ci[i : i + bs]]
-    yield np.concatenate(features, axis=1), np.array(transcripts)
+    samples, sample_lens = zip(*[load_wav(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]])
+    samples = list(samples)
+    # pad to same length
+    max_len = max(sample_lens)
+    for j in range(len(samples)):
+      samples[j] = np.pad(samples[j], (0, max_len - sample_lens[j]), "constant")
+    samples, sample_lens = np.array(samples), np.array(sample_lens)
+
+    yield feature_extract(samples, sample_lens), np.array([v["transcript"] for v in ci[i : i + bs]])
 
 if __name__ == "__main__":
   X, Y = next(iterate())
-  print(X.shape, Y.shape)
+  print(X[0].shape, Y.shape)

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -1,0 +1,54 @@
+import json
+import os
+import numpy as np
+import librosa
+
+BASEDIR = "/home/woze/projects/tinygrad/datasets/"
+ci = json.load(open(os.path.join(BASEDIR, "dev-clean-wav.json")))
+
+FILTER_BANK = np.expand_dims(librosa.filters.mel(sr=16000, n_fft=512, n_mels=80, fmin=0, fmax=8000), 0)
+
+def feature_extract(file):
+  x = np.expand_dims(librosa.load(file, sr=16000)[0], 0).astype(np.float32)
+
+  # pre-emphasis
+  x = np.concatenate((np.expand_dims(x[:, 0], 1), x[:, 1:] - 0.97 * x[:, :-1]), axis=1)
+
+  # stft
+  x = librosa.stft(x, n_fft=512, window="hann", hop_length=160, win_length=320, center=True)
+  x = np.stack((x.real, x.imag), axis=-1)
+
+  # power spectrum
+  x = (x**2).sum(-1)
+
+  # mel filter bank
+  x = np.matmul(FILTER_BANK, x)
+
+  # log
+  x = np.log(x + 1e-20)
+
+  # feature splice
+  frames = librosa.util.frame(x, frame_length=3, hop_length=1)
+  features = np.concatenate((frames[:, :, 0], frames[:, :, 1], frames[:, :, 2]), axis=1)[:, :, ::3]
+
+  # normalize
+  features_mean = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)
+  features_std = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)
+  for i in range(features.shape[0]):
+    features_mean[i, :] = features[i, :, :].mean(axis=1)
+    features_std[i, :] = features[i, :, :].std(axis=1, ddof=1)
+  features_std += 1e-5
+  features = (features - np.expand_dims(features_mean, 2)) / np.expand_dims(features_std, 2)
+
+  return features.transpose(2, 0, 1)
+
+def iterate(bs=1):
+  print(f"there are {len(ci)} samples in the dataset")
+  for i in range(0, len(ci), bs):
+    features = [feature_extract(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]]
+    transcripts = [v["transcript"] for v in ci[i : i + bs]]
+    yield np.concatenate(features, axis=1), np.array(transcripts)
+
+if __name__ == "__main__":
+  X, Y = next(iterate())
+  print(X.shape, Y.shape)

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -49,7 +49,7 @@ def load_wav(file):
   sample = librosa.load(file, sr=16000)[0].astype(np.float32)
   return sample, sample.shape[0]
 
-def iterate(bs=1, start=0):
+def iterate(bs=8, start=0):
   print(f"there are {len(ci)} samples in the dataset")
   for i in range(start, len(ci), bs):
     samples, sample_lens = zip(*[load_wav(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]])

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -4,6 +4,17 @@ import numpy as np
 import librosa
 import soundfile
 
+"""
+The dataset has to be downloaded manually from https://www.openslr.org/12/ and put in `datasets/librispeech`.
+For mlperf validation the dev-clean dataset is used.
+
+Then all the flacs have to be converted to wav using something like:
+```fish
+for file in **/*.flac; ffmpeg -i $file -ar 16k "$(dirname $file)/$(basename $file .flac).wav"; end
+```
+
+Then this [file](https://github.com/mlcommons/inference/blob/master/speech_recognition/rnnt/dev-clean-wav.json) has to also be put in `datasets/librispeech`.
+"""
 BASEDIR = pathlib.Path(__file__).parent.parent / "datasets/librispeech"
 with open(BASEDIR / "dev-clean-wav.json") as f:
   ci = json.load(f)

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -10,7 +10,6 @@ FILTER_BANK = np.expand_dims(librosa.filters.mel(sr=16000, n_fft=512, n_mels=80,
 
 def feature_extract(x, x_lens):
   x_lens = np.ceil((x_lens / 160) / 3).astype(np.int32)
-  print(x_lens)
 
   # pre-emphasis
   x = np.concatenate((np.expand_dims(x[:, 0], 1), x[:, 1:] - 0.97 * x[:, :-1]), axis=1)
@@ -35,7 +34,6 @@ def feature_extract(x, x_lens):
     tmp[:, :, :-i] = x[:, :, i:]
     seq.append(tmp)
   features = np.concatenate(seq, axis=1)[:, :, ::3]
-  print("===", features.shape)
 
   # normalize
   features_mean = np.zeros((features.shape[0], features.shape[1]), dtype=np.float32)
@@ -45,8 +43,6 @@ def feature_extract(x, x_lens):
     features_std[i, :] = features[i, :, :x_lens[i]].std(axis=1, ddof=1)
   features_std += 1e-5
   features = (features - np.expand_dims(features_mean, 2)) / np.expand_dims(features_std, 2)
-
-  print(features.shape)
 
   return features.transpose(2, 0, 1), x_lens.astype(np.float32)
 

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -64,7 +64,7 @@ def load_wav(file):
   sample = soundfile.read(file)[0].astype(np.float32)
   return sample, sample.shape[0]
 
-def iterate(bs=8, start=0):
+def iterate(bs=1, start=0):
   print(f"there are {len(ci)} samples in the dataset")
   for i in range(start, len(ci), bs):
     samples, sample_lens = zip(*[load_wav(BASEDIR / v["files"][0]["fname"]) for v in ci[i : i + bs]])

--- a/datasets/librispeech.py
+++ b/datasets/librispeech.py
@@ -1,10 +1,10 @@
 import json
-import os
+import pathlib
 import numpy as np
 import librosa
 
-BASEDIR = "/home/woze/projects/tinygrad/datasets/"
-ci = json.load(open(os.path.join(BASEDIR, "dev-clean-wav.json")))
+BASEDIR = pathlib.Path("/home/woze/projects/tinygrad/datasets/librispeech")
+ci = json.load(open(BASEDIR / "dev-clean-wav.json"))
 
 FILTER_BANK = np.expand_dims(librosa.filters.mel(sr=16000, n_fft=512, n_mels=80, fmin=0, fmax=8000), 0)
 
@@ -53,7 +53,7 @@ def load_wav(file):
 def iterate(bs=8, start=0):
   print(f"there are {len(ci)} samples in the dataset")
   for i in range(start, len(ci), bs):
-    samples, sample_lens = zip(*[load_wav(os.path.join(BASEDIR, v["files"][0]["fname"])) for v in ci[i : i + bs]])
+    samples, sample_lens = zip(*[load_wav(BASEDIR / v["files"][0]["fname"]) for v in ci[i : i + bs]])
     samples = list(samples)
     # pad to same length
     max_len = max(sample_lens)

--- a/examples/mlperf/metrics.py
+++ b/examples/mlperf/metrics.py
@@ -22,4 +22,4 @@ def word_error_rate(x, y):
     r_list = r.split()
     words += len(r_list)
     scores += levenshtein(h_list, r_list)
-  return 1.0 * scores / words
+  return float(scores) / words, float(scores), words

--- a/examples/mlperf/metrics.py
+++ b/examples/mlperf/metrics.py
@@ -1,0 +1,25 @@
+def levenshtein(a, b):
+  n, m = len(a), len(b)
+  if n > m:
+    a, b, n, m = b, a, m, n
+
+  current = list(range(n + 1))
+  for i in range(1, m + 1):
+    previous, current = current, [i] + [0] * n
+    for j in range(1, n + 1):
+      add, delete = previous[j] + 1, current[j - 1] + 1
+      change = previous[j - 1]
+      if a[j - 1] != b[i - 1]:
+        change = change + 1
+      current[j] = min(add, delete, change)
+
+  return current[n]
+
+def word_error_rate(x, y):
+  scores = words = 0
+  for h, r in zip(x, y):
+    h_list = h.split()
+    r_list = r.split()
+    words += len(r_list)
+    scores += levenshtein(h_list, r_list)
+  return 1.0 * scores / words

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -43,4 +43,27 @@ if __name__ == "__main__":
     print(f"****** {n}/{d}  {n*100.0/d:.2f}%")
     st = time.perf_counter()
 
+  # RNN-T
+  from models.rnnt import RNNT
+  mdl = RNNT()
+  mdl.load_from_pretrained()
 
+  from datasets.librispeech import iterate
+  from examples.mlperf.metrics import word_error_rate
+
+  LABELS = [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
+
+  wer = 0
+  c = 0
+  st = time.perf_counter()
+  for X, Y in iterate():
+    mt = time.perf_counter()
+    tt = mdl.decode(Tensor(X), Tensor([X.shape[0]]))
+    et = time.perf_counter()
+    print(f"{(mt-st)*1000:.2f} ms loading data, {(et-mt)*1000:.2f} ms to run model")
+    for n, t in enumerate(tt):
+      tnp = np.array(t)
+      wer += word_error_rate(["".join([LABELS[int(tnp[i])] for i in range(tnp.shape[0])])], [Y[n]])
+    c += len(tt)
+    print(f"WER: {wer/c:.8f}")
+    st = time.perf_counter()

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -53,8 +53,9 @@ if __name__ == "__main__":
 
   LABELS = [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
 
-  wer = 0
   c = 0
+  scores = 0
+  words = 0
   st = time.perf_counter()
   for X, Y in iterate():
     mt = time.perf_counter()
@@ -63,7 +64,9 @@ if __name__ == "__main__":
     print(f"{(mt-st)*1000:.2f} ms loading data, {(et-mt)*1000:.2f} ms to run model")
     for n, t in enumerate(tt):
       tnp = np.array(t)
-      wer += word_error_rate(["".join([LABELS[int(tnp[i])] for i in range(tnp.shape[0])])], [Y[n]])
+      _, scores_, words_ = word_error_rate(["".join([LABELS[int(tnp[i])] for i in range(tnp.shape[0])])], [Y[n]])
+      scores += scores_
+      words += words_
     c += len(tt)
-    print(f"WER: {wer/c}, {c} samples, raw wer: {wer}")
+    print(f"WER: {scores/words}, {words} words, raw scores: {scores}, c: {c}")
     st = time.perf_counter()

--- a/examples/mlperf/model_eval.py
+++ b/examples/mlperf/model_eval.py
@@ -58,12 +58,12 @@ if __name__ == "__main__":
   st = time.perf_counter()
   for X, Y in iterate():
     mt = time.perf_counter()
-    tt = mdl.decode(Tensor(X), Tensor([X.shape[0]]))
+    tt = mdl.decode(Tensor(X[0]), Tensor([X[1]]))
     et = time.perf_counter()
     print(f"{(mt-st)*1000:.2f} ms loading data, {(et-mt)*1000:.2f} ms to run model")
     for n, t in enumerate(tt):
       tnp = np.array(t)
       wer += word_error_rate(["".join([LABELS[int(tnp[i])] for i in range(tnp.shape[0])])], [Y[n]])
     c += len(tt)
-    print(f"WER: {wer/c:.8f}")
+    print(f"WER: {wer/c}, {c} samples, raw wer: {wer}")
     st = time.perf_counter()

--- a/examples/mlperf/model_spec.py
+++ b/examples/mlperf/model_spec.py
@@ -29,5 +29,11 @@ if __name__ == "__main__":
   test_model(mdl, img)
 
   # RNNT
+  from models.rnnt import RNNT
+  mdl = RNNT()
+  mdl.load_from_pretrained()
+  x = Tensor.randn(220, 1, 240)
+  y = Tensor.randn(220, 1, 240)
+  test_model(mdl, x, Tensor([220]), y)
 
   # BERT-large

--- a/examples/mlperf/model_spec.py
+++ b/examples/mlperf/model_spec.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
   mdl = RNNT()
   mdl.load_from_pretrained()
   x = Tensor.randn(220, 1, 240)
-  y = Tensor.randn(220, 1, 240)
-  test_model(mdl, x, Tensor([220]), y)
+  y = Tensor.randn(1, 220)
+  test_model(mdl, x, y)
 
   # BERT-large

--- a/models/rnnt.py
+++ b/models/rnnt.py
@@ -1,7 +1,6 @@
 from tinygrad.tensor import Tensor
 from tinygrad.jit import TinyJit
 from tinygrad.nn import Linear
-from tinygrad.helpers import dtypes
 import numpy as np
 from extra.utils import download_file
 from pathlib import Path

--- a/models/rnnt.py
+++ b/models/rnnt.py
@@ -14,7 +14,7 @@ class RNNT:
 
   def __call__(self, x, y, hc=None):
     f, _ = self.encoder(x, None)
-    g, _ = self.prediction(y, hc, Tensor.zeros(1, requires_grad=False))
+    g, _ = self.prediction(y, hc, Tensor.ones(1, requires_grad=False))
     out = self.joint(f, g)
     return out.realize()
 

--- a/models/rnnt.py
+++ b/models/rnnt.py
@@ -1,0 +1,202 @@
+from tinygrad.tensor import Tensor
+from tinygrad.nn import Linear
+import numpy as np
+from extra.utils import download_file
+from pathlib import Path
+
+
+class RNNT:
+  def __init__(self, input_features=240, vocab_size=29, enc_hidden_size=1024, pred_hidden_size=320, joint_hidden_size=512, pre_enc_layers=2, post_enc_layers=3, pred_layers=2, stack_time_factor=2, dropout=0.32):
+    self.encoder = Encoder(input_features, enc_hidden_size, pre_enc_layers, post_enc_layers, stack_time_factor, dropout)
+    self.prediction = Prediction(vocab_size, pred_hidden_size, pred_layers, dropout)
+    self.joint = Joint(vocab_size, pred_hidden_size, enc_hidden_size, joint_hidden_size, dropout)
+
+  def __call__(self, x, x_lens, y, h=None, c=None):
+    f, _ = self.encoder(x, x_lens)
+    g, _, _ = self.prediction(y, h, c)
+    out = self.joint(f, g)
+    return out
+
+  def decode(self, x, x_lens):
+    logits, logit_lens = self.encoder(x, x_lens)
+    outputs = []
+    for b in range(logits.shape[0]):
+      inseq = logits[b, :, :].unsqueeze(1)
+      logit_len = logit_lens[b]
+      seq = self._greedy_decode(inseq, logit_len)
+      outputs.append(seq)
+    return outputs
+
+  def _greedy_decode(self, logits, logit_lens):
+    h = c = None
+    labels = []
+    for time_idx in range(int(logit_lens.numpy().item())):
+      logit = logits[time_idx, :, :].unsqueeze(0)
+      not_blank = True
+      added = 0
+      while not_blank and added < 30:
+        label = Tensor([[labels[-1] if labels[-1] <= 28 else labels[-1] - 1]]) if len(labels) > 0 else None
+        g, h_, c_ = self.prediction(label, h, c)
+        j = self.joint(logit, g)[:, 0, 0, :][0, :].numpy()
+
+        k = np.argmax(j, axis=0)
+        not_blank = k != 28
+        if not_blank:
+          labels.append(k)
+          h, c = h_, c_
+        added += 1
+    return labels
+
+  def load_from_pretrained(self):
+    fn = Path(__file__).parent.parent / "weights/rnnt.pt"
+    download_file("https://zenodo.org/record/3662521/files/DistributedDataParallel_1576581068.9962234-epoch-100.pt?download=1", fn)
+
+    import torch
+    state_dict = torch.load(open(fn, "rb"), map_location="cpu")["state_dict"]
+
+    # encoder
+    for i in range(2):
+      self.encoder.pre_rnn.cells[i].weights_ih.assign(state_dict[f"encoder.pre_rnn.lstm.weight_ih_l{i}"].numpy())
+      self.encoder.pre_rnn.cells[i].weights_hh.assign(state_dict[f"encoder.pre_rnn.lstm.weight_hh_l{i}"].numpy())
+      self.encoder.pre_rnn.cells[i].bias_ih.assign(state_dict[f"encoder.pre_rnn.lstm.bias_ih_l{i}"].numpy())
+      self.encoder.pre_rnn.cells[i].bias_hh.assign(state_dict[f"encoder.pre_rnn.lstm.bias_hh_l{i}"].numpy())
+    for i in range(3):
+      self.encoder.post_rnn.cells[i].weights_ih.assign(state_dict[f"encoder.post_rnn.lstm.weight_ih_l{i}"].numpy())
+      self.encoder.post_rnn.cells[i].weights_hh.assign(state_dict[f"encoder.post_rnn.lstm.weight_hh_l{i}"].numpy())
+      self.encoder.post_rnn.cells[i].bias_ih.assign(state_dict[f"encoder.post_rnn.lstm.bias_ih_l{i}"].numpy())
+      self.encoder.post_rnn.cells[i].bias_hh.assign(state_dict[f"encoder.post_rnn.lstm.bias_hh_l{i}"].numpy())
+
+    # prediction
+    self.prediction.emb.weight.assign(state_dict["prediction.embed.weight"].numpy())
+    for i in range(2):
+      self.prediction.rnn.cells[i].weights_ih.assign(state_dict[f"prediction.dec_rnn.lstm.weight_ih_l{i}"].numpy())
+      self.prediction.rnn.cells[i].weights_hh.assign(state_dict[f"prediction.dec_rnn.lstm.weight_hh_l{i}"].numpy())
+      self.prediction.rnn.cells[i].bias_ih.assign(state_dict[f"prediction.dec_rnn.lstm.bias_ih_l{i}"].numpy())
+      self.prediction.rnn.cells[i].bias_hh.assign(state_dict[f"prediction.dec_rnn.lstm.bias_hh_l{i}"].numpy())
+
+    # joint
+    self.joint.l1.weight.assign(state_dict["joint_net.0.weight"].numpy())
+    self.joint.l1.bias.assign(state_dict["joint_net.0.bias"].numpy())
+    self.joint.l2.weight.assign(state_dict["joint_net.3.weight"].numpy())
+    self.joint.l2.bias.assign(state_dict["joint_net.3.bias"].numpy())
+
+
+class LSTMCell:
+  def __init__(self, input_size, hidden_size):
+    self.hidden_size = hidden_size
+
+    self.weights_ih = Tensor.uniform(hidden_size * 4, input_size)
+    self.bias_ih = Tensor.uniform(hidden_size * 4)
+    self.weights_hh = Tensor.uniform(hidden_size * 4, hidden_size)
+    self.bias_hh = Tensor.uniform(hidden_size * 4)
+
+  def __call__(self, x, h, c):
+    t = (x @ self.weights_ih.T) + self.bias_ih + (h @ self.weights_hh.T) + self.bias_hh
+
+    i, f, g, o = t.chunk(4, 1)
+    i, f, g, o = i.sigmoid(), f.sigmoid(), g.tanh(), o.sigmoid()
+
+    c = (f * c) + (i * g)
+    h = o * c.tanh()
+
+    return h.realize(), c.realize()
+
+
+class LSTM:
+  def __init__(self, input_size, hidden_size, layers, dropout):
+    self.input_size = input_size
+    self.hidden_size = hidden_size
+    self.layers = layers
+    self.dropout = dropout
+
+    self.cells = [LSTMCell(input_size, hidden_size) if i == 0 else LSTMCell(hidden_size, hidden_size) for i in range(layers)]
+
+  def __call__(self, x, h, c):
+    if h is None or c is None:
+      h = [Tensor.zeros(x.shape[1], self.hidden_size) for _ in range(self.layers)]
+      c = [Tensor.zeros(x.shape[1], self.hidden_size) for _ in range(self.layers)]
+    else:
+      h, c = h.copy(), c.copy()
+
+    output = None
+    for t in range(x.shape[0]):
+      input = x[t]
+      for i, cell in enumerate(self.cells):
+        h[i], c[i] = cell(input, h[i], c[i])
+        # dropout
+        if i != self.layers - 1:
+          h[i] = h[i].dropout(self.dropout)
+        input = h[i]
+      output = h[-1].unsqueeze(0) if output is None else Tensor.cat(output, h[-1].unsqueeze(0), dim=0).realize()
+
+    return output, h, c
+
+
+class StackTime:
+  def __init__(self, factor):
+    self.factor = factor
+
+  def __call__(self, x, x_lens):
+    r = x.transpose(0, 1)
+    if r.shape[1] % self.factor != 0:
+      r = r.cat(Tensor.zeros(r.shape[0], (-r.shape[1]) % self.factor, r.shape[2]), dim=1)
+    r = r.reshape(r.shape[0], r.shape[1] // self.factor, r.shape[2] * self.factor)
+    x_lens = Tensor(np.ceil((x_lens / self.factor).numpy()))
+    return r.transpose(0, 1), x_lens
+
+
+class Encoder:
+    def __init__(self, input_size, hidden_size, pre_layers, post_layers, stack_time_factor, dropout):
+      self.pre_rnn = LSTM(input_size, hidden_size, pre_layers, dropout)
+      self.stack_time = StackTime(stack_time_factor)
+      self.post_rnn = LSTM(stack_time_factor * hidden_size, hidden_size, post_layers, dropout)
+
+    def __call__(self, x, x_lens):
+      x, _, _ = self.pre_rnn(x, None, None)
+      x, x_lens = self.stack_time(x, x_lens)
+      x, _, _ = self.post_rnn(x, None, None)
+      return x.transpose(0, 1), x_lens
+
+
+class Embedding:
+  def __init__(self, vocab_size: int, embed_size: int):
+    self.vocab_size = vocab_size
+    self.weight = Tensor.scaled_uniform(vocab_size, embed_size)
+
+  def __call__(self, idx: Tensor) -> Tensor:
+    idxnp = idx.numpy().astype(np.int32)
+    onehot = np.zeros((idx.shape[0], idx.shape[1], self.vocab_size), dtype=np.float32)
+    for i in range(idx.shape[0]):
+      onehot[i, np.arange(idx.shape[1]), idxnp[i]] = 1
+    return Tensor(onehot, requires_grad=False) @ self.weight
+
+
+class Prediction:
+  def __init__(self, vocab_size, hidden_size, layers, dropout):
+    self.hidden_size = hidden_size
+
+    self.emb = Embedding(vocab_size - 1, hidden_size)
+    self.rnn = LSTM(hidden_size, hidden_size, layers, dropout)
+
+  def __call__(self, x, h, c):
+    x = self.emb(x) if x is not None else (Tensor.zeros(1, 1, self.hidden_size) if h is None else Tensor.zeros(h[0].shape[1], 1, self.hidden_size))
+    x, h, c = self.rnn(x.transpose(0, 1), h, c)
+    return x.transpose(0, 1), h, c
+
+
+class Joint:
+  def __init__(self, vocab_size, pred_hidden_size, enc_hidden_size, joint_hidden_size, dropout):
+    self.dropout = dropout
+
+    self.l1 = Linear(pred_hidden_size + enc_hidden_size, joint_hidden_size)
+    self.l2 = Linear(joint_hidden_size, vocab_size)
+
+  def __call__(self, f, g):
+    (_, T, H), (B, U, H2) = f.shape, g.shape
+    f = f.unsqueeze(2).expand(B, T, U, H)
+    g = g.unsqueeze(1).expand(B, T, U, H2)
+
+    inp = f.cat(g, dim=3)
+    t = self.l1(inp).relu()
+    t = t.dropout(self.dropout)
+    return self.l2(t)

--- a/models/rnnt.py
+++ b/models/rnnt.py
@@ -133,7 +133,7 @@ class LSTM:
     for t in range(x.shape[0]):
       hc = _do_cell(x[t] + 1 - 1, hc) # TODO: why do we need to do this?
       if output is None:
-        output = hc[-1, :x.shape[1]].unsqueeze(0).realize()
+        output = hc[-1, :x.shape[1]].unsqueeze(0)
       else:
         output = output.cat(hc[-1, :x.shape[1]].unsqueeze(0), dim=0).realize()
 
@@ -151,10 +151,9 @@ class StackTime:
     self.factor = factor
 
   def __call__(self, x, x_lens):
-    r = x.transpose(0, 1)
-    r = r.pad(((0, 0), (0, (-r.shape[1]) % self.factor), (0, 0)))
-    r = r.reshape(r.shape[0], r.shape[1] // self.factor, r.shape[2] * self.factor)
-    return r.transpose(0, 1), x_lens / self.factor if x_lens is not None else None
+    x = x.pad(((0, (-x.shape[0]) % self.factor), (0, 0), (0, 0)))
+    x = x.reshape(x.shape[0] // self.factor, x.shape[1], x.shape[2] * self.factor)
+    return x, x_lens / self.factor if x_lens is not None else None
 
 
 class Encoder:

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+import unittest
+import numpy as np
+from tinygrad.tensor import Tensor
+from models.rnnt import LSTM
+import torch
+
+class TestNN(unittest.TestCase):
+  def test_groupnorm(self):
+    BS, SQ, IS, HS, L = 8, 24, 512, 1024, 2
+
+    # create in torch
+    with torch.no_grad():
+      torch_layer = torch.nn.LSTM(IS, HS, L)
+
+    # create in tinygrad
+    layer = LSTM(IS, HS, L, 0.0)
+
+    # copy weights
+    with torch.no_grad():
+      layer.cells[0].weights_ih.assign(Tensor(torch_layer.weight_ih_l0.numpy()))
+      layer.cells[0].weights_hh.assign(Tensor(torch_layer.weight_hh_l0.numpy()))
+      layer.cells[0].bias_ih.assign(Tensor(torch_layer.bias_ih_l0.numpy()))
+      layer.cells[0].bias_hh.assign(Tensor(torch_layer.bias_hh_l0.numpy()))
+      layer.cells[1].weights_ih.assign(Tensor(torch_layer.weight_ih_l1.numpy()))
+      layer.cells[1].weights_hh.assign(Tensor(torch_layer.weight_hh_l1.numpy()))
+      layer.cells[1].bias_ih.assign(Tensor(torch_layer.bias_ih_l1.numpy()))
+      layer.cells[1].bias_hh.assign(Tensor(torch_layer.bias_hh_l1.numpy()))
+
+    # test
+    x = Tensor.randn(SQ, BS, IS)
+    z, _, _ = layer(x, None, None)
+    torch_x = torch.tensor(x.cpu().numpy())
+    torch_z, _ = torch_layer(torch_x)
+    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -7,9 +7,6 @@ import torch
 
 class TestRNNT(unittest.TestCase):
   def test_lstm(self):
-    Tensor.training = False
-    Tensor.no_grad = True
-
     BS, SQ, IS, HS, L = 4, 220, 240, 1024, 2
 
     # create in torch

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -5,8 +5,8 @@ from tinygrad.tensor import Tensor
 from models.rnnt import LSTM
 import torch
 
-class TestNN(unittest.TestCase):
-  def test_groupnorm(self):
+class TestRNNT(unittest.TestCase):
+  def test_lstm(self):
     BS, SQ, IS, HS, L = 8, 24, 512, 1024, 2
 
     # create in torch
@@ -29,9 +29,16 @@ class TestNN(unittest.TestCase):
 
     # test
     x = Tensor.randn(SQ, BS, IS)
-    z, _, _ = layer(x, None, None)
+    z, tg_h, tg_c = layer(x, None, None)
     torch_x = torch.tensor(x.cpu().numpy())
-    torch_z, _ = torch_layer(torch_x)
+    torch_z, pt_hidden = torch_layer(torch_x)
+    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
+
+    # test passing hidden
+    x = Tensor.randn(SQ, BS, IS)
+    z, tg_h, tg_c = layer(x, tg_h, tg_c)
+    torch_x = torch.tensor(x.cpu().numpy())
+    torch_z, pt_hidden = torch_layer(torch_x, pt_hidden)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
 
 if __name__ == '__main__':

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -31,8 +31,8 @@ class TestRNNT(unittest.TestCase):
       layer.cells[1].bias_hh.assign(Tensor(torch_layer.bias_hh_l1.numpy()))
 
     # test initial hidden
-    x = Tensor.randn(SQ, BS, IS)
     for _ in range(3):
+      x = Tensor.randn(SQ, BS, IS)
       z, hc = layer(x, None)
       torch_x = torch.tensor(x.cpu().numpy())
       torch_z, torch_hc = torch_layer(torch_x)

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -7,7 +7,7 @@ import torch
 
 class TestRNNT(unittest.TestCase):
   def test_lstm(self):
-    BS, SQ, IS, HS, L = 8, 24, 512, 1024, 2
+    BS, SQ, IS, HS, L = 8, 220, 240, 1024, 2
 
     # create in torch
     with torch.no_grad():
@@ -28,18 +28,20 @@ class TestRNNT(unittest.TestCase):
       layer.cells[1].bias_hh.assign(Tensor(torch_layer.bias_hh_l1.numpy()))
 
     # test
-    x = Tensor.randn(SQ, BS, IS)
-    z, tg_h, tg_c = layer(x, None, None)
-    torch_x = torch.tensor(x.cpu().numpy())
-    torch_z, pt_hidden = torch_layer(torch_x)
-    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
+    for i in range(3):
+      x = Tensor.randn(SQ, BS, IS)
+      z, hc = layer(x, None)
+      torch_x = torch.tensor(x.cpu().numpy())
+      torch_z, torch_hc = torch_layer(torch_x)
+      np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
 
     # test passing hidden
-    x = Tensor.randn(SQ, BS, IS)
-    z, tg_h, tg_c = layer(x, tg_h, tg_c)
-    torch_x = torch.tensor(x.cpu().numpy())
-    torch_z, pt_hidden = torch_layer(torch_x, pt_hidden)
-    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
+    for i in range(3):
+      x = Tensor.randn(SQ, BS, IS)
+      z, hc = layer(x, hc)
+      torch_x = torch.tensor(x.cpu().numpy())
+      torch_z, torch_hc = torch_layer(torch_x, torch_hc)
+      np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/models/test_rnnt.py
+++ b/test/models/test_rnnt.py
@@ -7,7 +7,10 @@ import torch
 
 class TestRNNT(unittest.TestCase):
   def test_lstm(self):
-    BS, SQ, IS, HS, L = 8, 220, 240, 1024, 2
+    Tensor.training = False
+    Tensor.no_grad = True
+
+    BS, SQ, IS, HS, L = 4, 220, 240, 1024, 2
 
     # create in torch
     with torch.no_grad():
@@ -27,16 +30,16 @@ class TestRNNT(unittest.TestCase):
       layer.cells[1].bias_ih.assign(Tensor(torch_layer.bias_ih_l1.numpy()))
       layer.cells[1].bias_hh.assign(Tensor(torch_layer.bias_hh_l1.numpy()))
 
-    # test
-    for i in range(3):
-      x = Tensor.randn(SQ, BS, IS)
+    # test initial hidden
+    x = Tensor.randn(SQ, BS, IS)
+    for _ in range(3):
       z, hc = layer(x, None)
       torch_x = torch.tensor(x.cpu().numpy())
       torch_z, torch_hc = torch_layer(torch_x)
       np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
 
     # test passing hidden
-    for i in range(3):
+    for _ in range(3):
       x = Tensor.randn(SQ, BS, IS)
       z, hc = layer(x, hc)
       torch_x = torch.tensor(x.cpu().numpy())


### PR DESCRIPTION
For now dataset has to be downloaded manually from https://www.openslr.org/12/. mlperf uses `dev-clean`.
Then all the flacs have to be converted to wav using something like:
```fish
for file in **/*.flac; ffmpeg -i $file -ar 16k "$(dirname $file)/$(basename $file .flac).wav"; end
```
Need this file as well https://github.com/mlcommons/inference/blob/master/speech_recognition/rnnt/dev-clean-wav.json.

I'm currently using `librosa` for the stft and audio file loading but it might be possible to rewrite them to not rely on librosa.
The RNN-T bench is also slightly different from the other ones as feature extraction is part of the benchmark, so I'm not quite sure where to put the feature extraction function.

Edit: this is also pretty slow rn
Edit again: not slow anymore