### PR TITLE
Batchnorm2d fixed running_var

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -46,7 +46,6 @@ class TestNN(unittest.TestCase):
 
     np.testing.assert_allclose(bn.running_mean.numpy(), tbn.running_mean.detach().numpy(), rtol=1e-5, atol=1e-6)
 
-    # TODO: this is failing
     np.testing.assert_allclose(bn.running_var.numpy(), tbn.running_var.detach().numpy(), rtol=1e-5)
 
   def test_batchnorm2d_training(self):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -47,7 +47,7 @@ class TestNN(unittest.TestCase):
     np.testing.assert_allclose(bn.running_mean.numpy(), tbn.running_mean.detach().numpy(), rtol=1e-5, atol=1e-6)
 
     # TODO: this is failing
-    # np.testing.assert_allclose(bn.running_var.numpy(), tbn.running_var.detach().numpy(), rtol=1e-5)
+    np.testing.assert_allclose(bn.running_var.numpy(), tbn.running_var.detach().numpy(), rtol=1e-5)
 
   def test_batchnorm2d_training(self):
     self.test_batchnorm2d(True)

--- a/tinygrad/nn/__init__.py
+++ b/tinygrad/nn/__init__.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union, Tuple
 from tinygrad.tensor import Tensor
+from tinygrad.helpers import prod
 
 class BatchNorm2d:
   def __init__(self, sz, eps=1e-5, affine=True, track_running_stats=True, momentum=0.1):
@@ -24,7 +25,7 @@ class BatchNorm2d:
       # NOTE: wow, this is done all throughout training in most PyTorch models
       if self.track_running_stats:
         self.running_mean.assign((1 - self.momentum) * self.running_mean + self.momentum * batch_mean.detach())
-        self.running_var.assign((1 - self.momentum) * self.running_var + self.momentum * batch_var.detach())
+        self.running_var.assign((1 - self.momentum) * self.running_var + self.momentum * prod(y.shape)/(prod(y.shape) - y.shape[1]) * batch_var.detach() )
         self.num_batches_tracked += 1
     else:
       batch_mean = self.running_mean


### PR DESCRIPTION
fixed running_var of BatchNorm2d where a test did not match pytorch's running_var.


BatchNorm2d is now implemented in the same way as pytorch, using the biased variance estimator for training and the unbiased estimator for inference.

Note that technically it would be more ideal to use the unbiased estimator for both training and inference, as mentioned here by Andrej Karpathy: 
https://www.youtube.com/watch?v=q8SA3rM6ckI&t=3920s