### PR TITLE
ONNX tests: exclude all unsupported filetype tests

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -53,10 +53,15 @@ backend_test.exclude('test_momentum_*')
 backend_test.exclude('test_eyelike_*')
 
 # we only support float32
-backend_test.exclude('test_add_uint8_*')
-backend_test.exclude('test_sub_uint8_*')
-backend_test.exclude('test_div_uint8_*')
-backend_test.exclude('test_mul_uint8_*')
+backend_test.exclude('uint8')
+backend_test.exclude('uint16')
+backend_test.exclude('uint32')
+backend_test.exclude('uint64')
+backend_test.exclude('int8')
+backend_test.exclude('int16')
+backend_test.exclude('float64')
+
+
 backend_test.exclude('test_pow_types_int*')
 backend_test.exclude('test_cast_*')
 backend_test.exclude('test_castlike_*')


### PR DESCRIPTION
There are ONXX tests for regular ops with a unsupported data types, such as test_max_uint8_cpu (int16, unint8, uint16, uint64, float64, ...). They don't get excluded by the current regex expressions.
I changed the exclusion regex, to include all tests containing these datatypes in their name, although I could write out all the tests in the format of test_\<OP\>_\<TYPE\>*, for clarity as well.
PASSED count is same pre & after the change (doesn't exclude any passing tests), but SKIPPED goes 1862 -> 1885.

Is a small change, but the first thing I noticed for getting to 0 FAILED. If some of these data types should work, I could look into making the tests PASS too.