### PR TITLE
fixed TestCustomFunction

### DIFF
--- a/test/test_custom_function.py
+++ b/test/test_custom_function.py
@@ -16,8 +16,8 @@ def atan2_gpu(ret:LazyBuffer, a:LazyBuffer, b:LazyBuffer):
   assert a.device == "GPU" and b.device == "GPU", "gpu function requires GPUBuffers"
   assert a.dtype == b.dtype and a.dtype == dtypes.float32, "gpu function only supports float32"
   ret.realized = Device[ret.device].buffer(prod(ret.shape), ret.dtype)
-  ASTRunner("atan2", """
-    __kernel void atan2(global float *c, global float *a, global float *b) {
+  ASTRunner("atan2_gpu", """
+    __kernel void atan2_gpu(global float *c, global float *a, global float *b) {
       int idx = get_global_id(0);
       c[idx] = atan2(a[idx], b[idx]);
     }""", global_size=[prod(ret.shape)]).build(Device[ret.device].runtime).exec([ret, a, b])


### PR DESCRIPTION
The following error was thrown while running the TestCustomFunction unit test, even adding an overloadable attribute didn't fix the problem, hence the PR.
```
E       pyopencl._cl.RuntimeError: clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE
E       
E       Build on <pyopencl.Device 'NVIDIA GeForce RTX 3050 Ti Laptop GPU' on 'NVIDIA CUDA' at 0x55b9b98c2cc0>:
E       
E       <kernel>:2:19: error: overloaded function 'atan2' must have the 'overloadable' attribute
E           __kernel void atan2(global float *c, global float *a, global float *b) {
E                         ^
E       cl_kernel.h:1879:27: note: previous overload of function is here
E       double16 __OVERLOADABLE__ atan2(double16, double16); 
E                                 ^
E       
E       (options: -I /home/tchikmagalore/projects/12-tinygrad/env/lib/python3.10/site-packages/pyopencl/cl)
E       (source saved as /tmp/tmp4s6bt1mv.cl)
../env/lib/python3.10/site-packages/pyopencl/__init__.py:584: RuntimeError
```