### PR TITLE
exclude float64 tests

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -156,6 +156,10 @@ backend_test.exclude('test_tfidfvectorizer_*')
 backend_test.exclude('test_stft_*')
 backend_test.exclude('test_melweightmatrix_*')
 
+# no float64
+backend_test.exclude('test_reduce_log_sum_exp_*')
+backend_test.exclude('test_operator_add_*')
+
 # disable model tests for now since they are slow
 if True:
   for x in backend_test.test_suite:


### PR DESCRIPTION
This excludes all the tests that require float64.
This solves https://github.com/geohot/tinygrad/issues/891#issue-1736175051