### PR TITLE
context var for Device.DEFAULT

### DIFF
--- a/docs/abstractions.py
+++ b/docs/abstractions.py
@@ -22,8 +22,8 @@ from abc import ABC
 # let's trace an addition down through the layers of abstraction.
 
 # we will be using the clang backend
-from tinygrad.lazy import Device
-Device.DEFAULT = "CLANG"
+from tinygrad.lazy import Device, DEFAULT_DEVICE
+DEFAULT_DEVICE("CLANG")
 
 # first, 2+3 as a Tensor, the highest level
 from tinygrad.tensor import Tensor

--- a/test/unit/test_context_vars.py
+++ b/test/unit/test_context_vars.py
@@ -1,0 +1,18 @@
+import unittest
+from tinygrad.helpers import Context, ContextVar
+from tinygrad.tensor import Tensor
+from tinygrad.lazy import Device, DEFAULT_DEVICE
+
+class TestContextStack(unittest.TestCase):
+  def test_default_device(self):
+    assert Tensor.empty(1).device == Device.DEFAULT
+    assert Tensor.ones(1).device == Device.DEFAULT
+    with Context(DEVICE="CPU"):
+      assert Tensor.empty(1).device == "CPU"
+      assert Tensor.ones(1).device == "CPU"
+      DEFAULT_DEVICE("gpu")
+      assert Tensor.empty(1).device == "GPU"
+      assert Tensor.ones(1).device == "GPU"
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -31,7 +31,7 @@ class ContextVar:
     self.key, self.initial_value = key, getenv(key, default_value)
     if key not in ContextVar.ctx_stack[-1]: ContextVar.ctx_stack[-1][key] = self.initial_value
   def __call__(self, x): ContextVar.ctx_stack[-1][self.key] = x
-  def __bool__(self): return self.value != 0
+  def __bool__(self): return bool(self.value)
   def __ge__(self, x): return self.value >= x
   def __gt__(self, x): return self.value > x
   @property

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, asdict
 import os, math, functools
 import numpy as np
 from typing import Tuple, Union, List, NamedTuple, Final, Iterator, ClassVar, Optional, Callable, Any
+from contextlib import ContextDecorator
 ShapeType = Tuple[int, ...]
 # NOTE: helpers is not allowed to import from anything else in tinygrad
 
@@ -20,16 +21,16 @@ def mnum(i) -> str: return str(i) if i >= 0 else f"m{-i}"
 @functools.lru_cache(maxsize=None)
 def getenv(key, default=0): return type(default)(os.getenv(key, default))
 
-class Context:
-  def __init__(self, **kwargs): self.pvars = kwargs
-  def __enter__(self): ContextVar.ctx_stack.append({ **self.pvars, **{ key: ContextVar.ctx_stack[-1][key] for key in ContextVar.ctx_stack[-1].keys() if key not in self.pvars } })
+class Context(ContextDecorator):
+  def __init__(self, **kwargs): self.pvars = { k.upper(): v for k, v in kwargs.items() }
+  def __enter__(self): ContextVar.ctx_stack.append({ **self.pvars, **{ k: v for k, v in ContextVar.ctx_stack[-1].items() if k not in self.pvars } })
   def __exit__(self, *args): ContextVar.ctx_stack.pop()
 
 class ContextVar:
   ctx_stack: ClassVar[List[dict[str, Any]]] = [{}]
   def __init__(self, key, default_value): 
-    self.key, self.initial_value = key, getenv(key, default_value)
-    if key not in ContextVar.ctx_stack[-1]: ContextVar.ctx_stack[-1][key] = self.initial_value
+    self.key, self.initial_value = key.upper(), getenv(key.upper(), default_value)
+    if self.key not in ContextVar.ctx_stack[-1]: ContextVar.ctx_stack[-1][self.key] = self.initial_value
   def __call__(self, x): ContextVar.ctx_stack[-1][self.key] = x
   def __bool__(self): return bool(self.value)
   def __ge__(self, x): return self.value >= x

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -33,7 +33,8 @@ class Tensor:
   no_grad: ClassVar[bool] = False
   default_type: ClassVar[DType] = dtypes.float32
 
-  def __init__(self, data:Union[list, LazyBuffer, LazyNumpyArray, np.ndarray], device=Device.DEFAULT, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
+  def __init__(self, data:Union[list, LazyBuffer, LazyNumpyArray, np.ndarray], device=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
+    device = Device.DEFAULT if device is None else device
     device = (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')).replace(":0", "")  # canonicalize device
     if isinstance(data, list):
       data = np.array(data, dtype=(dtype if dtype is not None else Tensor.default_type).np)
@@ -143,7 +144,8 @@ class Tensor:
   def ones_like(tensor, **kwargs): return Tensor.full_like(tensor, 1, **kwargs)
 
   @staticmethod
-  def empty(*shape, device=Device.DEFAULT, dtype:Optional[DType]=None, **kwargs):
+  def empty(*shape, device=None, dtype:Optional[DType]=None, **kwargs):
+    device = Device.DEFAULT if device is None else device
     # NOTE: we do the reshape to fix interpreted buffers
     return Tensor(LazyBuffer.empty([prod(shape)], Tensor.default_type if dtype is None else dtype, device), dtype=dtype, device=device, **kwargs).reshape(*shape)
 


### PR DESCRIPTION
Allows changing the default device with a context var.
```python
from tinygrad.helpers import Context
from tinygrad.tensor import Tensor
from tinygrad.lazy import Device, DEFAULT_DEVICE

DEFAULT_DEVICE("cpu") # internally uses name "DEVICE"

a = Tensor.ones(1) # on cpu

with Context(device="gpu"):
    b = Tensor.ones(1) # on gpu
    print((a.to("gpu") + b).numpy())
```

The current implementation breaks `Device.DEFAULT = x` (only used by TG in abstractions.py). 

I also changed the context to key.upper() allowing for lowercase "device" and added support for using `Context` as a function decorator. This should also be helpful for the "training" context var.

I don't really like that "DEFAULT_DEVICE" is named differently than its internal context var "DEVICE", but I wanted to avoid having both `Device` and `DEVICE` in lazy.py.

This also means, that there are now 2 ways of selecting a device with envs.