### PR TITLE
[bug fix] limit split to 1 due to windows path containing :

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -1,6 +1,7 @@
 # https://arxiv.org/pdf/2112.10752.pdf
 # https://github.com/ekagra-ranjan/huggingface-blog/blob/main/stable_diffusion.md
-
+import os
+import tempfile
 from pathlib import Path
 import gzip, argparse, math, re
 from functools import lru_cache
@@ -604,7 +605,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Run Stable Diffusion', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
   parser.add_argument('--steps', type=int, default=5, help="Number of steps in diffusion")
   parser.add_argument('--prompt', type=str, default="a horse sized cat eating a bagel", help="Phrase to render")
-  parser.add_argument('--out', type=str, default="/tmp/rendered.png", help="Output filename")
+  parser.add_argument('--out', type=str, default=os.path.join(tempfile.gettempdir(), "rendered.png"), help="Output filename")
   args = parser.parse_args()
 
   Tensor.no_grad = True

--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -106,7 +106,7 @@ class LazyBuffer:
     if GRAPH >= 3: log_op(self, self.op, phantom=True)
 
   def __repr__(self): return f"<LB {self.shape} {self.dtype} op:{self.op.op if self.realized is None else self.realized} st:{self.st}>"
-  def _device_extra_args(self) -> Dict[str, str]: return {"device": self.device.split(":")[1]} if ":" in self.device else {}
+  def _device_extra_args(self) -> Dict[str, str]: return {"device": self.device.split(":", 1)[1]} if ":" in self.device else {}
 
   def realize(self:LazyBuffer) -> LazyBuffer:
     if self.realized is None:


### PR DESCRIPTION
Disk tensor bug on windows, when parsing the device string the split does not limit to 1. Since window path includes a ":" this results in the disk tensor only getting the drive letter as the path. Limiting the split to 1 passes the full path to file to disk tensor.

Closes (#927)