### PR TITLE
Add mlperf training scaffolding

### DIFF
--- a/examples/mlperf/model_train.py
+++ b/examples/mlperf/model_train.py
@@ -1,0 +1,37 @@
+from tinygrad.tensor import Tensor
+from tinygrad.helpers import getenv
+
+def train_resnet():
+  # TODO: Resnet50-v1.5
+  pass
+
+def train_retinanet():
+  # TODO: Retinanet
+  pass
+
+def train_unet3d():
+  # TODO: Unet3d
+  pass
+
+def train_rnnt():
+  # TODO: RNN-T
+  pass
+
+def train_bert():
+  # TODO: BERT
+  pass
+
+def train_maskrcnn():
+  # TODO: Mask RCNN
+  pass
+
+if __name__ == "__main__":
+  Tensor.training = True
+
+  for m in getenv("MODEL", "resnet,retinanet,unet3d,rnnt,bert,maskrcnn").split(","):
+    nm = f"train_{m}"
+    if nm in globals():
+      print(f"training {m}")
+      globals()[nm]()
+
+


### PR DESCRIPTION
Start of mlperf training! :)

No models in here yet, this is just so that we have a unified place to put the model training code so that we have less merge conflicts later. I'm not actually sure if this is the best way, maybe a better idea would be to use this as sort of an entrypoint for training that imports individual training scripts from a subdirectory? Cuz some of the training scripts could get pretty long.

Maybe we want to wait for https://github.com/geohot/tinygrad/pull/844 to be merged and a decision to be made on https://github.com/geohot/tinygrad/pull/608 before this is merged just so that this can follow what the recommended way to train is.