### PR TITLE
Test nllloss

### DIFF
--- a/extra/onnx_ops.py
+++ b/extra/onnx_ops.py
@@ -230,3 +230,13 @@ def MeanVarianceNormalization(input, axis=(0, 2, 3)):
   data_mean = input.mean(axis=axis, keepdim=True)
   std = ((input**2).mean(axis=axis, keepdim=True) - data_mean**2).sqrt()
   return (input - data_mean) / (std + 1e-9)
+
+def NegativeLogLikelihoodLoss(input, target, weights=None, ignore_index=None, reduction="mean"):
+  # Create an index array that selects the correct class from the log_probs
+  # Index into the log_probs with the class indices in target
+  loss = -((target[:,None] == Tensor.arange(input.shape[1])) * input).T.sum(axis=0)
+  if reduction == "mean":
+    loss = loss.mean()
+  elif reduction == "sum":
+    loss = loss.sum(axis=0)
+  return self# loss 

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -256,6 +256,7 @@ class Tensor:
   #          is possible.
   #        - Apply Shrink to do the slice [:, 0] on axes of shapes [dim_sz_padded // s, s].
   def __getitem__(self, val):
+    print(val)
     def normalize_int(e, i, dim_sz):
       if -dim_sz <= e < dim_sz: return e if e != -1 else dim_sz-1
       raise IndexError(f"index {e} is out of bounds for dimension {i} with size {self.shape[i]}")

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -256,7 +256,6 @@ class Tensor:
   #          is possible.
   #        - Apply Shrink to do the slice [:, 0] on axes of shapes [dim_sz_padded // s, s].
   def __getitem__(self, val):
-    print(val)
     def normalize_int(e, i, dim_sz):
       if -dim_sz <= e < dim_sz: return e if e != -1 else dim_sz-1
       raise IndexError(f"index {e} is out of bounds for dimension {i} with size {self.shape[i]}")


### PR DESCRIPTION
Before
=== 227 failed, 597 passed, 1810 skipped, 2 warnings in 34.87s ===
After
=== 209 failed, 615 passed, 1810 skipped, 2 warnings in 27.66s ===

The implementation is slower than torch.NLLLoss but I had to do the indexing using a mask. Also, I only use NumPy to gather the weights but if that's a problem I could probably find another way. 