### PR TITLE
Fixed all ConstantOfShape test suite

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -208,7 +208,7 @@ def Not(x:Tensor): return Where((x==1), Tensor.zeros(*x.shape), Tensor.ones(*x.s
 def ConstantOfShape(input, value:Tensor=None):
   if value is None: value=Tensor([0.0])
   shape = [int(x) for x in safe_numpy(input)]
-  return Tensor.ones(*shape, dtype=value.dtype) * (value if input.shape !=(0,) else 1)
+  return Tensor.ones(*shape, dtype=value.dtype) * (value if shape[0]!=0 else 1)
 
 # this is obviously wrong, but since we don't have types, it's better than nothing
 def Cast(input, to):


### PR DESCRIPTION
In the last merge, I introduced a bug that made one of the 3 tests fails, this fixes it. My bad, sorry for the trouble

Before:
=== 295 failed, 531 passed, 1808 skipped, 2 warnings in 31.32s ===
After:
=== 294 failed, 532 passed, 1808 skipped, 2 warnings in 28.58s ===