### PR TITLE
Fix ONNX dropout and unify the implementation

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -97,8 +97,13 @@ def ConvTranspose(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_
   return X.conv_transpose2d(W, B, stride=strides, groups=group, dilation=dilations, padding=(pads[1], pads[3], pads[0], pads[2]) if pads is not None else 0)
 
 def Dropout(data, ratio=0.5, training_mode=False, seed=None):
+  class _FakeRNG:
+    def __init__(self, seed): self.seed = seed
+    def random(self, size=None, dtype=None):
+      ret = np.random.RandomState(self.seed).random(size)
+      return ret.astype(dtype) if dtype else ret
   Tensor.training = training_mode
-  if seed is not None: Tensor._rng = np.random.RandomState(seed)  # Need to use RandomState because of how test data gets generated.
+  if seed is not None: Tensor._rng = _FakeRNG(seed)  # Need to use RandomState because of how test data gets generated.
   ratio = ratio.lazydata.realize().toCPU()[0] if isinstance(ratio, Tensor) else ratio
   return data.dropout(p=ratio, return_mask=True)
 

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -97,13 +97,8 @@ def ConvTranspose(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_
   return X.conv_transpose2d(W, B, stride=strides, groups=group, dilation=dilations, padding=(pads[1], pads[3], pads[0], pads[2]) if pads is not None else 0)
 
 def Dropout(data, ratio=0.5, training_mode=False, seed=None):
-  class _FakeRNG:
-    def __init__(self, seed): self.seed = seed
-    def random(self, size=None, dtype=None):
-      ret = np.random.RandomState(self.seed).random(size)
-      return ret.astype(dtype) if dtype else ret
   Tensor.training = training_mode
-  if seed is not None: Tensor._rng = _FakeRNG(seed)  # Need to use RandomState because of how test data gets generated.
+  if seed is not None: Tensor.manual_seed(seed=seed, legacy=True)  # Need to use legacy RNG because of how test data gets generated.
   ratio = ratio.lazydata.realize().toCPU()[0] if isinstance(ratio, Tensor) else ratio
   return data.dropout(p=ratio, return_mask=True)
 

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -96,14 +96,11 @@ def Conv(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_shape=Non
 def ConvTranspose(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_shape=None, pads=None, strides=1):
   return X.conv_transpose2d(W, B, stride=strides, groups=group, dilation=dilations, padding=(pads[1], pads[3], pads[0], pads[2]) if pads is not None else 0)
 
-# TODO: copied from tensor.py
 def Dropout(data, ratio=0.5, training_mode=False, seed=None):
-  # TODO: mask should be a boolean tensor
-  if not training_mode: return data, Tensor.ones(*data.shape)  # if mask is requested as output it will contain all ones.
-  if seed is not None: Tensor.manual_seed(seed)
-  _mask : np.ndarray = np.asarray(Tensor._rng.binomial(1, 1.0-ratio, size=data.shape), dtype=data.dtype)
-  mask = Tensor(_mask, requires_grad=False, device=data.device)
-  return data * mask * (1/(1.0 - ratio)), mask
+  Tensor.training = training_mode
+  if seed is not None: Tensor._rng = np.random.RandomState(seed)  # Need to use RandomState because of how test data gets generated.
+  ratio = ratio.lazydata.realize().toCPU()[0] if isinstance(ratio, Tensor) else ratio
+  return data.dropout(p=ratio, return_mask=True)
 
 def Shape(data, end=None, start=0): return list(data.shape)[start:end]
 def Size(data): return prod(data.shape)

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -148,13 +148,12 @@ class TestTinygrad(unittest.TestCase):
 
   def test_random_fns_are_deterministic_with_seed(self):
     for random_fn in [Tensor.randn, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform]:
-      for legacy in [True, False, None]:
-        with self.subTest(msg=f"Tensor.{random_fn.__name__}.legacy_{legacy}"):
-          Tensor.manual_seed(1337) if legacy is None else Tensor.manual_seed(1337, legacy=legacy)
-          a = random_fn(10,10).realize()
-          Tensor.manual_seed(1337) if legacy is None else Tensor.manual_seed(1337, legacy=legacy)
-          b = random_fn(10,10).realize()
-          np.testing.assert_allclose(a.numpy(), b.numpy())
+      with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
+        Tensor.manual_seed(1337)
+        a = random_fn(10,10).realize()
+        Tensor.manual_seed(1337)
+        b = random_fn(10,10).realize()
+        np.testing.assert_allclose(a.numpy(), b.numpy())
 
   def test_zeros_like_has_same_dtype(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -148,12 +148,13 @@ class TestTinygrad(unittest.TestCase):
 
   def test_random_fns_are_deterministic_with_seed(self):
     for random_fn in [Tensor.randn, Tensor.uniform, Tensor.scaled_uniform, Tensor.glorot_uniform]:
-      with self.subTest(msg=f"Tensor.{random_fn.__name__}"):
-        Tensor.manual_seed(1337)
-        a = random_fn(10,10).realize()
-        Tensor.manual_seed(1337)
-        b = random_fn(10,10).realize()
-        np.testing.assert_allclose(a.numpy(), b.numpy())
+      for legacy in [True, False, None]:
+        with self.subTest(msg=f"Tensor.{random_fn.__name__}.legacy_{legacy}"):
+          Tensor.manual_seed(1337) if legacy is None else Tensor.manual_seed(1337, legacy=legacy)
+          a = random_fn(10,10).realize()
+          Tensor.manual_seed(1337) if legacy is None else Tensor.manual_seed(1337, legacy=legacy)
+          b = random_fn(10,10).realize()
+          np.testing.assert_allclose(a.numpy(), b.numpy())
 
   def test_zeros_like_has_same_dtype(self):
     for datatype in [dtypes.float16, dtypes.float32, dtypes.int8, dtypes.int32, dtypes.int64, dtypes.uint8]:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -525,9 +525,7 @@ class Tensor:
     if not Tensor.training:
       # if mask is requested as output it will contain all True's.
       return (self, Tensor.ones(*self.shape, requires_grad=False, dtype=dtypes.bool)) if return_mask else self
-    # TODO: why is this going through numpy?
-    _mask: np.ndarray = Tensor._rng.choice(a=[False, True], size=self.shape, p=[p, 1-p])
-    mask = Tensor(_mask, requires_grad=False, device=self.device)
+    mask = (Tensor.rand(*self.shape, requires_grad=False) >= p).cast(dtypes.bool)
     result = self * mask * (1/(1.0 - p))
     return (result, mask) if return_mask else result
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -156,14 +156,14 @@ class Tensor:
 
   @staticmethod
   def rand(*shape, **kwargs) -> Tensor:
-    random = lambda size, dtype: Tensor._rng.random(size=size, dtype=dtype) if isinstance(Tensor._rng, np.random.Generator) else Tensor._rng.random(size).astype(dtype)
-    return Tensor(LazyNumpyArray(lambda lna: random(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
+    def _random(size, dtype): return Tensor._rng.random(size=size, dtype=dtype) if isinstance(Tensor._rng, np.random.Generator) else Tensor._rng.random(size).astype(dtype)
+    return Tensor(LazyNumpyArray(lambda lna: _random(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
 
   # TODO: replace with a transformation from uniform -> gaussian
   @staticmethod
   def randn(*shape, **kwargs) -> Tensor:
-    standard_normal = lambda size, dtype: Tensor._rng.standard_normal(size=size, dtype=dtype) if isinstance(Tensor._rng, np.random.Generator) else Tensor._rng.standard_normal(size).astype(dtype)
-    return Tensor(LazyNumpyArray(lambda lna: standard_normal(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
+    def _standard_normal(size, dtype): return Tensor._rng.standard_normal(size=size, dtype=dtype) if isinstance(Tensor._rng, np.random.Generator) else Tensor._rng.standard_normal(size).astype(dtype)
+    return Tensor(LazyNumpyArray(lambda lna: _standard_normal(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
 
   # ***** rng hlops *****
 


### PR DESCRIPTION
I had to change `Tensor._rng` from outside because the ONNX tests use `np.random.seed()` for the expected dropout mask, and using `default_rng(seed)` won't give the same results as when the same seed is used in `np.random.seed(seed)` (because the latter [uses](https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html) a [RandomState](https://numpy.org/doc/stable/reference/random/legacy.html#numpy.random.RandomState)).