### PR TITLE
Add LAMB optimizer

### DIFF
--- a/test/external/external_test_optim.py
+++ b/test/external/external_test_optim.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+import unittest
+import numpy as np
+import tensorflow as tf
+import tensorflow_addons as tfa
+from tinygrad.tensor import Tensor
+from tinygrad.nn.optim import LAMB
+
+np.random.seed(1337)
+x_init = np.random.randn(1,4).astype(np.float32)
+W_init = np.random.randn(4,4).astype(np.float32)
+m_init = np.random.randn(1,4).astype(np.float32)
+
+class TinyNet():
+  def __init__(self):
+    self.x = Tensor(x_init.copy(), requires_grad=True)
+    self.W = Tensor(W_init.copy(), requires_grad=True)
+    self.m = Tensor(m_init.copy())
+
+  def forward(self):
+    out = self.x.matmul(self.W).relu()
+    out = out.log_softmax(1)
+    out = out.mul(self.m).add(self.m).sum()
+    return out
+
+class TinyNetTF():
+  def __init__(self):
+    self.x = tf.Variable(x_init.copy(), trainable=True)
+    self.W = tf.Variable(W_init.copy(), trainable=True)
+    self.m = tf.constant(m_init.copy())
+
+  def forward(self):
+    out = tf.matmul(self.x, self.W)
+    out = tf.nn.relu(out)
+    out = tf.nn.log_softmax(out, axis=1)
+    out = tf.multiply(out, self.m) + self.m
+    out = tf.reduce_sum(out)
+    return out
+
+def step(optim, steps=1, kwargs={}):
+  net = TinyNet()
+  optim = optim([net.x, net.W], **kwargs)
+  for _ in range(steps):
+    out = net.forward()
+    optim.zero_grad()
+    out.backward()
+    optim.step()
+  return net.x.detach().numpy(), net.W.detach().numpy()
+
+def step_tf(optim, steps=1, kwargs={}):
+  net = TinyNetTF()
+  optim = optim(**kwargs)
+  for _ in range(steps):
+    with tf.GradientTape() as tape:
+      out = net.forward()
+    grads = tape.gradient(out, [net.x, net.W])
+    optim.apply_gradients(zip(grads, [net.x, net.W]))
+  return net.x.numpy(), net.W.numpy()
+
+class ExternalTestOptim(unittest.TestCase):
+  def _test_optim(self, tinygrad_optim, tensorflow_optim, steps, opts, atol, rtol):
+    for x,y in zip(step(tinygrad_optim, steps, kwargs=opts),
+                   step_tf(tensorflow_optim, steps, kwargs=opts)):
+      np.testing.assert_allclose(x, y, atol=atol, rtol=rtol)
+
+  def _test_lamb(self, steps, opts, atol, rtol): self._test_optim(LAMB, tfa.optimizers.LAMB, steps, opts, atol, rtol)
+
+  def test_lamb(self): self._test_lamb(1, {'lr': 0.001}, 1e-5, 0)
+  def test_lamb_high_lr(self): self._test_lamb(1, {'lr': 10}, 1e-5, 1e-5)
+
+  def test_multistep_lamb(self): self._test_lamb(10, {'lr': 0.001}, 1e-5, 0)
+  def test_multistep_lamb_high_lr(self): self._test_lamb(10, {'lr': 10}, 1e-5, 3e-4)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -78,7 +78,8 @@ class LAMB(Optimizer):
       up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
       r1 = t.detach().square().sum().sqrt()
       r2 = up.square().sum().sqrt()
-      t.assign(t.detach() - self.lr * (1 if r1 == 0 or r2 == 0 or self.adam else r1 / r2) * up)
+      r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0) if not self.adam else 1.0
+      t.assign(t.detach() - self.lr * r * up)
     self.realize([self.t] + self.m + self.v)
 
 def get_state_dict(obj, prefix:str='') -> Dict[str, Tensor]:

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -59,6 +59,28 @@ class AdamW(Optimizer):
 
 def Adam(params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8): return AdamW(params, lr, b1, b2, eps, 0.0)
 
+class LAMB(Optimizer):
+  def __init__(self, params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, wd=0.0, adam=False):
+    super().__init__(params)
+    self.lr, self.b1, self.b2, self.eps, self.wd, self.adam, self.t = lr, b1, b2, eps, wd, adam, Tensor([0], requires_grad=False).realize()
+    self.m = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
+    self.v = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
+
+  def step(self) -> None:
+    self.t.assign(self.t + 1).realize()
+    for i, t in enumerate(self.params):
+      assert t.grad is not None
+      g = t.grad.realize()
+      self.m[i].assign(self.b1 * self.m[i] + (1.0 - self.b1) * g).realize()
+      self.v[i].assign(self.b2 * self.v[i] + (1.0 - self.b2) * (g * g)).realize()
+      m_hat = self.m[i] / (1.0 - self.b1**self.t)
+      v_hat = self.v[i] / (1.0 - self.b2**self.t)
+      up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
+      r1 = t.detach().square().sum().sqrt()
+      r2 = up.square().sum().sqrt()
+      t.assign(t.detach() - self.lr * (1 if r1 == 0 or r2 == 0 or self.adam else r1 / r2) * up)
+    self.realize([self.t] + self.m + self.v)
+
 def get_state_dict(obj, prefix:str='') -> Dict[str, Tensor]:
   if isinstance(obj, Tensor): return {prefix.strip('.'):obj}
   if hasattr(obj, '__dict__'): return get_state_dict(obj.__dict__, prefix)


### PR DESCRIPTION
This is the first in what will hopefully be a series of prs to get RNN-T training working.

This adds the [LAMB optimizer](https://arxiv.org/abs/1904.00962) based on the official tensorflow implementation [here](https://github.com/tensorflow/addons/blob/master/tensorflow_addons/optimizers/lamb.py).

I'm not sure what the best way to test this is as pytorch doesn't have LAMB implemented and the implementations that I could find are either [CUDA specific](https://nvidia.github.io/apex/_modules/apex/optimizers/fused_lamb.html) or [broken](https://github.com/jettify/pytorch-optimizer/issues/226). So thats why this is draft for now.

I have tested this on training a small net on MNIST and it does work.

It should also be possible to rewrite AdamW and Adam as functions of LAMB if we wanted to save some lines.