### PR TITLE
clang rt for msvc

### DIFF
--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -5,10 +5,10 @@ from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 
 cfg = {
   # NOTE: --rtlib=compiler-rt fixes float16 on Linux, it defines __gnu_h2f_ieee and __gnu_f2h_ieee
-  'base'   : ['clang', '-shared', '-O2', '-Wall', '-Werror', '--rtlib=compiler-rt', '-x', 'c'],
+  'base': ['clang', '-shared', '-O2', '-Wall', '-Werror', '--rtlib=compiler-rt', '-x', 'c'],
   'Windows': {'cflags':[''], 'ext':'dll', 'export':'__declspec(dllexport)'},
-  'Linux'  : {'cflags':['-lm', '-fPIC'], 'ext':'so', 'export':'__attribute__((visibility("default")))'},
-  'Darwin' : {'cflags':[''], 'ext':'dylib', 'export':''}
+  'Linux': {'cflags':['-lm', '-fPIC'], 'ext':'so', 'export':'__attribute__((visibility("default")))'},
+  'Darwin': {'cflags':[''], 'ext':'dylib', 'export':''}
 }
 plat_cfg = cfg[platform.system()]
 

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -5,10 +5,10 @@ from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 
 cfg = {
   # NOTE: --rtlib=compiler-rt fixes float16 on Linux, it defines __gnu_h2f_ieee and __gnu_f2h_ieee
-  'base': ['clang', '-shared', '-O2', '-Wall', '-Werror', '--rtlib=compiler-rt', '-x', 'c'],
-  'Windows': {'cflags':[''], 'ext':'dll', 'export':'__declspec(dllexport)'},
-  'Linux': {'cflags':['-lm', '-fPIC'], 'ext':'so', 'export':'__attribute__((visibility("default")))'},
-  'Darwin': {'cflags':[''], 'ext':'dylib', 'export':''}
+  'base': {'cflags':'clang -shared -O2 -Wall -Werror --rtlib=compiler-rt -x c', 'ext':'', 'export':''},
+  'Windows': {'cflags':'', 'ext':'dll', 'export':'__declspec(dllexport)'},
+  'Linux': {'cflags':'-lm -fPIC', 'ext':'so', 'export':'__attribute__((visibility("default")))'},
+  'Darwin': {'cflags':'', 'ext':'dylib', 'export':''}
 }
 plat_cfg = cfg[platform.system()]
 
@@ -18,7 +18,7 @@ class ClangProgram:
     # TODO: is there a way to not write this to disk?
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{plat_cfg['ext']}"
     if not os.path.exists(fn):
-      subprocess.check_output(cfg['base'] + plat_cfg['cflags'] + ['-o', fn+".tmp", '-'], input=prg.encode('utf-8'))
+      subprocess.check_output( (cfg['base']['cflags']+' '+plat_cfg['cflags']+ ' -o ' + fn+ '.tmp -').split(), input=prg.encode('utf-8'))
       os.rename(fn+".tmp", fn)
     self.lib = ctypes.CDLL(fn)
     self.fxn = self.lib[name]

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -1,16 +1,24 @@
-import os, time, ctypes, hashlib, subprocess, platform
+import os, time, ctypes, hashlib, subprocess, platform, tempfile
 from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawMallocBuffer
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
+
+cfg = {
+  # NOTE: --rtlib=compiler-rt fixes float16 on Linux, it defines __gnu_h2f_ieee and __gnu_f2h_ieee
+  'base'   : ['clang', '-shared', '-O2', '-Wall', '-Werror', '--rtlib=compiler-rt', '-x', 'c'],
+  'Windows': {'cflags':[''], 'ext':'dll', 'export':'__declspec(dllexport)'},
+  'Linux'  : {'cflags':['-lm', '-fPIC'], 'ext':'so', 'export':'__attribute__((visibility("default")))'},
+  'Darwin' : {'cflags':[''], 'ext':'dylib', 'export':''}
+}
+plat_cfg = cfg[platform.system()]
 
 class ClangProgram:
   def __init__(self, name:str, prg:str):
     prg = "#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n" + prg
     # TODO: is there a way to not write this to disk?
-    fn = f"/tmp/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{'dylib' if platform.system() == 'Darwin' else 'so'}"
-    # NOTE: --rtlib=compiler-rt fixes float16 on Linux, it defines __gnu_h2f_ieee and __gnu_f2h_ieee
+    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{plat_cfg['ext']}"
     if not os.path.exists(fn):
-      subprocess.check_output(['clang', '-shared', '-O2', '-Wall','-Werror', '-lm', '--rtlib=compiler-rt', '-fPIC', '-x', 'c', '-', '-o', fn+".tmp"], input=prg.encode('utf-8'))
+      subprocess.check_output(cfg['base'] + plat_cfg['cflags'] + ['-o', fn+".tmp", '-'], input=prg.encode('utf-8'))
       os.rename(fn+".tmp", fn)
     self.lib = ctypes.CDLL(fn)
     self.fxn = self.lib[name]
@@ -21,7 +29,7 @@ class ClangProgram:
     if wait: return time.monotonic()-st
 
 class ClangCodegen(CStyleCodegen):
-  lang = CStyleLanguage(buffer_suffix=" restrict")
+  lang = CStyleLanguage(kernel_prefix=plat_cfg['export'], buffer_suffix=" restrict")
   supports_float4: bool = False
 
 ClangBuffer = Compiled(RawMallocBuffer, ClangCodegen, ClangProgram)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -3,22 +3,24 @@ from tinygrad.ops import Compiled
 from tinygrad.runtime.lib import RawMallocBuffer
 from tinygrad.codegen.cstyle import CStyleCodegen, CStyleLanguage
 
-cfg = {
-  # NOTE: --rtlib=compiler-rt fixes float16 on Linux, it defines __gnu_h2f_ieee and __gnu_f2h_ieee
-  'base': {'cflags':'clang -shared -O2 -Wall -Werror --rtlib=compiler-rt -x c', 'ext':'', 'export':''},
-  'Windows': {'cflags':'', 'ext':'dll', 'export':'__declspec(dllexport)'},
-  'Linux': {'cflags':'-lm -fPIC', 'ext':'so', 'export':'__attribute__((visibility("default")))'},
-  'Darwin': {'cflags':'', 'ext':'dylib', 'export':''}
-}
-plat_cfg = cfg[platform.system()]
+class Config:
+  program = '#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n'
+  platform = {
+    'Windows': {'cflags':'', 'ext':'dll', 'export':'__declspec(dllexport)'},
+    'Linux': {'cflags':'-lm -fPIC --rtlib=compiler-rt ', 'ext':'so', 'export':'__attribute__((visibility("default")))'},
+    'Darwin': {'cflags':'', 'ext':'dylib', 'export':''}
+  }[platform.system()]
+  command = 'clang -shared -O2 -Wall -Werror -x c '+platform['cflags']+' - -o '
+  extension = platform['ext']
+  export = platform['export']
 
 class ClangProgram:
   def __init__(self, name:str, prg:str):
-    prg = "#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n" + prg
+    prg = Config.program + prg
     # TODO: is there a way to not write this to disk?
-    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{plat_cfg['ext']}"
+    fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{Config.extension}"
     if not os.path.exists(fn):
-      subprocess.check_output( (cfg['base']['cflags']+' '+plat_cfg['cflags']+ ' -o ' + fn+ '.tmp -').split(), input=prg.encode('utf-8'))
+      subprocess.check_output((Config.command + fn+'.tmp').split(), input=prg.encode('utf-8'))
       os.rename(fn+".tmp", fn)
     self.lib = ctypes.CDLL(fn)
     self.fxn = self.lib[name]
@@ -29,7 +31,7 @@ class ClangProgram:
     if wait: return time.monotonic()-st
 
 class ClangCodegen(CStyleCodegen):
-  lang = CStyleLanguage(kernel_prefix=plat_cfg['export'], buffer_suffix=" restrict")
+  lang = CStyleLanguage(kernel_prefix=Config.export, buffer_suffix=" restrict")
   supports_float4: bool = False
 
 ClangBuffer = Compiled(RawMallocBuffer, ClangCodegen, ClangProgram)

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -9,7 +9,7 @@ class DynLib:
     self.args = {
       'Windows': {'cflags':'', 'ext':'dll', 'exp':'__declspec(dllexport)'},
       'Linux': {'cflags':'-lm -fPIC --rtlib=compiler-rt ', 'ext':'so', 'exp':''},
-      'Darwin': {'cflags':'', 'ext':'dylib', 'exp':''}
+      'Darwin': {'cflags':'-lm -fPIC --rtlib=compiler-rt ', 'ext':'dylib', 'exp':''}
     }[sys]
     self.ext = self.args['ext']
     self.exp = self.args['exp']

--- a/tinygrad/runtime/ops_clang.py
+++ b/tinygrad/runtime/ops_clang.py
@@ -11,7 +11,7 @@ args = {
 
 class ClangProgram:
   def __init__(self, name:str, prg:str):
-    prg = '#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n' + prg;
+    prg = '#include <math.h>\n#define max(x,y) ((x>y)?x:y)\n#define int64 long\n#define half __fp16\n#define uchar unsigned char\n#define bool uchar\n' + prg
     # TODO: is there a way to not write this to disk?
     fn = f"{tempfile.gettempdir()}/clang_{hashlib.md5(prg.encode('utf-8')).hexdigest()}.{args['ext']}"
     if not os.path.exists(fn):


### PR DESCRIPTION
addressing #981 
- split clang cflags, dynlib extension, and function export decorator by platform
- removed clang-rt from msvc linker args based on comment, added msvc dllexport decorator for kernel function
- retained darwin cflags from the linux config as i am not setup to verify correctness (assuming clang rt worked as expected on darwin)

tested on: win10, arch

note: these cflags assume the clang in PATH is set to target the host machine by default, some additional configuration would allow cross compilation 