### PR TITLE
Fix ONNX slice tests for model version > 10

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -155,7 +155,7 @@ def get_run_onnx(onnx_model):
           i = i+s
         continue
       elif n.op_type == "Slice":
-        assert onnx_version == 10
+        assert onnx_version >= 10, f'only onnx version >= 10 supported for slice'
         arg = [(0,x) for x in inp[0].shape]
         starts, ends, axes = inp[1:4]
         assert axes.shape == (1,)


### PR DESCRIPTION
ONNX version can be any version, any version above 10 should have the same behaviour as version 10.
Slice can be implemented not only by version 10.

Fixes:

```
OnnxBackendNodeModelTest::test_slice_end_out_of_bounds_cpu
OnnxBackendNodeModelTest::test_slice_neg_cpu
OnnxBackendNodeModelTest::test_slice_start_out_of_bounds_cpu
```

This PR, however, does not fix that the whole slice implementation is buggy.
