### PR TITLE
train_efficientnet: only import datasets.imagenet when IMAGENET is set

### DIFF
--- a/examples/train_efficientnet.py
+++ b/examples/train_efficientnet.py
@@ -7,7 +7,6 @@ from tinygrad.nn import optim
 from tinygrad.helpers import getenv
 from tinygrad.tensor import Tensor
 from datasets import fetch_cifar
-from datasets.imagenet import fetch_batch
 from models.efficientnet import EfficientNet
 
 class TinyConvNet:
@@ -46,6 +45,7 @@ if __name__ == "__main__":
   print(f"training with batch size {BS} for {steps} steps")
 
   if IMAGENET:
+    from datasets.imagenet import fetch_batch
     def loader(q):
       while 1:
         try:


### PR DESCRIPTION
make it work out of the box for new users.

the default configuration of train_efficientnet is to use the smaller cifar dataset. import datasets.imagenet tries to open imagenet_class_index.json and will fail, unless user has already downloaded it.