### PR TITLE
Optimizations in `symbolic.py`

### DIFF
--- a/test/unit/test_symbolic.py
+++ b/test/unit/test_symbolic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import unittest
-from tinygrad.shape.symbolic import Variable, NumNode, Node
+from tinygrad.shape.symbolic import MulNode, SumNode, Variable, NumNode, Node
 
 class TestSymbolic(unittest.TestCase):
   def helper_test_variable(self, v, n, m, s):
@@ -177,6 +177,9 @@ class TestSymbolic(unittest.TestCase):
 
   def test_sum_combine_num(self):
     self.helper_test_variable(Variable.sum([Variable.num(29), Variable("a", 0, 10), Variable.num(-23)]), 6, 16, "(6+a)")
+
+  def test_sum_num_hoisted_and_factors_cancel_out(self):
+    self.helper_test_variable(Variable.sum([Variable("a", 0, 1) * -4 + 1, Variable("a", 0, 1) * 4]), 1, 1, "1")
 
   def test_div_factor(self):
     self.helper_test_variable(Variable.sum([Variable.num(-40), Variable("a", 0, 10)*2, Variable("b", 0, 10)*40]) // 40, -1, 9, "(-1+b)")


### PR DESCRIPTION
# Summary

This diff modifies the `symbolic.py` file mainly to not rely on calls to the expensive `isinstance` by leveraging inheritance to dispatch the correct routines instead.

Changelog:
1. Get rid of `create_opnode` because it had a massive if-else ladder of checking the class type, replace by computing minmax bounds at init time of `OpNode`
2. Move logic for `__mul__`, `__floordiv__`, and `__mod__` inside each opcode
3. Rewrite the `Variable.sum` simplification routine to avoid having to order the list of `MulNodes` before grouping them

# Test Plan

## Correctness

Local test suite is passing. Wait for CI

## Performance

`test_net_speed.py` benchmark:

### Before

```
test/test_net_speed.py::TestConvSpeed::test_mnist torch forward pass:  19.031 ms
torch backward pass: 19.433 ms
         475052 function calls (464120 primitive calls) in 280.306 seconds

   Ordered by: internal time
   List reduced from 593 to 119 due to restriction <0.2>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   132929   20.959    0.000   20.959    0.000 {built-in method builtins.isinstance}
11513/11458   14.423    0.001   34.881    0.003 symbolic.py:28(__mul__)
     8384    9.673    0.001   15.625    0.002 symbolic.py:170(create_opnode)
9207/6134    7.457    0.001   13.082    0.002 symbolic.py:13(render)
     1142    6.776    0.006   78.155    0.068 symbolic.py:109(sum)
        5    6.689    1.338    6.921    1.384 ops_gpu.py:44(_copyin)
    13180    5.426    0.000    7.322    0.001 symbolic.py:118(<lambda>)
      791    5.350    0.007   45.426    0.057 shapetracker.py:185(reshape)
       16    5.255    0.328    5.255    0.328 {built-in method io.open}
   910/20    4.914    0.005  175.367    8.768 lazy.py:107(realize)
     1845    4.770    0.003    7.997    0.004 shapetracker.py:33(__init__)
     1142    4.062    0.004   31.675    0.028 symbolic.py:126(<listcomp>)
1200/1035    3.753    0.003   79.001    0.076 lazy.py:187(movement_op)
1933/1655    3.464    0.002    7.902    0.005 symbolic.py:43(__floordiv__)
     9006    3.377    0.000    3.944    0.000 symbolic.py:156(create_node)
     7998    3.338    0.000    4.493    0.001 symbolic.py:123(<lambda>)
     7998    3.330    0.000   11.514    0.001 symbolic.py:126(<genexpr>)
     5893    3.289    0.001   10.449    0.002 symbolic.py:20(__eq__)
     2284    3.258    0.001    9.107    0.004 helpers.py:15(<listcomp>)
    11150    3.227    0.000    3.227    0.000 shapetracker.py:34(<genexpr>)
  1680/80    3.195    0.002    9.183    0.115 dataclasses.py:1280(_asdict_inner)
      520    2.986    0.006   41.359    0.080 shapetracker.py:61(expr_node)
17256/15872    2.974    0.000    3.466    0.000 {built-in method builtins.len}

forward pass:  16.695 ms, 0.88x off baseline 19.031 ms
backward pass: 40.735 ms, 2.10x off baseline 19.433 ms
```

### After

```
test/test_net_speed.py::TestConvSpeed::test_mnist torch forward pass:  19.160 ms
torch backward pass: 20.129 ms
         361819 function calls (351235 primitive calls) in 238.417 seconds

   Ordered by: internal time
   List reduced from 592 to 118 due to restriction <0.2>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1142   12.107    0.011   42.137    0.037 symbolic.py:59(sum)
        5   10.644    2.129   10.822    2.164 ops_gpu.py:44(_copyin)
    55789    8.929    0.000    8.929    0.000 {built-in method builtins.isinstance}
    11876    7.517    0.001   18.580    0.002 symbolic.py:30(__mul__)
8036/4978    6.466    0.001   11.452    0.002 symbolic.py:15(render)
        4    6.166    1.541    6.166    1.541 {built-in method posix.unlink}
    10086    5.767    0.001    9.687    0.001 symbolic.py:120(__init__)
       16    5.684    0.355    5.684    0.355 {built-in method io.open}
      791    5.028    0.006   33.577    0.042 shapetracker.py:185(reshape)
     1845    4.653    0.003    7.756    0.004 shapetracker.py:33(__init__)
   910/20    4.559    0.005  143.841    7.192 lazy.py:107(realize)
        4    4.387    1.097    4.387    1.097 {built-in method posix.open}
     9488    3.644    0.000    3.644    0.000 symbolic.py:145(get_bounds)
1200/1035    3.622    0.003   66.761    0.065 lazy.py:187(movement_op)
     9470    3.112    0.000    3.647    0.000 symbolic.py:114(create_node)
    11150    3.103    0.000    3.103    0.000 shapetracker.py:34(<genexpr>)
     1142    3.086    0.003   12.706    0.011 symbolic.py:84(<listcomp>)
  1680/80    3.020    0.002    8.799    0.110 dataclasses.py:1280(_asdict_inner)
     1475    2.975    0.002   49.009    0.033 shapetracker.py:230(movement_op)
     6610    2.927    0.000    4.568    0.001 {built-in method builtins.sum}
     
forward pass:  15.501 ms, 0.81x off baseline 19.160 ms
backward pass: 32.857 ms, 1.63x off baseline 20.129 ms
```

We save roughly `80,000` calls to `isinstance` from `132,929` to `55,789` **(-58%)**. 

Forward pass on average **9%** faster
Backward pass on average **18%** faster

# Future iterations

There's still `isinstance` in a _lot_ of places in the codebase, might be worth trying to remove as many as possible. Would be down to work on that.

I also had some optimizations on `shapetracker.py` but it's probably better I submit them in a separate PR
