### PR TITLE
Fix missing path configs to test example models 

### DIFF
--- a/test/extra/syspathcfg.py
+++ b/test/extra/syspathcfg.py
@@ -1,0 +1,5 @@
+import os 
+import sys 
+
+TINYGRAD_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(TINYGRAD_DIR)

--- a/test/extra/test_lr_scheduler.py
+++ b/test/extra/test_lr_scheduler.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import unittest
+import syspathcfg
 from tinygrad.tensor import Tensor
 from tinygrad.nn.optim import Adam, get_parameters
 from extra.lr_scheduler import MultiStepLR, ReduceLROnPlateau, CosineAnnealingLR

--- a/test/extra/test_utils.py
+++ b/test/extra/test_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import io
 import unittest
+import syspathcfg
 from tinygrad.helpers import getenv
 from extra.utils import fetch, fake_torch_load_zipped
 from PIL import Image

--- a/test/models/syspathcfg.py
+++ b/test/models/syspathcfg.py
@@ -1,0 +1,5 @@
+import os 
+import sys 
+
+TINYGRAD_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(TINYGRAD_DIR)

--- a/test/models/test_mnist.py
+++ b/test/models/test_mnist.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import numpy as np
+import syspathcfg
 from tinygrad.tensor import Tensor, Device
 from tinygrad.nn import optim, BatchNorm2d
 from extra.training import train, evaluate

--- a/test/models/test_onnx.py
+++ b/test/models/test_onnx.py
@@ -5,6 +5,7 @@ import io
 import unittest
 import numpy as np
 import onnx
+import syspathcfg
 from extra.utils import fetch
 from extra.onnx import get_run_onnx
 from tinygrad.tensor import Tensor

--- a/test/models/test_train.py
+++ b/test/models/test_train.py
@@ -1,6 +1,7 @@
 import unittest
 import time
 import numpy as np
+import syspathcfg
 from tinygrad.nn import optim
 from tinygrad.tensor import Device
 from tinygrad.helpers import getenv


### PR DESCRIPTION
Add sys path config which is needed to run the example models.

Couldn't use extra.training/extra.utils/extra.* without explicit import in this dir. 