### PR TITLE
Onnx: fix squeeze and dropout

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -130,7 +130,7 @@ def get_run_onnx(onnx_model: ModelProto):
       elif n.op_type == "Concat": ret = inp[0].cat(*inp[1:], dim=opt['axis'])
       elif n.op_type == "Transpose": ret = inp[0].permute(order=opt.get('perm', list(range(len(inp[0].shape))[::-1])))
       elif n.op_type == "Squeeze":
-        axes = (safe_numpy(inp[1]) + len(inp[0].shape)) % len(inp[0].shape)
+        axes = (safe_numpy(inp[1] if len(inp) > 1 else opt['axes']) + len(inp[0].shape)) % len(inp[0].shape)
         ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in axes])
       elif n.op_type == "Div":
         # in openpilot, due to SHUFFLE_PAD_OPS issues, we are spending an extra kernel

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -79,7 +79,6 @@ def get_run_onnx(onnx_model: ModelProto):
   attribute_dict = {}
   for num,n in enumerate(onnx_model.graph.node):
     attribute_dict[num] = attribute_to_dict(n.attribute)
-
   onnx_model_version = onnx_model.opset_import[0].version
 
   def run_onnx(inputs={}, debug=False):
@@ -131,7 +130,7 @@ def get_run_onnx(onnx_model: ModelProto):
       elif n.op_type == "Concat": ret = inp[0].cat(*inp[1:], dim=opt['axis'])
       elif n.op_type == "Transpose": ret = inp[0].permute(order=opt.get('perm', list(range(len(inp[0].shape))[::-1])))
       elif n.op_type == "Squeeze":
-        axes = (inp[1].numpy() + len(inp[0].shape)) % len(inp[0].shape)
+        axes = (safe_numpy(inp[1]) + len(inp[0].shape)) % len(inp[0].shape)
         ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in axes])
       elif n.op_type == "Div":
         # in openpilot, due to SHUFFLE_PAD_OPS issues, we are spending an extra kernel

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -130,7 +130,9 @@ def get_run_onnx(onnx_model: ModelProto):
       elif n.op_type == "Elu": ret = inp[0].elu(alpha=opt.get('alpha', 1.0))
       elif n.op_type == "Concat": ret = inp[0].cat(*inp[1:], dim=opt['axis'])
       elif n.op_type == "Transpose": ret = inp[0].permute(order=opt.get('perm', list(range(len(inp[0].shape))[::-1])))
-      elif n.op_type == "Squeeze": ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in opt['axes']])
+      elif n.op_type == "Squeeze":
+        axes = (inp[1].numpy() + len(inp[0].shape)) % len(inp[0].shape)
+        ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in axes])
       elif n.op_type == "Div":
         # in openpilot, due to SHUFFLE_PAD_OPS issues, we are spending an extra kernel
         ret = inp[0].div(inp[1])

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -99,8 +99,6 @@ def get_run_onnx(onnx_model: ModelProto):
         else:
           input_tensors[inp.name] = Tensor(inputs[inp.name], requires_grad=False)
         input_shape = input_tensors[inp.name].shape
-        if input_shape == (0,): raise NotImplementedError("empty tensors aren't supported in tinygrad")
-        assert input_shape == shape, f"wrong shape for input {inp.name}, {input_shape} isn't {shape}"
         for _,v in input_tensors.items(): v.realize()
       else:
         raise Exception(f"no data for {inp.name} with shape {shape}")

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -128,7 +128,7 @@ def get_run_onnx(onnx_model: ModelProto):
       elif n.op_type == "Concat": ret = inp[0].cat(*inp[1:], dim=opt['axis'])
       elif n.op_type == "Transpose": ret = inp[0].permute(order=opt.get('perm', list(range(len(inp[0].shape))[::-1])))
       elif n.op_type == "Squeeze":
-        axes = (safe_numpy(inp[1] if len(inp) > 1 else opt['axes']) + len(inp[0].shape)) % len(inp[0].shape)
+        axes = (safe_numpy(inp[1] if len(inp) > 1 else Tensor(opt['axes'])) + len(inp[0].shape)) % len(inp[0].shape)
         ret = inp[0].reshape([s for i,s in enumerate(inp[0].shape) if i not in axes])
       elif n.op_type == "Div":
         # in openpilot, due to SHUFFLE_PAD_OPS issues, we are spending an extra kernel

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -20,7 +20,7 @@ def Unsqueeze(data, axes):
 def Gemm(A, B, C=None, alpha=1.0, beta=1.0, transA=0, transB=0, broadcast=None):
   ret = alpha * ((A.transpose() if transA == 1 else A) @ (B.transpose() if transB == 1 else B))
   if C is not None:
-      if broadcast: C = C.reshape([-1 if i == broadcast else 1 for i in range(len(ret.shape))]) # onnx.py:152
+    if broadcast: C = C.reshape([-1 if i == broadcast else 1 for i in range(len(ret.shape))]) # onnx.py:152
     ret += beta * C
   return ret
 

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -106,7 +106,7 @@ def ConvTranspose(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_
 def Dropout(data, ratio=0.5, training_mode=False, seed=None):
   if not training_mode: return data, Tensor.ones(*data.shape, dtype=dtypes.bool)  # if mask is requested as output it will contain all True's.
   rng = np.random.RandomState(seed)
-  ratio = ratio.lazydata.realize().toCPU()[0] if isinstance(ratio, Tensor) else ratio
+  ratio = ratio.realize().numpy() if isinstance(ratio, Tensor) else ratio
   mask = Tensor((rng.random(data.shape) >= ratio), requires_grad=False, device=data.device)
   return data * mask * (1/(1.0 - ratio)), mask
 

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -17,9 +17,11 @@ def Unsqueeze(data, axes):
       ptr += 1
   return data.reshape(new_shape)
 
-def Gemm(A, B, C=None, alpha=1.0, beta=1.0, transA=0, transB=0):
+def Gemm(A, B, C=None, alpha=1.0, beta=1.0, transA=0, transB=0, broadcast=None):
   ret = alpha * ((A.transpose() if transA == 1 else A) @ (B.transpose() if transB == 1 else B))
-  if C is not None: ret += beta * C
+  if C is not None:
+      if broadcast: C = C.reshape([-1 if i == broadcast else 1 for i in range(len(ret.shape))]) # onnx.py:152
+    ret += beta * C
   return ret
 
 # TODO: this is copied from tinygrad/nn/__init__.py

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -106,7 +106,7 @@ def ConvTranspose(X, W, B=None, auto_pad="NOTSET", dilations=1, group=1, kernel_
 def Dropout(data, ratio=0.5, training_mode=False, seed=None):
   if not training_mode: return data, Tensor.ones(*data.shape, dtype=dtypes.bool)  # if mask is requested as output it will contain all True's.
   rng = np.random.RandomState(seed)
-  ratio = ratio.realize().numpy() if isinstance(ratio, Tensor) else ratio
+  ratio = ratio.numpy() if isinstance(ratio, Tensor) else ratio
   mask = Tensor((rng.random(data.shape) >= ratio), requires_grad=False, device=data.device)
   return data * mask * (1/(1.0 - ratio)), mask
 

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -177,7 +177,9 @@ def Min(*data_0): return functools.reduce(Tensor.minimum, data_0)
 def Sum(*data_0): return functools.reduce(Tensor.__add__, data_0)
 def Mean(*data_0): return functools.reduce(Tensor.__add__, data_0) / len(data_0)
 
-def _axes(axes, noop_with_empty_axes): return [int(x) for x in safe_numpy(axes)] if axes is not None else ([] if noop_with_empty_axes else None)
+def _axes(axes, noop_with_empty_axes):
+  ret = [int(x) for x in safe_numpy(axes)] if axes is not None else []
+  return ret if len(ret) or noop_with_empty_axes else None
 
 # ReduceProd would require a new llop
 def ReduceMax(data, axes=None, keepdims=1, noop_with_empty_axes=0): return data.max(_axes(axes, noop_with_empty_axes), keepdim=keepdims)
@@ -203,7 +205,7 @@ def Tile(input, repeats):
   final_shape = [r*s for r,s in zip(repeats_, input.shape)]
   return input.reshape(new_shape).expand(expand_shape).reshape(final_shape)
 
-def Range(start, limit, delta): return Tensor.arange(safe_numpy(limit)[0], safe_numpy(start)[0], safe_numpy(delta)[0])
+def Range(start, limit, delta): return Tensor.arange(safe_numpy(limit).item(), safe_numpy(start).item(), safe_numpy(delta).item())
 def Where(condition:Tensor,X:Tensor,Y:Tensor): return condition.where(X, Y).cast(X.dtype)
 
 def And(x:Tensor, y:Tensor): return Where((x==y), x, Tensor.zeros(*x.shape)).cast(dtypes.bool)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -134,7 +134,7 @@ class Tensor:
   # ***** creation helper functions *****
 
   @staticmethod
-  def full(shape:Tuple[int, ...], fill_value, **kwargs): return Tensor(fill_value, **kwargs).reshape([1]*len(new_shape := argfix(shape))).expand(new_shape).contiguous()
+  def full(shape:Tuple[int, ...], fill_value, **kwargs): return Tensor(fill_value, **kwargs).reshape([1]*len(new_shape := tuple(map(int, argfix(shape))))).expand(new_shape).contiguous()
 
   @staticmethod
   def zeros(*shape, **kwargs): return Tensor.full(argfix(*shape), 0, **kwargs)
@@ -471,7 +471,7 @@ class Tensor:
   def cumsum(self, axis=0):
     x = self.permute(*(i for i in range(self.ndim) if i != axis), axis)
     return x.reshape(1, 1, -1, self.shape[axis]).conv2d(Tensor.ones(1, 1, 1, self.shape[axis], dtype=self.dtype, device=self.device), padding=(self.shape[axis]-1, 0, 0, 0)).reshape(*x.shape).permute(*range(axis), self.ndim - 1, *range(axis, self.ndim-1))
-  
+
   # ***** mlops (unary) *****
 
   def contiguous(self): return mlops.Contiguous.apply(self)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -134,7 +134,7 @@ class Tensor:
   # ***** creation helper functions *****
 
   @staticmethod
-  def full(shape:Tuple[int, ...], fill_value, **kwargs): return Tensor(fill_value, **kwargs).reshape([1]*len(new_shape := tuple(map(int, argfix(shape))))).expand(new_shape).contiguous()
+  def full(shape:Tuple[int, ...], fill_value, **kwargs): return Tensor(fill_value, **kwargs).reshape([1]*len(new_shape := argfix(shape))).expand(new_shape).contiguous()
 
   @staticmethod
   def zeros(*shape, **kwargs): return Tensor.full(argfix(*shape), 0, **kwargs)
@@ -143,7 +143,7 @@ class Tensor:
   def ones(*shape, **kwargs): return Tensor.full(argfix(*shape), 1, **kwargs)
 
   @staticmethod
-  def arange(stop, start=0, step=1, **kwargs): return Tensor.full(((stop-start)//step,), step, **kwargs).cumsum() + (start - step)
+  def arange(stop, start=0, step=1, **kwargs): return Tensor.full((int((stop-start)//step),), step, **kwargs).cumsum() + (start - step)
 
   @staticmethod
   def full_like(tensor, fill_value, dtype:Optional[DType]=None, **kwargs):


### PR DESCRIPTION
OnnxBackendPyTorchConvertedModelTest eats up too much ram triggering my oom, so these results are without it.
 
`242 failed, 500 passed, 1892 skipped, 2 warnings in 25.76s`