### PR TITLE
Replaced broken link to /tests with /test

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -224,7 +224,7 @@ print(f"Time: {time.perf_counter() - st}")
 
 Highly recommend you check out the [examples/](/examples) folder for more examples of using tinygrad.
 Reading the source code of tinygrad is also a great way to learn how it works.
-Specifically the tests in [tests/](/tests) are a great place to see how to use and the semantics of the different operations.
+Specifically the tests in [test/](/test) are a great place to see how to use and the semantics of the different operations.
 There are also a bunch of models implemented in [models/](/models) that you can use as a reference.
 
 Additionally, feel free to ask questions in the `#learn-tinygrad` channel on the [discord](https://discord.gg/beYbxwxVdx). Don't ask to ask, just ask!


### PR DESCRIPTION
Updating broken link in `docs/quickstart.md` from `/tests` to `/test`.