### PR TITLE
Ability to exclude cl devices from being used

### DIFF
--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -23,7 +23,7 @@ class _CL:
   def __init__(self):
     platforms: List[List[cl.Device]] = [y for y in ([x.get_devices(device_type=cl.device_type.GPU) for x in cl.get_platforms()] + [x.get_devices(device_type=cl.device_type.CPU) for x in cl.get_platforms()]) if len(y)]
     if DEBUG >= 1: print(f"using {platforms[getenv('CL_PLATFORM', 0)]}")
-    self.cl_ctx: cl.Context = cl.Context(devices=platforms[getenv('CL_PLATFORM', 0)])
+    self.cl_ctx: cl.Context = cl.Context(devices=[x for x in platforms[getenv('CL_PLATFORM', 0)] if x.name not in getenv('CL_EXCLUDE', "").split(",")])
     self.cl_queue: List[cl.CommandQueue] = [cl.CommandQueue(self.cl_ctx, device=device, properties=cl.command_queue_properties.PROFILING_ENABLE) for device in self.cl_ctx.devices]
   def synchronize(self):
     for q in self.cl_queue: q.finish()


### PR DESCRIPTION
The motivation for this is that on certain devices with multiple different gpus like a laptop with a dedicated and intergrated gpu, it may be preferable to prevent tinygrad from using a specific gpu like the intergrated one.

Specifically for me with a gfx1032 and a gfx1035, the gfx1035 crashes the kernel driver when used.

To fix this we allow the exclusion of gpu devices by name with the environment variable `CL_EXCLUDE`.