### PR TITLE
zeros_like use dtype if specified else default to tensor’s dtype

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -159,8 +159,13 @@ class TestTinygrad(unittest.TestCase):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:
       a = Tensor([1, 2, 3], dtype=datatype)
       b = Tensor.zeros_like(a)
-      assert a.dtype == b.dtype
-      assert a.shape == b.shape
+      assert a.dtype == b.dtype, f"a.dtype and b.dtype should be {datatype}"
+      assert a.shape == b.shape, f"shape mismatch (Tensor.zeros_like){a.shape} != (torch){b.shape}"
+
+    a = Tensor([1, 2, 3])
+    b = Tensor.zeros_like(a, dtype=dtypes.int8)
+    assert a.dtype != b.dtype and a.dtype == dtypes.float32 and b.dtype == dtypes.int8, "a.dtype should be float and b.dtype should be char"
+    assert a.shape == b.shape, f"shape mismatch (Tensor.zeros_like){a.shape} != (torch){b.shape}"
 
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -128,7 +128,7 @@ class Tensor:
   def ones(*shape, **kwargs): return Tensor([1], **kwargs).reshape([1]*len(shape)).expand(shape).contiguous()
 
   @staticmethod
-  def zeros_like(tensor, **kwargs): return Tensor.zeros(*tensor.shape, dtype=tensor.dtype, **kwargs)
+  def zeros_like(tensor, dtype:Optional[DType]=None, **kwargs): return Tensor.zeros(*tensor.shape, dtype=tensor.dtype if dtype is None else dtype, **kwargs)
 
   @staticmethod
   def empty(*shape, device=Device.DEFAULT, dtype:Optional[DType]=None, **kwargs):


### PR DESCRIPTION
Same behavior as in [pytorch](https://pytorch.org/docs/stable/generated/torch.zeros_like.html#torch.zeros_like), if `dtype` is specified when using `Tensor.zeros_like()` then create tensor with given `dtype`, otherwise create it with the tensor's `dtype`.