### PR TITLE
Fix PytestCollectionWarning when running tests

### DIFF
--- a/test/unit/test_flopcounter.py
+++ b/test/unit/test_flopcounter.py
@@ -5,6 +5,7 @@ from tinygrad.ops import LazyOp, BinaryOps, ReduceOps, get_lazyop_info
 from tinygrad.helpers import DType, dtypes
 
 class TestBuffer(NamedTuple):
+  __test__ = False # To prevent pytest from collecting this as a test
   shape: Tuple[int, ...]
   dtype: DType
 


### PR DESCRIPTION
Ran all the tests, got a warning, checked stack overflow to see how to get rid of it :smile: 
Seems like pytest thought that `TestBuffer`  was supposed to be a test and was complaining about it, so setting that variable to False tells pytest to not treat it as a test. 

I get a few other warnings about overflows as well