### PR TITLE
Fix ResNet Kernel Fusion (from bounty)

### DIFF
--- a/models/resnet.py
+++ b/models/resnet.py
@@ -18,11 +18,15 @@ class BasicBlock:
       ]
 
   def __call__(self, x):
-    out = self.bn1(self.conv1(x)).relu()
-    out = self.bn2(self.conv2(out))
-    out = out + x.sequential(self.downsample)
-    out = out.relu()
-    return out
+    y = x
+    x = self.bn1(self.conv1(x)).relu()
+    x = self.bn2(self.conv2(x))
+    if len(self.downsample) != 0:
+      y = y.sequential(self.downsample)
+      y.realize()
+    x = x + y
+    x = x.relu()
+    return x
 
 
 class Bottleneck:

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -18,15 +18,11 @@ class BasicBlock:
       ]
 
   def __call__(self, x):
-    y = x
-    x = self.bn1(self.conv1(x)).relu()
-    x = self.bn2(self.conv2(x))
-    if len(self.downsample) != 0:
-      y = y.sequential(self.downsample)
-      y.realize()
-    x = x + y
-    x = x.relu()
-    return x
+    out = self.bn1(self.conv1(x)).relu()
+    out = self.bn2(self.conv2(x))
+    out = out + x.sequential(self.downsample)
+    out = out.relu()
+    return out
 
 
 class Bottleneck:

--- a/models/resnet.py
+++ b/models/resnet.py
@@ -19,7 +19,7 @@ class BasicBlock:
 
   def __call__(self, x):
     out = self.bn1(self.conv1(x)).relu()
-    out = self.bn2(self.conv2(x))
+    out = self.bn2(self.conv2(out))
     out = out + x.sequential(self.downsample)
     out = out.relu()
     return out

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -33,7 +33,7 @@ def _ast_binaryops(self:LazyBuffer) -> LazyOp:
   # TODO: this can also support late fusion of BinaryOps, required for test_fold_conv_sgd
   psrcs: List[Tuple[LazyBuffer, LazyBuffer]] = [(k,x) for k,x in zip(real_srcs.keys(), map(get_movementroot_contiguous, real_srcs.keys())) if x.optype == ReduceOps and x.realized is None and prod(k.shape) == prod(x.shape) and len(x.children) <= 1 and len(k.children) <= 1]
   intermediate_shape: Tuple[int, ...] = self.shape
-  if len(psrcs) == 1 and MERGE_ONE_REDUCE_INTO_ELEMENTWISE:
+  if len(psrcs) >= 1 and MERGE_ONE_REDUCE_INTO_ELEMENTWISE:
     psrc = psrcs[0] # NOTE: right now we can't handle multiple, as we'd have to check for loop
     if psrc[1].optype == ReduceOps:
       top = _ast_reduceops(psrc[1])


### PR DESCRIPTION
After the fix, running `test_resnet` gives the following output:
```
cache: entering
cache: exiting with size 26 allowed 31
```
Before the current change, it was showing 29(instead of 26)
Please confirm if this is the correct fix.
