### PR TITLE
Put temporary file in the same directory as the destination file

### DIFF
--- a/extra/utils.py
+++ b/extra/utils.py
@@ -21,17 +21,18 @@ def fetch(url):
     return f.read()
 
 def download_file(url, fp, skip_if_exists=True):
-  import requests, os
+  import requests, os, pathlib
   if skip_if_exists and os.path.isfile(fp) and os.stat(fp).st_size > 0:
     return
   r = requests.get(url, stream=True)
   assert r.status_code == 200
   progress_bar = tqdm(total=int(r.headers.get('content-length', 0)), unit='B', unit_scale=True, desc=url)
-  with tempfile.NamedTemporaryFile(delete=False) as f:
+  with tempfile.NamedTemporaryFile(dir=pathlib.Path(fp).parent, delete=False) as f:
     for chunk in r.iter_content(chunk_size=16384):
       progress_bar.update(f.write(chunk))
     f.close()
     os.rename(f.name, fp)
+
 
 def my_unpickle(fb0):
   key_prelookup = defaultdict(list)


### PR DESCRIPTION
On Linux or maybe more POSIX systems `os.rename` will fail if the source and destination are on different filesystems.

~~For me this is the case as the `NamedTemporaryFile` would be put somewhere under `/run` which is mounted as a tmpfs.~~

~~`shutil.move` does not have this limitation.~~

Edit: This now puts the temporary file in the same directory as the destination which allows `os.rename` to work.