### PR TITLE
Add unary sin and cos ops. 

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -8,7 +8,7 @@ from tinygrad.lazy import Device
 
 FORWARD_ONLY = getenv("FORWARD_ONLY", 0)
 PRINT_TENSORS = getenv("PRINT_TENSORS", 0)
-def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, grad_atol=1e-4, grad_rtol=1e-3, forward_only=False, vals=None, a=-0.5, b=3):
+def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, grad_atol=1e-4, grad_rtol=1e-3, forward_only=False, vals=None, a=-0.5, b=3, printer=False):
   if tinygrad_fxn is None: tinygrad_fxn = torch_fxn
   torch.manual_seed(0)
   np.random.seed(0)
@@ -24,6 +24,9 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
   torch_fp = time.monotonic() - st
 
   st = time.monotonic()
+  if printer:
+    print("PRINTING TORCH INPUT")
+    print(ts[0])
   ret = tinygrad_fxn(*tst).realize()
   tinygrad_fp = time.monotonic() - st
 
@@ -148,6 +151,10 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], lambda x: torch.log(x), Tensor.log)
   def test_exp(self):
     helper_test_op([(45,65)], lambda x: torch.exp(x), Tensor.exp)
+  def test_sin(self):
+    helper_test_op([(45,65)], lambda x: torch.sin(x), Tensor.sin, printer=True)
+  def test_cos(self):
+    helper_test_op([(45,65)], lambda x: torch.cos(x), Tensor.cos)
   def test_sign(self):
     helper_test_op([(45,65)], lambda x: torch.sign(x), Tensor.sign)
   def test_softsign(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -8,7 +8,7 @@ from tinygrad.lazy import Device
 
 FORWARD_ONLY = getenv("FORWARD_ONLY", 0)
 PRINT_TENSORS = getenv("PRINT_TENSORS", 0)
-def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, grad_atol=1e-4, grad_rtol=1e-3, forward_only=False, vals=None, a=-0.5, b=3, printer=False):
+def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, grad_atol=1e-4, grad_rtol=1e-3, forward_only=False, vals=None, a=-0.5, b=3):
   if tinygrad_fxn is None: tinygrad_fxn = torch_fxn
   torch.manual_seed(0)
   np.random.seed(0)
@@ -24,9 +24,6 @@ def helper_test_op(shps, torch_fxn, tinygrad_fxn=None, atol=1e-6, rtol=1e-3, gra
   torch_fp = time.monotonic() - st
 
   st = time.monotonic()
-  if printer:
-    print("PRINTING TORCH INPUT")
-    print(ts[0])
   ret = tinygrad_fxn(*tst).realize()
   tinygrad_fp = time.monotonic() - st
 
@@ -152,7 +149,7 @@ class TestOps(unittest.TestCase):
   def test_exp(self):
     helper_test_op([(45,65)], lambda x: torch.exp(x), Tensor.exp)
   def test_sin(self):
-    helper_test_op([(45,65)], lambda x: torch.sin(x), Tensor.sin, printer=True)
+    helper_test_op([(45,65)], lambda x: torch.sin(x), Tensor.sin)
   def test_cos(self):
     helper_test_op([(45,65)], lambda x: torch.cos(x), Tensor.cos)
   def test_sign(self):

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -46,8 +46,7 @@ class Exp(Function):
 class Sin(Function):
   def forward(self, x:LazyBuffer) -> LazyBuffer:
     self.x = x
-    self.ret = x.unary_op(UnaryOps.SIN)
-    return self.ret
+    return x.unary_op(UnaryOps.SIN)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return self.x.unary_op(UnaryOps.COS).binary_op(BinaryOps.MUL, grad_output)
@@ -55,8 +54,7 @@ class Sin(Function):
 class Cos(Function):
   def forward(self, x:LazyBuffer) -> LazyBuffer:
     self.x = x
-    self.ret = x.unary_op(UnaryOps.COS)
-    return self.ret
+    return x.unary_op(UnaryOps.COS)
 
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return self.ret.const_like(-1).binary_op(BinaryOps.MUL, self.x.unary_op(UnaryOps.SIN)).binary_op(BinaryOps.MUL, grad_output)

--- a/tinygrad/mlops.py
+++ b/tinygrad/mlops.py
@@ -43,6 +43,24 @@ class Exp(Function):
   def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
     return self.ret.binary_op(BinaryOps.MUL, grad_output)
 
+class Sin(Function):
+  def forward(self, x:LazyBuffer) -> LazyBuffer:
+    self.x = x
+    self.ret = x.unary_op(UnaryOps.SIN)
+    return self.ret
+
+  def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
+    return self.x.unary_op(UnaryOps.COS).binary_op(BinaryOps.MUL, grad_output)
+
+class Cos(Function):
+  def forward(self, x:LazyBuffer) -> LazyBuffer:
+    self.x = x
+    self.ret = x.unary_op(UnaryOps.COS)
+    return self.ret
+
+  def backward(self, grad_output:LazyBuffer) -> LazyBuffer:
+    return self.ret.const_like(-1).binary_op(BinaryOps.MUL, self.x.unary_op(UnaryOps.SIN)).binary_op(BinaryOps.MUL, grad_output)
+
 # ************* reduce ops *************
 
 class Sum(Function):

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -8,7 +8,7 @@ from tinygrad.runtime.lib import RawBuffer, RawConst
 
 # these are the llops your accelerator must implement, along with toCpu
 # the Enum class doesn't work with mypy, this is static. sorry it's ugly
-class UnaryOps(Enum): NOOP = auto(); EXP = auto(); LOG = auto(); CAST = auto() # noqa: E702
+class UnaryOps(Enum): NOOP = auto(); EXP = auto(); LOG = auto(); CAST = auto(); SIN = auto(); COS = auto(); # noqa: E702
 class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto() # noqa: E702
 class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
 class FusedOps(Enum): MULACC = auto() # noqa: E702

--- a/tinygrad/runtime/ops_cpu.py
+++ b/tinygrad/runtime/ops_cpu.py
@@ -27,7 +27,7 @@ def einsum_mulacc(einsum, get_strides, expand):
   return mulacc
 
 numpy_fxn_for_op: Dict[Op, Callable] = {**base_fxn_for_op, **{
-  UnaryOps.NOOP: lambda x: np.require(x, requirements='C'), UnaryOps.EXP: np.exp, UnaryOps.LOG: np.log, UnaryOps.CAST: lambda x,y: x.astype(y.np),
+  UnaryOps.NOOP: lambda x: np.require(x, requirements='C'), UnaryOps.EXP: np.exp, UnaryOps.LOG: np.log, UnaryOps.CAST: lambda x,y: x.astype(y.np), UnaryOps.SIN: np.sin, UnaryOps.COS: np.cos,
   BinaryOps.MAX: np.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).astype(np.float32),
   MovementOps.PERMUTE: lambda x, order: x.transpose(order), MovementOps.PAD: np.pad, MovementOps.EXPAND: np.broadcast_to,
   MovementOps.STRIDE: lambda x, arg: x[tuple(slice(None, None, i) for i in arg)],

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -9,7 +9,7 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if geten
 type_map = {torch.float16: dtypes.float16, torch.float32: dtypes.float32}
 
 torch_fxn_for_op: Dict[Op, Callable] = {**base_fxn_for_op, **{
-  UnaryOps.NOOP: lambda x: x.contiguous(), UnaryOps.EXP: lambda x: x.exp(), UnaryOps.LOG: lambda x: x.log(), UnaryOps.CAST: lambda x,y: x.type(next(k for k,v in type_map.items() if v==y)),
+  UnaryOps.NOOP: lambda x: x.contiguous(), UnaryOps.EXP: lambda x: x.exp(), UnaryOps.LOG: lambda x: x.log(), UnaryOps.CAST: lambda x,y: x.type(next(k for k,v in type_map.items() if v==y)), UnaryOps.SIN: lambda x: x.sin(), UnaryOps.COS: lambda: x: x.cos()
   BinaryOps.MAX: torch.maximum, BinaryOps.CMPEQ: lambda x,y: (x==y).float(),
   MovementOps.PAD: lambda x, padding: torch.nn.functional.pad(x, [item for sublist in padding[::-1] for item in sublist]),
   FusedOps.MULACC: einsum_mulacc(lambda s,a,b: torch.einsum(s, a.float(), b.float()).type(torch.promote_types(a.dtype, b.dtype)), lambda x: x.stride(), lambda x,s: x.expand(s)),

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -396,6 +396,8 @@ class Tensor:
   def log(self): return mlops.Log.apply(self)
   def exp(self): return mlops.Exp.apply(self)
   def relu(self): return mlops.Relu.apply(self)
+  def sin(self): return mlops.Sin.apply(self)
+  def cos(self): return mlops.Cos.apply(self)
 
   # ***** math functions (unary) *****
 


### PR DESCRIPTION
Small PR. Right now derivative is implemented as sin(x) = cos(x) and just calls cos(x) unary op (Vice versa). Potentially it can also be done as cos(x) = sin(pi/2-x), but this adds extra operations. 