### PR TITLE
Rewrite Adam/W as functions of LAMB

### DIFF
--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -50,20 +50,21 @@ class LAMB(Optimizer):
 
   def step(self) -> None:
     self.t.assign(self.t + 1).realize()
-    a = self.lr * ((1.0 - self.b2**self.t)**0.5) / (1.0 - self.b1**self.t)
     for i, t in enumerate(self.params):
       assert t.grad is not None
       g = t.grad.realize()
       self.m[i].assign(self.b1 * self.m[i] + (1.0 - self.b1) * g).realize()
       self.v[i].assign(self.b2 * self.v[i] + (1.0 - self.b2) * (g * g)).realize()
-      up = a * (self.m[i] / (self.v[i].sqrt() + self.eps)) + self.lr * self.wd * t.detach()
+      m_hat = self.m[i] / (1.0 - self.b1**self.t)
+      v_hat = self.v[i] / (1.0 - self.b2**self.t)
+      up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
       if not self.adam:
         r1 = t.detach().square().sum().sqrt()
         r2 = up.square().sum().sqrt()
         r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
       else:
         r = 1.0
-      t.assign(t.detach() - r * up)
+      t.assign(t.detach() - self.lr * r * up)
     self.realize([self.t] + self.m + self.v)
 
 def get_state_dict(obj, prefix:str='') -> Dict[str, Tensor]:

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -37,8 +37,8 @@ class SGD(Optimizer):
       t.assign(t.detach() - g * self.lr)
     self.realize(self.b)
 
+# LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
 def AdamW(params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8, wd=0.01): return LAMB(params, lr, b1, b2, eps, wd, adam=True)
-
 def Adam(params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-8): return LAMB(params, lr, b1, b2, eps, 0.0, adam=True)
 
 class LAMB(Optimizer):
@@ -50,21 +50,20 @@ class LAMB(Optimizer):
 
   def step(self) -> None:
     self.t.assign(self.t + 1).realize()
+    a = self.lr * ((1.0 - self.b2**self.t)**0.5) / (1.0 - self.b1**self.t)
     for i, t in enumerate(self.params):
       assert t.grad is not None
       g = t.grad.realize()
       self.m[i].assign(self.b1 * self.m[i] + (1.0 - self.b1) * g).realize()
       self.v[i].assign(self.b2 * self.v[i] + (1.0 - self.b2) * (g * g)).realize()
-      m_hat = self.m[i] / (1.0 - self.b1**self.t)
-      v_hat = self.v[i] / (1.0 - self.b2**self.t)
-      up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
+      up = a * (self.m[i] / (self.v[i].sqrt() + self.eps)) + self.lr * self.wd * t.detach()
       if not self.adam:
         r1 = t.detach().square().sum().sqrt()
         r2 = up.square().sum().sqrt()
         r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
       else:
         r = 1.0
-      t.assign(t.detach() - self.lr * r * up)
+      t.assign(t.detach() - r * up)
     self.realize([self.t] + self.m + self.v)
 
 def get_state_dict(obj, prefix:str='') -> Dict[str, Tensor]:


### PR DESCRIPTION
Follow up to https://github.com/geohot/tinygrad/pull/821

I'm not sure if we actually want this, it does save quite a few lines but it kind of loses the actual adam implementation, and it "adds" a test for the `adam` flag.

LAMB is essentially just LARS applied to Adam so if we just set the trust ratio to `1.0` its just Adam.

I'm not quite sure whats going on with METAL tho.