### PR TITLE
One liner pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This project is maintained by [tiny corp](https://tinygrad.org/).
 ### Installation
 
 ```bash
+python3 -m pip install git+https://git@github.com/geohot/tinygrad.git
+
+# or
 git clone https://github.com/geohot/tinygrad.git
 cd tinygrad
 python3 -m pip install -e .


### PR DESCRIPTION
For non-contributors sufficient to not clone the repo.
Works also with editable mode this way:
```bash
python3 -m pip install -e git+https://git@github.com/geohot/tinygrad.git#egg=tinygrad
```