### PR TITLE
Onnx: added GatherElements, modified Gather, Split, Squeeze

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -138,17 +138,10 @@ def get_run_onnx(onnx_model: ModelProto):
         ret = ret.expand([val for pair in zip(inp[0].shape, [int(x) for x in scales]) for val in pair])
         ret = ret.reshape([x*y for x,y in zip(inp[0].shape, [int(x) for x in scales])])
       elif n.op_type == "Gather":
-        # TODO: is this correct? seems to work for simple gather ops
         if 'axis' not in opt: opt['axis'] = 0
         axis = opt['axis']
         data, indices = [safe_numpy(i) for i in inp]
         ret = Tensor(np.take(data, indices, axis))
-        #shape = list(inp[0].shape)
-        #print(f'SHAPE: {shape}')
-        #indices = [shape[axis]+int(x) if x<0 else int(x) for x in safe_numpy(inp[1])]
-        #args = [[(0,x) if j != axis else (i,i+1) for j, x in enumerate(shape)] for i in indices]
-        #ret = inp[0].slice(arg=args[0]).cat(*[inp[0].slice(arg=arg) for arg in args[1:]], dim=axis)
-        #ret = ret.reshape([s for i,s in enumerate(shape) if i != axis]) if len(indices) == 1 else ret # squeeze if needed
       elif n.op_type == "GatherElements":
         axis = opt['axis']
         data, indices = inp

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -108,6 +108,9 @@ def get_run_onnx(onnx_model: ModelProto):
       inp = [tensors[x] if x in tensors else (intermediate_tensors[x] if x in intermediate_tensors else (input_tensors[x] if x != str() else None)) for x in n.input]
       opt = attribute_dict[num]
       if debug: print(f"{num}: op {n.op_type} shape {[x.shape if isinstance(x, Tensor) else x for x in inp]} opt {opt}")
+      if debug:
+        print(f"n.input: {n.input}")
+        print(f"n.output: {n.output}")
 
       # free ones
       if n.op_type == "Relu": ret = inp[0].relu()
@@ -118,7 +121,7 @@ def get_run_onnx(onnx_model: ModelProto):
       elif n.op_type == "Elu": ret = inp[0].elu(alpha=opt.get('alpha', 1.0))
       elif n.op_type == "Concat": ret = inp[0].cat(*inp[1:], dim=opt['axis'])
       elif n.op_type == "Transpose": ret = inp[0].permute(order=opt.get('perm', list(range(len(inp[0].shape))[::-1])))
-      elif n.op_type == "Squeeze": ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in opt['axes']])
+      elif n.op_type == "Squeeze": ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in opt['axes']]) if 'axes' in opt else inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in inp[1].numpy()]) #HACK inp[1] is axes for some tests
       elif n.op_type == "Div":
         # in openpilot, due to SHUFFLE_PAD_OPS issues, we are spending an extra kernel
         ret = inp[0].div(inp[1])
@@ -139,12 +142,23 @@ def get_run_onnx(onnx_model: ModelProto):
         ret = ret.reshape([x*y for x,y in zip(inp[0].shape, [int(x) for x in scales])])
       elif n.op_type == "Gather":
         # TODO: is this correct? seems to work for simple gather ops
+        if 'axis' not in opt: opt['axis'] = 0
         axis = opt['axis']
-        shape = list(inp[0].shape)
-        indices = [shape[axis]+int(x) if x<0 else int(x) for x in safe_numpy(inp[1])]
-        args = [[(0,x) if j != axis else (i,i+1) for j, x in enumerate(shape)] for i in indices]
-        ret = inp[0].slice(arg=args[0]).cat(*[inp[0].slice(arg=arg) for arg in args[1:]], dim=axis)
-        ret = ret.reshape([s for i,s in enumerate(shape) if i != axis]) if len(indices) == 1 else ret # squeeze if needed
+        data, indices = [safe_numpy(i) for i in inp]
+        ret = Tensor(np.take(data, indices, axis))
+        #shape = list(inp[0].shape)
+        #print(f'SHAPE: {shape}')
+        #indices = [shape[axis]+int(x) if x<0 else int(x) for x in safe_numpy(inp[1])]
+        #args = [[(0,x) if j != axis else (i,i+1) for j, x in enumerate(shape)] for i in indices]
+        #ret = inp[0].slice(arg=args[0]).cat(*[inp[0].slice(arg=arg) for arg in args[1:]], dim=axis)
+        #ret = ret.reshape([s for i,s in enumerate(shape) if i != axis]) if len(indices) == 1 else ret # squeeze if needed
+      elif n.op_type == "GatherElements":
+        axis = opt['axis']
+        data, indices = inp
+        data = data.transpose(ax1=0, ax2=axis)
+        indices = indices.transpose(ax1=0, ax2=axis)
+        ret = Tensor(np.choose(safe_numpy(indices), safe_numpy(data).astype('float32'), mode='wrap'))
+        ret = ret.transpose(ax1=0, ax2=axis)
       elif n.op_type in ["Add", "Sub", "Mul", "Pow"]:
         if (len(inp[0].shape) != len(inp[1].shape)) and (prod(inp[0].shape) == prod(inp[1].shape)):
           inp[1] = inp[1].reshape(inp[0].shape)
@@ -155,8 +169,12 @@ def get_run_onnx(onnx_model: ModelProto):
         if n.op_type == "Mul": ret = inp[0] * inp[1]
         if n.op_type == "Pow": ret = inp[0] ** inp[1]
       elif n.op_type == "Split":
-        if 'split' not in opt: opt['split'] = [int(x) for x in safe_numpy(inp[1])]  # split can be a tensor
         if 'axis' not in opt: opt['axis'] = 0
+        if 'num_outputs' in opt or len(inp) == 1: 
+          opt['split'] = [inp[0].shape[opt['axis']] // len(n.output)] * len(n.output)
+          for i in range(inp[0].shape[opt['axis']] % len(n.output)):
+            opt['split'][i] += 1
+        if 'split' not in opt: opt['split'] = [int(x) for x in safe_numpy(inp[1])]  # split can be a tensor
         i = 0
         arg = [(0,x) for x in inp[0].shape]
         for o,s in zip(n.output, opt['split']):

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -108,9 +108,6 @@ def get_run_onnx(onnx_model: ModelProto):
       inp = [tensors[x] if x in tensors else (intermediate_tensors[x] if x in intermediate_tensors else (input_tensors[x] if x != str() else None)) for x in n.input]
       opt = attribute_dict[num]
       if debug: print(f"{num}: op {n.op_type} shape {[x.shape if isinstance(x, Tensor) else x for x in inp]} opt {opt}")
-      if debug:
-        print(f"n.input: {n.input}")
-        print(f"n.output: {n.output}")
 
       # free ones
       if n.op_type == "Relu": ret = inp[0].relu()

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -150,8 +150,8 @@ def get_run_onnx(onnx_model: ModelProto):
         #ret = inp[0].slice(arg=args[0]).cat(*[inp[0].slice(arg=arg) for arg in args[1:]], dim=axis)
         #ret = ret.reshape([s for i,s in enumerate(shape) if i != axis]) if len(indices) == 1 else ret # squeeze if needed
       elif n.op_type == "GatherElements":
-        data, indices = inp
         axis = opt['axis']
+        data, indices = inp
         data = data.transpose(ax1=0, ax2=axis)
         indices = indices.transpose(ax1=0, ax2=axis)
         ret = Tensor(np.choose(safe_numpy(indices), safe_numpy(data).astype('float32'), mode='wrap'))

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -150,8 +150,8 @@ def get_run_onnx(onnx_model: ModelProto):
         #ret = inp[0].slice(arg=args[0]).cat(*[inp[0].slice(arg=arg) for arg in args[1:]], dim=axis)
         #ret = ret.reshape([s for i,s in enumerate(shape) if i != axis]) if len(indices) == 1 else ret # squeeze if needed
       elif n.op_type == "GatherElements":
-        axis = opt['axis']
         data, indices = inp
+        axis = opt['axis']
         data = data.transpose(ax1=0, ax2=axis)
         indices = indices.transpose(ax1=0, ax2=axis)
         ret = Tensor(np.choose(safe_numpy(indices), safe_numpy(data).astype('float32'), mode='wrap'))

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -111,7 +111,7 @@ def Dropout(data, ratio=0.5, training_mode=False, seed=None):
   return data * mask * (1/(1.0 - ratio)), mask
 
 def Shape(data, end=None, start=0): return list(data.shape)[start:end]
-def Size(data): return prod(data.shape)
+def Size(data): return data.numel()
 
 # TODO: this doesn't match Tensor.flatten behavior
 def Flatten(input, axis=1):


### PR DESCRIPTION
First ever PR in my whole entire life! pls be gentle
not sure why the diff looks soo janky...

=== 294 failed, 532 passed, 1808 skipped, 2 warnings in 28.58s ===
to
========== 271 failed, 555 passed, 1808 skipped, 2 warnings in 18.65s ==========

Not asking to commit yet since I still need to get rid of np.take() and np.choose() and review/clean up code
just posting it first so no one steals my PR >:D
also, should GatherElements be in onnx_ops.py instead?

and I found this https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/test/testdata/onnx_backend_test_series_filters.jsonc
I saw geohot mention in discord that some tests for stupid ops should be skipped. 
I found tests that asks for "Rank" as output while the op_type is "Size"...  and that test is included in "current_failing_tests_DNNL" inside that json.
So maybe this filter can help filter some tests out?