### PR TITLE
Fix .std() tests on torch=1.13

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -305,8 +305,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(3,4,5,6)], lambda x: x.mean(axis=(1,2)), lambda x: Tensor.mean(x, axis=(1,2)))
   def test_std(self):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x), lambda x: Tensor.std(x))
-    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=0), lambda x: Tensor.std(x, correction=0))
-    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=5), lambda x: Tensor.std(x, correction=5))
+    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=0), lambda x: Tensor.std(x, correction=0))
+    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, correction=5), lambda x: Tensor.std(x, correction=5))
   def test_std_axis(self):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=0), lambda x: Tensor.std(x, axis=0))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=2), lambda x: Tensor.std(x, axis=2))
@@ -317,8 +317,8 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=0, dim=[1, 2]), lambda x: Tensor.std(x, axis=[1, 2], correction=0))
     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=0, dim=None), lambda x: Tensor.std(x, axis=None, correction=0))
   def test_std_keepdim(self):
-    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, keepdim=True), lambda x: Tensor.std(x, keepdim=True))
-    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, keepdim=True, correction=0, dim=0), lambda x: Tensor.std(x, keepdim=True, correction=0, axis=0))
+    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=None, keepdim=True), lambda x: Tensor.std(x, keepdim=True))
+    helper_test_op([(45, 65, 85)], lambda x: torch.std(x, dim=0, keepdim=True, correction=0), lambda x: Tensor.std(x, keepdim=True, correction=0, axis=0))
   def test_log_softmax(self):
     helper_test_op([(45,65)], lambda x: torch.nn.LogSoftmax(dim=1)(x), Tensor.log_softmax, atol=1e-7, grad_atol=1e-7)
     helper_test_op([()], lambda x: torch.nn.LogSoftmax(dim=0)(x), Tensor.log_softmax, atol=1e-7, grad_atol=1e-7)
@@ -886,7 +886,7 @@ class TestOps(unittest.TestCase):
 
     with self.assertRaises(IndexError):
       Tensor.stack([x], dim=77)
-    
+
     a = Tensor(3.14)
     np.testing.assert_allclose(Tensor.stack([a, a]).numpy(), Tensor([3.14, 3.14]).numpy())
 


### PR DESCRIPTION
Pytorch 1.13 is being an idiot, but this is an easy fix.
The trick is to add `dim=None` if we are using `keepdim=True`.
I tested, and this still works with torch=2.0.1.


Here is the full log - it has to do with the Python - C interface if I understand it correctly.
```
$ env CPU=1 EXCLUDE_DEVICES=GPU pytest test/test_ops.py 
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.10.11, pytest-7.3.1, pluggy-1.0.0
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/xl0/work/projects/tinygrad/tinygrad
plugins: mock-3.10.0, asyncio-0.21.0, benchmark-4.0.0, cov-4.1.0, integration-0.2.3, recording-0.12.2, anyio-3.6.2, xdist-3.3.1
asyncio: mode=strict
collected 160 items                                                                                                                                                      

test/test_ops.py ...............................................s......ss...................................................s...............ss.......s..s....F.F.. [ 90%]
...............                                                                                                                                                    [100%]

================================================================================ FAILURES ================================================================================
____________________________________________________________________________ TestOps.test_std ____________________________________________________________________________

self = <test.test_ops.TestOps testMethod=test_std>

    def test_std(self):
      helper_test_op([(45, 65, 85)], lambda x: torch.std(x), lambda x: Tensor.std(x))
>     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=0), lambda x: Tensor.std(x, correction=0))

test/test_ops.py:308: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test/test_ops.py:23: in helper_test_op
    out = torch_fxn(*ts)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = tensor([[[ 0.1464,  0.6456,  0.3083,  ..., -1.3076,  0.5774,  0.1998],
         [-0.7038,  0.0697, -1.2182,  ..., -0.4... -0.2363,  0.5361],
         [-1.1415,  1.2157,  0.6194,  ..., -0.6504, -1.1164,  1.4967]]],
       requires_grad=True)

>   helper_test_op([(45, 65, 85)], lambda x: torch.std(x, correction=0), lambda x: Tensor.std(x, correction=0))
E   TypeError: std() received an invalid combination of arguments - got (Tensor, correction=int), but expected one of:
E    * (Tensor input, tuple of ints dim, *, int correction, bool keepdim, Tensor out)
E    * (Tensor input, tuple of ints dim, bool unbiased, bool keepdim, *, Tensor out)
E    * (Tensor input, bool unbiased)
E         didn't match because some of the keywords were incorrect: correction
E    * (Tensor input, tuple of names dim, *, int correction, bool keepdim, Tensor out)
E    * (Tensor input, tuple of names dim, bool unbiased, bool keepdim, *, Tensor out)

test/test_ops.py:308: TypeError
-------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------

testing                           [(45, 65, 85)]   torch/tinygrad fp: 1.25 / 2.59 ms  bp: 0.39 / 3.97 ms 
________________________________________________________________________ TestOps.test_std_keepdim ________________________________________________________________________

self = <test.test_ops.TestOps testMethod=test_std_keepdim>

    def test_std_keepdim(self):
>     helper_test_op([(45, 65, 85)], lambda x: torch.std(x, keepdim=True), lambda x: Tensor.std(x, keepdim=True))

test/test_ops.py:320: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test/test_ops.py:23: in helper_test_op
    out = torch_fxn(*ts)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

x = tensor([[[ 0.1464,  0.6456,  0.3083,  ..., -1.3076,  0.5774,  0.1998],
         [-0.7038,  0.0697, -1.2182,  ..., -0.4... -0.2363,  0.5361],
         [-1.1415,  1.2157,  0.6194,  ..., -0.6504, -1.1164,  1.4967]]],
       requires_grad=True)

>   helper_test_op([(45, 65, 85)], lambda x: torch.std(x, keepdim=True), lambda x: Tensor.std(x, keepdim=True))
E   TypeError: std() received an invalid combination of arguments - got (Tensor, keepdim=bool), but expected one of:
E    * (Tensor input, tuple of ints dim, *, int correction, bool keepdim, Tensor out)
E    * (Tensor input, tuple of ints dim, bool unbiased, bool keepdim, *, Tensor out)
E    * (Tensor input, bool unbiased)
E         didn't match because some of the keywords were incorrect: keepdim
E    * (Tensor input, tuple of names dim, *, int correction, bool keepdim, Tensor out)
E    * (Tensor input, tuple of names dim, bool unbiased, bool keepdim, *, Tensor out)

test/test_ops.py:320: TypeError
============================================================================ warnings summary ============================================================================
test/test_ops.py::TestOps::test_empty_0
  /home/xl0/work/projects/tinygrad/tinygrad/tinygrad/ops.py:54: RuntimeWarning: invalid value encountered in divide
    ret = self.from_underlying(self.fxn_for_op[ast.op](*([self.to_underlying(x) for x in srcs] + ([ast.arg] if ast.arg is not None else []))))

test/test_ops.py::TestOps::test_log
  /home/xl0/work/projects/tinygrad/tinygrad/tinygrad/ops.py:54: RuntimeWarning: invalid value encountered in log
    ret = self.from_underlying(self.fxn_for_op[ast.op](*([self.to_underlying(x) for x in srcs] + ([ast.arg] if ast.arg is not None else []))))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== short test summary info =========================================================================
FAILED test/test_ops.py::TestOps::test_std - TypeError: std() received an invalid combination of arguments - got (Tensor, correction=int), but expected one of:
FAILED test/test_ops.py::TestOps::test_std_keepdim - TypeError: std() received an invalid combination of arguments - got (Tensor, keepdim=bool), but expected one of:
========================================================== 2 failed, 150 passed, 8 skipped, 2 warnings in 5.16s ==========================================================
