### PR TITLE
Promote Embedding to `nn`

### DIFF
--- a/models/rnnt.py
+++ b/models/rnnt.py
@@ -1,6 +1,6 @@
 from tinygrad.tensor import Tensor
 from tinygrad.jit import TinyJit
-from tinygrad.nn import Linear
+from tinygrad.nn import Linear, Embedding
 import numpy as np
 from extra.utils import download_file
 from pathlib import Path
@@ -169,22 +169,6 @@ class Encoder:
     x, x_lens = self.stack_time(x, x_lens)
     x, _ = self.post_rnn(x, None)
     return x.transpose(0, 1), x_lens
-
-
-class Embedding:
-  def __init__(self, vocab_size: int, embed_size: int):
-    self.vocab_size = vocab_size
-    self.vocab_counter = Tensor(np.arange(vocab_size, dtype=np.float32), requires_grad=False)
-    self.weight = Tensor.scaled_uniform(vocab_size, embed_size)
-
-  def __call__(self, idx: Tensor) -> Tensor:
-    oha = []
-    for i in range(idx.shape[0]):
-      ohba = []
-      for j in range(idx.shape[1]):
-        ohba.append((self.vocab_counter == idx[i, j]).realize())
-      oha.append(Tensor.stack(ohba).realize())
-    return Tensor.stack(oha) @ self.weight
 
 
 class Prediction:

--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -81,12 +81,12 @@ class TestInferenceMinKernels(unittest.TestCase):
       out.realize()
 
   def test_llama(self):
-    from examples.llama import Transformer, onehot_encode
+    from examples.llama import Transformer
     args_tiny = {"dim": 512, "multiple_of": 256, "n_heads": 8, "n_layers": 4, "norm_eps": 1e-05, "vocab_size": 1000}
     model = Transformer(**args_tiny)
     for p in get_parameters(model): p.assign(np.zeros(p.shape, dtype=p.dtype.np))
-    with CLCache(85):
-      model(onehot_encode([1,2,3,4], vocab_size=args_tiny['vocab_size']), 0).realize()
+    with CLCache(86):
+      model(Tensor([[1,2,3,4]]), 0).realize()
 
 @unittest.skipUnless(Device.DEFAULT == "GPU", "Not Implemented")
 class TestOptBinOp(unittest.TestCase):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+from tinygrad.jit import TinyJit
 from tinygrad.tensor import Tensor, Device
 from tinygrad.nn import BatchNorm2d, Conv2d, Linear, GroupNorm, LayerNorm, LayerNorm2d, Embedding
 import torch
@@ -166,6 +167,18 @@ class TestNN(unittest.TestCase):
     torch_x = torch.tensor(x.cpu().numpy().astype(np.int32))
     torch_z = torch_layer(torch_x)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
+
+    # test with jit enabled
+    @TinyJit
+    def layer_jit(x):
+        return layer(x).realize()
+
+    for _ in range(3):
+        x = Tensor(np.random.randint(0, VS, (B, T)).astype(np.float32))
+        z = layer_jit(x)
+        torch_x = torch.tensor(x.cpu().numpy().astype(np.int32))
+        torch_z = torch_layer(torch_x)
+        np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
 
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -171,14 +171,14 @@ class TestNN(unittest.TestCase):
     # test with jit enabled
     @TinyJit
     def layer_jit(x):
-        return layer(x).realize()
+      return layer(x).realize()
 
     for _ in range(3):
-        x = Tensor(np.random.randint(0, VS, (B, T)).astype(np.float32))
-        z = layer_jit(x)
-        torch_x = torch.tensor(x.cpu().numpy().astype(np.int32))
-        torch_z = torch_layer(torch_x)
-        np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
+      x = Tensor(np.random.randint(0, VS, (B, T)).astype(np.float32))
+      z = layer_jit(x)
+      torch_x = torch.tensor(x.cpu().numpy().astype(np.int32))
+      torch_z = torch_layer(torch_x)
+      np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
 
 
 if __name__ == '__main__':

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -2,7 +2,7 @@
 import unittest
 import numpy as np
 from tinygrad.tensor import Tensor, Device
-from tinygrad.nn import BatchNorm2d, Conv2d, Linear, GroupNorm, LayerNorm, LayerNorm2d
+from tinygrad.nn import BatchNorm2d, Conv2d, Linear, GroupNorm, LayerNorm, LayerNorm2d, Embedding
 import torch
 
 class TestNN(unittest.TestCase):
@@ -149,6 +149,24 @@ class TestNN(unittest.TestCase):
     torch_x = torch.tensor(x.cpu().numpy())
     torch_z = torch_layer(torch_x.permute(0,2,3,1)).permute(0,3,1,2)
     np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=5e-3, rtol=5e-3)
+
+  def test_embedding(self):
+    B, T, C, VS = 4, 10, 20, 28
+
+    # create in tinygrad
+    layer = Embedding(VS, C)
+
+    with torch.no_grad():
+      torch_layer = torch.nn.Embedding(VS, C).eval()
+      torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
+
+    # test
+    x = Tensor(np.random.randint(0, VS, (B, T)).astype(np.float32))
+    z = layer(x)
+    torch_x = torch.tensor(x.cpu().numpy().astype(np.int32))
+    torch_z = torch_layer(torch_x)
+    np.testing.assert_allclose(z.numpy(), torch_z.detach().numpy(), atol=1e-8, rtol=1e-8)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -84,14 +84,9 @@ class LayerNorm2d(LayerNorm):
 
 class Embedding:
   def __init__(self, vocab_size:int, embed_size:int):
-    self.vocab_counter = Tensor.arange(vocab_size, requires_grad=False)
+    self.vocab_size = vocab_size
     self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
 
   def __call__(self, idx:Tensor) -> Tensor:
-    oha = []
-    for i in range(idx.shape[0]):
-      ohba = []
-      for j in range(idx.shape[1]):
-        ohba.append((self.vocab_counter == idx[i, j]).realize())
-      oha.append(Tensor.stack(ohba).realize())
-    return Tensor.stack(oha) @ self.weight
+    vocab_counter = Tensor.arange(self.vocab_size, requires_grad=False).reshape(1, 1, self.vocab_size).expand(*idx.shape, self.vocab_size)
+    return (vocab_counter == idx.unsqueeze(2).expand(*idx.shape, self.vocab_size)) @ self.weight

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -81,3 +81,17 @@ class LayerNorm:
 
 class LayerNorm2d(LayerNorm):
   def __call__(self, x): return super().__call__(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
+
+class Embedding:
+  def __init__(self, vocab_size:int, embed_size:int):
+    self.vocab_counter = Tensor.arange(vocab_size, requires_grad=False)
+    self.weight = Tensor.glorot_uniform(vocab_size, embed_size)
+
+  def __call__(self, idx:Tensor) -> Tensor:
+    oha = []
+    for i in range(idx.shape[0]):
+      ohba = []
+      for j in range(idx.shape[1]):
+        ohba.append((self.vocab_counter == idx[i, j]).realize())
+      oha.append(Tensor.stack(ohba).realize())
+    return Tensor.stack(oha) @ self.weight


### PR DESCRIPTION
Embedding is used in a few models now (RNN-T and LLaMA) and will be used in BERT and other language models as well. So we should promote it to nn.

Rewrote it to no longer rely on numpy which means that this can now be JIT compiled.

Added a test to see if it matches torch.