### PR TITLE
Add tensorflow GEMM benchmark script

### DIFF
--- a/extra/gemm/tf_gemm.py
+++ b/extra/gemm/tf_gemm.py
@@ -1,0 +1,33 @@
+import time
+import tensorflow as tf
+
+gpus = tf.config.list_physical_devices('GPU')
+if gpus:
+  try:
+    # Currently, memory growth needs to be the same across GPUs
+    for gpu in gpus:
+      tf.config.experimental.set_memory_growth(gpu, True)
+    logical_gpus = tf.config.list_logical_devices('GPU')
+    print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
+  except RuntimeError as e:
+    # Memory growth must be set before GPUs have been initialized
+    print(e)
+
+for dtype in [tf.float16, tf.float32]:
+  for N in [256, 512, 1024, 2048, 4096, 8192]:
+    FLOPS = N*N*N*2
+
+    b = tf.random.uniform((N, N), dtype=dtype)
+    c = tf.random.uniform((N, N), dtype=dtype)
+
+    b = tf.Variable(b)
+    c = tf.Variable(c)
+
+    def tf_prog(b, c):
+      st = time.perf_counter()
+      a = tf.matmul(b, c)
+      tf.debugging.check_numerics(a, "Nan or Inf in result") # Ensures that the calculation is done.
+      return time.perf_counter() - st
+
+    tm = min([tf_prog(b, c) for _ in range(20)])
+    print(f"{N*N:10d} {tm*1e6:9.2f} us, would be {FLOPS*1e-9/tm:9.2f} GFLOPS {N:4d}x{N:4d}x{N:4d} matmul in {dtype}")


### PR DESCRIPTION
I was running into extremely poor performance training with TensorFlow on my AMD card, which led me to this repository.  I was curious how TF stacked up compared to tinygrad, and I figured this script might be useful to others as well.

It's modelled closely after the existing torch benchmark script but just adapted slightly for tensorflow.

Here are my results for `tf_gemm.py` on 7900 XTX with ROCm 5.5:

```
     65536    107.37 us, would be    312.52 GFLOPS  256x 256x 256 matmul in <dtype: 'float16'>
    262144    105.39 us, would be   2546.97 GFLOPS  512x 512x 512 matmul in <dtype: 'float16'>
   1048576    171.60 us, would be  12514.40 GFLOPS 1024x1024x1024 matmul in <dtype: 'float16'>
   4194304    316.75 us, would be  54237.60 GFLOPS 2048x2048x2048 matmul in <dtype: 'float16'>
  16777216   1360.75 us, would be 101002.35 GFLOPS 4096x4096x4096 matmul in <dtype: 'float16'>
  67108864  11088.54 us, would be  99157.45 GFLOPS 8192x8192x8192 matmul in <dtype: 'float16'>
     65536    154.33 us, would be    217.42 GFLOPS  256x 256x 256 matmul in <dtype: 'float32'>
    262144    171.53 us, would be   1564.94 GFLOPS  512x 512x 512 matmul in <dtype: 'float32'>
   1048576    446.09 us, would be   4813.99 GFLOPS 1024x1024x1024 matmul in <dtype: 'float32'>
   4194304   2506.63 us, would be   6853.79 GFLOPS 2048x2048x2048 matmul in <dtype: 'float32'>
  16777216  20202.74 us, would be   6802.99 GFLOPS 4096x4096x4096 matmul in <dtype: 'float32'>
  67108864 175615.43 us, would be   6260.91 GFLOPS 8192x8192x8192 matmul in <dtype: 'float32'>
```

Compared to `torch_gemm.py`:

```
     65536     33.16 us, would be   1011.77 GFLOPS  256x 256x 256 matmul in torch.float16
    262144     41.93 us, would be   6401.84 GFLOPS  512x 512x 512 matmul in torch.float16
   1048576    103.30 us, would be  20788.81 GFLOPS 1024x1024x1024 matmul in torch.float16
   4194304    307.41 us, would be  55885.12 GFLOPS 2048x2048x2048 matmul in torch.float16
  16777216   1156.04 us, would be 118887.30 GFLOPS 4096x4096x4096 matmul in torch.float16
     65536     32.08 us, would be   1045.90 GFLOPS  256x 256x 256 matmul in torch.float32
    262144     64.71 us, would be   4148.60 GFLOPS  512x 512x 512 matmul in torch.float32
   1048576    338.51 us, would be   6344.02 GFLOPS 1024x1024x1024 matmul in torch.float32
   4194304   2285.88 us, would be   7515.65 GFLOPS 2048x2048x2048 matmul in torch.float32
  16777216  19274.65 us, would be   7130.56 GFLOPS 4096x4096x4096 matmul in torch.float32
```

Seems that f16 is close to theoretical max, but f32 is ~10x slower than theoretical max.

Running the `rocm/rdna3/asm.py` script gives me 60TFLOPS f32 performance, matching theoretical max.  I'd love to see if it's possible to hit that 120TFLOPS f16 mark via the raw assembly approach you're currently using!