### PR TITLE
Replace randn to use Box-Muller transform of rand

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -169,9 +169,8 @@ class Tensor:
   @staticmethod
   def rand(*shape, **kwargs) -> Tensor: return Tensor(LazyNumpyArray(lambda lna: Tensor._rng.random(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
 
-  # TODO: replace with a transformation from uniform -> gaussian
   @staticmethod
-  def randn(*shape, **kwargs) -> Tensor: return Tensor(LazyNumpyArray(lambda lna: Tensor._rng.standard_normal(size=lna.shape, dtype=lna.dtype), shape, np.float32), **kwargs)
+  def randn(*shape, **kwargs) -> Tensor: return Tensor.rand(*shape, **kwargs).mul(2*math.pi).sin().mul(Tensor.rand(*shape, **kwargs).log().mul(-2).sqrt())
 
   # ***** rng hlops *****
 


### PR DESCRIPTION
This replaces the Tensor.randn method to be a transform of Tensor.rand. 

It uses the Box-Muller transform https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform to generate independent random Gaussian variables.

Just to be clear, we are computing sin(2 * pi * uniform_1) * sqrt(-2 * log(uniform_2)) (i.e. only Z_1 as in the Wikipedia link. Even though computing Z_0 would mean a call to rand with half the size, calling rand is not expensive compared to manipulating tensors and so this method ended up quicker + more clear)

Wondering if it should be expanded to multiple lines for readability?