### PR TITLE
Set Split Axis Default to 0

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -147,6 +147,7 @@ def get_run_onnx(onnx_model):
         if n.op_type == "Pow": ret = inp[0] ** inp[1]
       elif n.op_type == "Split":
         if 'split' not in opt: opt['split'] = [int(x) for x in safe_numpy(inp[1])]  # split can be a tensor
+        if 'axis' not in opt: opt['axis'] = 0
         i = 0
         arg = [(0,x) for x in inp[0].shape]
         for o,s in zip(n.output, opt['split']):


### PR DESCRIPTION
As specified in the documentation for onnx split:
https://github.com/onnx/onnx/blob/main/docs/Operators.md#attributes-98

Axis defaults to 0

---

Fixes two tests:

Before: `=== 329 failed, 497 passed, 1808 skipped, 2 warnings in 18.43s ===`
After: `=== 327 failed, 499 passed, 1808 skipped, 2 warnings in 19.11s ===`