### PR TITLE
Minor improvements + cleanup to `ops_gpu.py`

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -38,6 +38,9 @@ ENABLE_METHOD_CACHE | [1]        | enable method cache (this is the default)
 EARLY_STOPPING      | [# > 0]  | stop after this many kernels
 DISALLOW_ASSIGN     | [1]        | disallow assignment of tensors
 NATIVE_EXPLOG       | [1]        | enable using native exp and log
+CL_EXCLUDE          | [name0,name1] | comma-separated list of device names to exclude when using OpenCL GPU backend (like `CL_EXCLUDE=gfx1036`)
+CL_PLATFORM         | [# >= 0]   | index of the OpenCL [platform](https://documen.tician.de/pyopencl/runtime_platform.html#pyopencl.Platform) to run on. Defaults to 0.
+RDNA                | [1]        | enable the specialized [RDNA 3](https://en.wikipedia.org/wiki/RDNA_3) assembler for AMD 7000-series GPUs. If not set, defaults to generic OpenCL codegen backend.
 
 ## File Specific Variables
 

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -19,8 +19,9 @@ if DEBUG >= 5:
 class _CL:
   def __init__(self):
     platforms: List[List[cl.Device]] = [y for y in ([x.get_devices(device_type=cl.device_type.GPU) for x in cl.get_platforms()] + [x.get_devices(device_type=cl.device_type.CPU) for x in cl.get_platforms()]) if len(y)]
-    if DEBUG >= 1: print(f"using devices: {[d.hashable_model_and_version_identifier for d in platforms[getenv('CL_PLATFORM', 0)] if d.name not in getenv('CL_EXCLUDE', '').split(',')]}")
-    self.cl_ctx: cl.Context = cl.Context(devices=[x for x in platforms[getenv('CL_PLATFORM', 0)] if x.name not in getenv('CL_EXCLUDE', '').split(',')])
+    devices: List[cl.Device] = [x for x in platforms[getenv('CL_PLATFORM', 0)] if x.name not in getenv('CL_EXCLUDE', '').split(',')]
+    if DEBUG >= 1: print(f"using devices: {[d.hashable_model_and_version_identifier for d in devices]}")
+    self.cl_ctx: cl.Context = cl.Context(devices=devices)
     self.cl_queue: List[cl.CommandQueue] = [cl.CommandQueue(self.cl_ctx, device=device, properties=cl.command_queue_properties.PROFILING_ENABLE) for device in self.cl_ctx.devices]
 
   def synchronize(self):

--- a/tinygrad/runtime/ops_gpu.py
+++ b/tinygrad/runtime/ops_gpu.py
@@ -18,9 +18,9 @@ if DEBUG >= 5:
 
 class _CL:
   def __init__(self):
-    platform: List[cl.Device] = [y for y in ([x.get_devices(device_type=cl.device_type.GPU | cl.device_type.CPU) for x in cl.get_platforms()]) if len(y)][getenv('CL_PLATFORM', 0)]
-    if DEBUG >= 1: print(f"using devices: {[d.hashable_model_and_version_identifier for d in platform if d.name not in getenv('CL_EXCLUDE', '').split(',')]}")
-    self.cl_ctx: cl.Context = cl.Context(devices=[x for x in platform if x.name not in getenv('CL_EXCLUDE', '').split(',')])
+    platforms: List[List[cl.Device]] = [y for y in ([x.get_devices(device_type=cl.device_type.GPU) for x in cl.get_platforms()] + [x.get_devices(device_type=cl.device_type.CPU) for x in cl.get_platforms()]) if len(y)]
+    if DEBUG >= 1: print(f"using devices: {[d.hashable_model_and_version_identifier for d in platforms[getenv('CL_PLATFORM', 0)] if d.name not in getenv('CL_EXCLUDE', '').split(',')]}")
+    self.cl_ctx: cl.Context = cl.Context(devices=[x for x in platforms[getenv('CL_PLATFORM', 0)] if x.name not in getenv('CL_EXCLUDE', '').split(',')])
     self.cl_queue: List[cl.CommandQueue] = [cl.CommandQueue(self.cl_ctx, device=device, properties=cl.command_queue_properties.PROFILING_ENABLE) for device in self.cl_ctx.devices]
 
   def synchronize(self):


### PR DESCRIPTION
## Changes

 * Add some previously undocumented environment variables from `ops_gpu.py` to `env_vars.md`
 * Update debug print for OpenCL to print the devices that will be used post-filtering with `CL_EXCLUDE`
   * Print more detailed device info rather than raw Python objects with addresses etc.
 * Remove a couple unused or superfluous variables and assignments
 * Use `fromimport` shorthand to shave off a couple precious LOC
 * Couple small whitespace changes to clean things up

## Summary

The main motivation for this was to ease setup for users like me that have to filter out an iGPU from their OpenCL device list.  Trying to launch kernels on the iGPU causes the Python script to hang at best and my computer to blackscreen at worst.

I felt that printing out the _actual_ devices that are used post-filtering made more sense, as without that it seems that the filtering isn't working.

I don't know if some of these changes would be considered "code golf".  I tried to match the terseness and density of the existing code as best I could.

