### PR TITLE
Use correct onnx op version

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -181,7 +181,7 @@ def get_run_onnx(onnx_model: ModelProto):
         fxn = getattr(onnx_ops, n.op_type)
         if isinstance(fxn, dict):
           for k in sorted(fxn.keys()):
-            if k < onnx_model_version:
+            if k <= onnx_model_version:
               real_fxn = fxn[k]
         else:
           real_fxn = fxn


### PR DESCRIPTION
Fixes `test_softmax_default_axis_cpu` by correctly choosing the new Softmax implementation for onnx_model_version 13.