### PR TITLE
Onnx slice fixups 

### DIFF
--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -176,10 +176,8 @@ def get_run_onnx(onnx_model: ModelProto):
         continue
       elif n.op_type == "Slice":
         assert onnx_model_version >= 10, f'only onnx version >= 10 supported for slice'
-        # print("INPUTS", len(inp))
         arg = [(0,x) for x in inp[0].shape]
         starts, ends = inp[1:3]
-        # print(starts, ends)
         axes = safe_numpy(Tensor.arange(inp[0].ndim, dtype=dtypes.int32) if len(inp) <= 3 else inp[3])
         steps = safe_numpy(inp[4])[0] if len(inp) > 4 else 1
         starts, ends = safe_numpy(starts.cast(dtypes.int32)).tolist(), safe_numpy(ends.cast(dtypes.int32)).tolist() # TODO: when indexing is added use that
@@ -206,7 +204,7 @@ def get_run_onnx(onnx_model: ModelProto):
       if debug: print([x.shape if isinstance(x, Tensor) else None for x in ret])
       if debug: print("outputs:")
       for i in range(len(n.output)): 
-        if debug: print(f"\t{n.output[i]} shape - {ret[i].shape if isinstance(ret[i], Tensor) else ret[i]} dtype - {ret[i].dtype if isinstance(ret[i], Tensor) else ret[i]}")
+        if debug: print(f"\t{n.output[i]} - {ret[i]}")
         intermediate_tensors[n.output[i]] = ret[i]
       #print(ret[0].numpy().mean())
       if num == ONNXLIMIT:

--- a/extra/onnx.py
+++ b/extra/onnx.py
@@ -4,6 +4,7 @@ import importlib
 import numpy as np
 from tinygrad.tensor import Tensor
 from tinygrad.helpers import prod, getenv, DEBUG, dtypes
+from typing import List
 from onnx.onnx_pb import AttributeProto, ModelProto, TensorProto
 try:
   from onnx.helper import tensor_dtype_to_np_dtype
@@ -110,7 +111,7 @@ def get_run_onnx(onnx_model: ModelProto):
       return None
 
     for num,n in enumerate(onnx_model.graph.node):
-      inp = []
+      inp: List[Tensor] = []
       if debug: print("inputs:")
       for x in n.input:
         t = fetch_tensor(x)

--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -75,7 +75,7 @@ def _padding(X, pads=None, auto_pad="NOTSET", axes=None, constant_value=0.):
   return zero_padded + constant_padder
 
 def Pad(x: Tensor, pads: Union[Tensor, Tuple[int, ...]], constant_value: Tensor=None, axes: Tensor=None, mode="constant", value: float=0.):
-  assert mode == "constant"
+  assert mode == "constant", f"WARNING: Pad mode {mode} not implemented"
   constant_value = value if constant_value is None else constant_value.numpy()
   seq_pads = list(pads) if isinstance(pads, tuple) else pads.numpy().astype(np.int32).tolist()
   seq_axes = axes.numpy().astype(np.int32).tolist() if axes is not None else None
@@ -110,8 +110,8 @@ def Dropout(data, ratio=0.5, training_mode=False, seed=None):
   mask = Tensor((rng.random(data.shape) >= ratio), requires_grad=False, device=data.device)
   return data * mask * (1/(1.0 - ratio)), mask
 
-def Shape(data, end=None, start=0): return list(data.shape)[start:end]
-def Size(data): return prod(data.shape)
+def Shape(data, end=None, start=0): return Tensor(list(data.shape)[start:end], dtype=dtypes.int64)
+def Size(data): return prod(data if isinstance(data, list) else data.shape)
 
 # TODO: this doesn't match Tensor.flatten behavior
 def Flatten(input, axis=1):

--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -92,18 +92,9 @@ backend_test.exclude('test_asin_*')
 backend_test.exclude('test_asinh_*')
 backend_test.exclude('test_atan_*')
 backend_test.exclude('test_atanh_*')
-# backend_test.include('test_cos_*')
-# backend_test.include('test_cosh_*')
-# backend_test.exclude('test_sin_*')
-# backend_test.include('test_sinh_*')
-# backend_test.include('test_tanh_*')
 
 # no boolean ops (2d, 3d, 4d)
-# backend_test.exclude('test_and*')
-# backend_test.exclude('test_xor*')
-# backend_test.exclude('test_or*')
 backend_test.exclude('test_bitshift_*')
-# backend_test.include('test_not_*')
 
 # no scatter gather
 backend_test.exclude('test_gather_*')

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -76,7 +76,7 @@ class dtypes:
   def from_np(x) -> DType: return asdict(dtypes())[np.dtype(x).name]
   bool: Final[DType] = DType(0, 1, "bool", bool)
   float16: Final[DType] = DType(0, 2, "half", np.float16)
-  float32: Final[DType] = DType(1, 4, "float", np.float32)
+  float32: Final[DType] = DType(4, 4, "float", np.float32)
   int8: Final[DType] = DType(0, 1, "char", np.int8)
   int32: Final[DType] = DType(1, 4, "int", np.int32)
   int64: Final[DType] = DType(2, 8, "int64", np.int64)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -143,7 +143,7 @@ class Tensor:
   def ones(*shape, **kwargs): return Tensor.full(argfix(*shape), 1, **kwargs)
 
   @staticmethod
-  def arange(stop, start=0, step=1, **kwargs): return Tensor.full(((stop-start)//step,), step).cumsum() + (start - step)
+  def arange(stop, start=0, step=1, **kwargs): return Tensor.full(((stop-start)//step,), step, **kwargs).cumsum() + (start - step)
 
   @staticmethod
   def full_like(tensor, fill_value, dtype:Optional[DType]=None, **kwargs):
@@ -470,7 +470,7 @@ class Tensor:
 
   def cumsum(self, axis=0):
     x = self.permute(*(i for i in range(self.ndim) if i != axis), axis)
-    return x.reshape(1, 1, -1, self.shape[axis]).conv2d(Tensor.ones(1, 1, 1, self.shape[axis]), padding=(self.shape[axis]-1, 0, 0, 0)).reshape(*x.shape).permute(*range(axis), self.ndim - 1, *range(axis, self.ndim-1))
+    return x.reshape(1, 1, -1, self.shape[axis]).conv2d(Tensor.ones(1, 1, 1, self.shape[axis], dtype=self.dtype), padding=(self.shape[axis]-1, 0, 0, 0)).reshape(*x.shape).permute(*range(axis), self.ndim - 1, *range(axis, self.ndim-1))
   
   # ***** mlops (unary) *****
 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -470,7 +470,7 @@ class Tensor:
 
   def cumsum(self, axis=0):
     x = self.permute(*(i for i in range(self.ndim) if i != axis), axis)
-    return x.reshape(1, 1, -1, self.shape[axis]).conv2d(Tensor.ones(1, 1, 1, self.shape[axis], dtype=self.dtype), padding=(self.shape[axis]-1, 0, 0, 0)).reshape(*x.shape).permute(*range(axis), self.ndim - 1, *range(axis, self.ndim-1))
+    return x.reshape(1, 1, -1, self.shape[axis]).conv2d(Tensor.ones(1, 1, 1, self.shape[axis], dtype=self.dtype, device=self.device), padding=(self.shape[axis]-1, 0, 0, 0)).reshape(*x.shape).permute(*range(axis), self.ndim - 1, *range(axis, self.ndim-1))
   
   # ***** mlops (unary) *****
 


### PR DESCRIPTION
Resolved some issues with Slice/Shape/Size that were causing some tests to fail.

Made some changes to onnx debugging to help track models that use multiple ops. 

Increased the priority of float in dtypes to match torch when adding float + int64

Before - 283 failed, 541 passed, 1810 skipped, 2 warnings in 14.55s
After - 258 failed, 566 passed, 1810 skipped, 2 warnings in 14.10s