### PR TITLE
Don't collapse dimensions during batched matmul (FIX #799)

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -186,8 +186,12 @@ class TestOps(unittest.TestCase):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_matmul(self):
     helper_test_op([(64), (64,99)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+
+  @unittest.skipIf(IMAGE>0, "no batched matmul on images")
   def test_matmul_batched(self):
     helper_test_op([(3), (1,3,3,5)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+
+  @unittest.skipIf(IMAGE>0, "no batched matmul on images")
   def test_matmul_batched_vector(self):
     helper_test_op([(4,3), (1,3,3,5)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_gemm(self):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -186,6 +186,10 @@ class TestOps(unittest.TestCase):
     helper_test_op([(4), (4,4)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_matmul(self):
     helper_test_op([(64), (64,99)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+  def test_matmul_batched(self):
+    helper_test_op([(3), (1,3,3,5)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+  def test_matmul_batched_vector(self):
+    helper_test_op([(4,3), (1,3,3,5)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_gemm(self):
     helper_test_op([(64,64), (64,64)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-3)
   def test_broadcastdot(self):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -388,7 +388,8 @@ class Tensor:
   def dot(self, w:Tensor) -> Tensor:
     x = self.reshape(*self.shape[0:-1], 1, self.shape[-1])
     w = w.reshape(*w.shape[0:-2], 1, w.shape[-2], w.shape[-1]).transpose(-1, -2)
-    return (x*w).sum(-1).reshape(*x.shape[0:-2], -1)
+    r = (x*w).sum(-1)
+    return r.reshape((*r.shape[:-2], r.shape[-1]) if len(self.shape) == 1 else r.shape)
 
   # ***** mlops (unary) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -389,7 +389,7 @@ class Tensor:
     x = self.reshape(*self.shape[0:-1], 1, self.shape[-1])
     w = w.reshape(*w.shape[0:-2], 1, w.shape[-2], w.shape[-1]).transpose(-1, -2)
     r = (x*w).sum(-1)
-    return r.reshape((*r.shape[:-2], r.shape[-1]) if len(self.shape) == 1 else r.shape)
+    return r.reshape((*r.shape[:-2], r.shape[-1])) if len(self.shape) == 1 else r
 
   # ***** mlops (unary) *****
 


### PR DESCRIPTION
The reshape should only be necessary when multiplying a vector with a matrix - this fixes batched matmul.