### PR TITLE
Remove barrier in Metal matmul

### DIFF
--- a/extra/gemm/metal_matmul.py
+++ b/extra/gemm/metal_matmul.py
@@ -36,7 +36,6 @@ kernel void test(device float *a, device const float *data1, device const float 
   simdgroup_float8x8 A[4];
   simdgroup_float8x8 B[4];
   for (uint k = 0; k < {N}; k+=8) {{
-    threadgroup_barrier(mem_flags::mem_threadgroup);
     simdgroup_load(A[0], data1+k+{0*N}, {N}, ulong2(0, 0));
     simdgroup_load(A[1], data1+k+{8*N}, {N}, ulong2(0, 0));
     simdgroup_load(A[2], data1+k+{16*N}, {N}, ulong2(0, 0));


### PR DESCRIPTION
I saw a significant speedup in an untuned shader, when I removed the barrier:

```metal
    for (uint k_floor = 0; k_floor < K; k_floor += 8) {
      ushort k = 0;
      {
        WRITE_BLOCK(load, A, B, A_index, B_index, K, N)
      }
#undef WRITE_BLOCK
      A_index.x += 8;
      B_index.y += 8;
      
      inner_loop(A_value, B_value, C_value);
      
      // TODO: Do we really need a barrier here?
      simdgroup_barrier(mem_flags::mem_none);
    }
```

With the barrier:

```
MxNxKxDType: MFA ALU% vs MPS ALU%
MFA algorithm: gemm_simdgroup
tb_size: 4x1x4
sb_size: 24x8x24
tgb_size: 48x16x48

2023-05-22 15:19:04.744819-0400 MetalFlashAttention[20287:3209502] flock failed to lock list file (/var/folders/qn/86czb43d3pv03bfnxvb3x66h0000gn/C//com.apple.metal/31001/libraries.list): errno = 35
2023-05-22 15:19:04.744909-0400 MetalFlashAttention[20287:3209502] flock failed to lock list file (/var/folders/qn/86czb43d3pv03bfnxvb3x66h0000gn/C//com.apple.metal/31001/libraries1.list): errno = 35
96x96x32xF32: 0.182% vs 0.392%
Large square sizes:
1920x1920x1920xF32: 40.6% vs 77.4%
Mini-suite took 391 ms

Multiples of 384MN/48K:
384x384x48xF32: 5.2% vs 13.2%
768x384x96xF32: 12.6% vs 28.8%
384x384x912xF32: 29.6% vs 47.1%
768x768x720xF32: 34.3% vs 57.8%
384x1152x48xF32: 8.86% vs 23.6%
1152x384x144xF32: 18.7% vs 44.7%
Mini-suite took 125 ms
```

Without the barrier:

```
MxNxKxDType: MFA ALU% vs MPS ALU%
MFA algorithm: gemm_simdgroup
tb_size: 4x1x4
sb_size: 24x8x24
tgb_size: 48x16x48

2023-05-22 15:20:13.332941-0400 MetalFlashAttention[20319:3210831] flock failed to lock list file (/var/folders/qn/86czb43d3pv03bfnxvb3x66h0000gn/C//com.apple.metal/31001/libraries.list): errno = 35
2023-05-22 15:20:13.333048-0400 MetalFlashAttention[20319:3210831] flock failed to lock list file (/var/folders/qn/86czb43d3pv03bfnxvb3x66h0000gn/C//com.apple.metal/31001/libraries1.list): errno = 35
96x96x32xF32: 0.388% vs 0.663%
Large square sizes:
1920x1920x1920xF32: 47.3% vs 77.3%
Mini-suite took 369 ms

Multiples of 384MN/48K:
384x384x48xF32: 5.31% vs 13.2%
768x384x96xF32: 13% vs 29%
384x384x912xF32: 31.1% vs 46.8%
768x768x720xF32: 40.6% vs 57.7%
384x1152x48xF32: 8.82% vs 23.5%
1152x384x144xF32: 19.9% vs 45.1%
Mini-suite took 114 ms
```