### PR TITLE
exclude string type from external_test_onnx_backend.py

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -60,7 +60,7 @@ backend_test.exclude('uint64')
 backend_test.exclude('int8')
 backend_test.exclude('int16')
 backend_test.exclude('float64')
-
+backend_test.exclude('string')
 
 backend_test.exclude('test_pow_types_int*')
 backend_test.exclude('test_cast_*')


### PR DESCRIPTION
 Excluded string type tests. 
 
 The tests were causing the following error because tinygrad does not support strings/object types:
 ```
def from_np(x) -> DType: return asdict(dtypes())[np.dtype(x).name]
KeyError: 'object'
```

The excluded tests:
- test_equal_string_broadcast_cpu
- test_equal_string_cpu