### PR TITLE
Eliminate LoadOps.FROMCPU

### DIFF
--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -182,7 +182,7 @@ class TestTinygrad(unittest.TestCase):
     assert Tensor.randn(10, 10).numel() == 100
     assert Tensor.randn(1,2,5).numel() == 10
     assert Tensor.randn(1,1,1,1,1,1).numel() == 1
-    assert Tensor([]).numel() == 0
+    # assert Tensor([]).numel() == 0 # TODO: fix empty buffers
     # assert Tensor.randn(1,0,2,5) == 0 # TODO: fix empty tensors
 
   def test_element_size(self):

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -182,7 +182,7 @@ class TestTinygrad(unittest.TestCase):
     assert Tensor.randn(10, 10).numel() == 100
     assert Tensor.randn(1,2,5).numel() == 10
     assert Tensor.randn(1,1,1,1,1,1).numel() == 1
-    # assert Tensor([]).numel() == 0 # TODO: fix empty buffers
+    assert Tensor([]).numel() == 0
     # assert Tensor.randn(1,0,2,5) == 0 # TODO: fix empty tensors
 
   def test_element_size(self):

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -87,7 +87,7 @@ def create_lazybuffer(device:str, shape:Union[ShapeTracker, Tuple[int, ...]], op
 
 class LazyBuffer:
   __deletable__ = ('op',)
-  def __init__(self, device:str, st: ShapeTracker, optype:OpType, op:Optional[LazyOp], dtype:DType, buf:Optional[RawBuffer]):
+  def __init__(self, device:str, st:ShapeTracker, optype:OpType, op:Optional[LazyOp], dtype:DType, buf:Optional[RawBuffer]):
     self.st = st  # NOTE: this is not a copy! this should be a "read-only" ShapeTracker
     self.device, self.shape, self.optype, self.dtype = device, self.st.shape, optype, dtype
     self.realized: Optional[RawBuffer] = buf
@@ -179,8 +179,7 @@ class LazyBuffer:
 
   @staticmethod
   def fromCPU(x: np.ndarray, device: str) -> LazyBuffer:
-    buf = Device[device].buffer.fromCPU(x, **Device.extra_args(device))
-    return LazyBuffer(device, ShapeTracker(tuple(x.shape)), LoadOps, None, dtypes.from_np(x.dtype), buf)
+    return LazyBuffer(device, ShapeTracker(tuple(x.shape)), LoadOps, None, dtypes.from_np(x.dtype), Device[device].buffer.fromCPU(x, **Device.extra_args(device)))
 
   # create a constant with the shape and dtype of self
   def const_like(self, val) -> LazyBuffer:

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -12,7 +12,7 @@ class UnaryOps(Enum): NOOP = auto(); EXP = auto(); LOG = auto(); CAST = auto(); 
 class BinaryOps(Enum): ADD = auto(); SUB = auto(); MUL = auto(); DIV = auto(); POW = auto(); CMPEQ = auto(); MAX = auto() # noqa: E702
 class ReduceOps(Enum): SUM = auto(); MAX = auto() # noqa: E702
 class FusedOps(Enum): MULACC = auto() # noqa: E702
-class LoadOps(Enum): EMPTY = auto(); RAND = auto(); CONST = auto(); FROM = auto(); FROMCPU = auto(); CONTIGUOUS = auto(); CUSTOM = auto() # noqa: E702
+class LoadOps(Enum): EMPTY = auto(); RAND = auto(); CONST = auto(); FROM = auto(); CONTIGUOUS = auto(); CUSTOM = auto() # noqa: E702
 
 Op = Union[UnaryOps, BinaryOps, ReduceOps, MovementOps, LoadOps, FusedOps]
 OpType = Union[Type[UnaryOps], Type[BinaryOps], Type[ReduceOps], Type[MovementOps], Type[LoadOps], Type[FusedOps]]

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -36,7 +36,7 @@ class RawBufferMapped(RawBufferCopyIn):
 
 # this one is simple enough that i moved it out of the runtimes
 class RawMallocBuffer(RawBufferMapped):
-  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int64: ctypes.c_int64}[dtype] * size)())
+  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int32: ctypes.c_int32, dtypes.int64: ctypes.c_int64}[dtype] * size)())
   def _buffer(self): return memoryview(self._buf)
 
 class RawBufferCopyInOut(RawBufferCopyIn):

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -25,7 +25,6 @@ class RawBufferCopyIn(RawBuffer):
 
   @classmethod
   def fromCPU(cls, x:np.ndarray, **kwargs):
-    if x.size == 0: return EmptyBuffer.fromCPU(x)
     ret = cls(prod(x.shape), dtypes.from_np(x.dtype), **kwargs)
     ret._copyin(x)
     return ret
@@ -37,7 +36,7 @@ class RawBufferMapped(RawBufferCopyIn):
 
 # this one is simple enough that i moved it out of the runtimes
 class RawMallocBuffer(RawBufferMapped):
-  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int32: ctypes.c_int32, dtypes.int64: ctypes.c_int64}[dtype] * size)())
+  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int64: ctypes.c_int64}[dtype] * size)())
   def _buffer(self): return memoryview(self._buf)
 
 class RawBufferCopyInOut(RawBufferCopyIn):
@@ -50,8 +49,3 @@ class RawBufferCopyInOut(RawBufferCopyIn):
 
 class RawConst(RawBuffer): # pylint: disable=abstract-method
   def __repr__(self): return f"const<{self._buf}, {self.dtype}>"
-
-class EmptyBuffer(RawBuffer):
-  @classmethod
-  def fromCPU(cls, x:np.ndarray): return cls(0, dtypes.from_np(x.dtype))
-  def toCPU(self) -> np.ndarray: return np.empty(0, dtype=self.dtype.np)

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -25,6 +25,7 @@ class RawBufferCopyIn(RawBuffer):
 
   @classmethod
   def fromCPU(cls, x:np.ndarray, **kwargs):
+    if x.size == 0: return EmptyBuffer.fromCPU(x)
     ret = cls(prod(x.shape), dtypes.from_np(x.dtype), **kwargs)
     ret._copyin(x)
     return ret
@@ -36,7 +37,7 @@ class RawBufferMapped(RawBufferCopyIn):
 
 # this one is simple enough that i moved it out of the runtimes
 class RawMallocBuffer(RawBufferMapped):
-  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int64: ctypes.c_int64}[dtype] * size)())
+  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int32: ctypes.c_int32, dtypes.int64: ctypes.c_int64}[dtype] * size)())
   def _buffer(self): return memoryview(self._buf)
 
 class RawBufferCopyInOut(RawBufferCopyIn):
@@ -49,3 +50,8 @@ class RawBufferCopyInOut(RawBufferCopyIn):
 
 class RawConst(RawBuffer): # pylint: disable=abstract-method
   def __repr__(self): return f"const<{self._buf}, {self.dtype}>"
+
+class EmptyBuffer(RawBuffer):
+  @classmethod
+  def fromCPU(cls, x:np.ndarray): return cls(0, dtypes.from_np(x.dtype))
+  def toCPU(self) -> np.ndarray: return np.empty(0, dtype=self.dtype.np)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -6,6 +6,7 @@ from typing import List, Tuple, Callable, Optional, ClassVar, Type, Union, Seque
 from tinygrad.helpers import prod, argfix, make_pair, getenv, IMAGE, DEBUG, flatten, DType, dtypes
 from tinygrad.lazy import Device, LazyBuffer
 from tinygrad.ops import LoadOps
+from tinygrad.shape.shapetracker import ShapeTracker
 
 # An instantiation of the Function is the Context
 class Function:
@@ -44,7 +45,7 @@ class Tensor:
       assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
       lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
     elif isinstance(data, np.ndarray):
-      lazydata = LazyBuffer.fromCPU(data, device)
+      lazydata = LazyBuffer(device, ShapeTracker(tuple(data.shape)), LoadOps, Device[device].buffer.fromCPU(data, **Device.extra_args(device)), dtypes.from_np(data.dtype))
     elif isinstance(data, (int, float)):
       lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype if dtype is not None else Tensor.default_type, device, data)
     else:

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -44,8 +44,7 @@ class Tensor:
       assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
       lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
     elif isinstance(data, np.ndarray):
-      # TODO: create CPUBuffer directly
-      lazydata = LazyBuffer.loadop(LoadOps.FROMCPU, data.shape, dtypes.from_np(data.dtype), device, data)
+      lazydata = LazyBuffer.fromCPU(data, device)
     elif isinstance(data, (int, float)):
       lazydata = LazyBuffer.loadop(LoadOps.CONST, tuple(), dtype if dtype is not None else Tensor.default_type, device, data)
     else:


### PR DESCRIPTION
- new `LazyBuffer.fromCPU` method to create from `ndarray` + changing the `__init__` method to have optional `LazyOp`/`RawBuffer`
- Add `int32` support for `RawMallocBuffer`