### PR TITLE
added CUDA and PTX to env_vars.md

### DIFF
--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -17,6 +17,7 @@ Variable | Possible Value(s) | Description
 ---|---|---
 DEBUG               | [1-4]      | enable debugging output, with 4 you get operations, timings, speed, generated code and more
 GPU                 | [1]        | enable the GPU backend
+CUDA                | [1]        | enable CUDA backend
 CPU                 | [1]        | enable CPU backend
 MPS                 | [1]        | enable MPS device (for Mac M1 and after)
 METAL               | [1]        | enable Metal backend (for Mac M1 and after)
@@ -41,6 +42,7 @@ NATIVE_EXPLOG       | [1]        | enable using native exp and log
 CL_EXCLUDE          | [name0,name1] | comma-separated list of device names to exclude when using OpenCL GPU backend (like `CL_EXCLUDE=gfx1036`)
 CL_PLATFORM         | [# >= 0]   | index of the OpenCL [platform](https://documen.tician.de/pyopencl/runtime_platform.html#pyopencl.Platform) to run on. Defaults to 0.
 RDNA                | [1]        | enable the specialized [RDNA 3](https://en.wikipedia.org/wiki/RDNA_3) assembler for AMD 7000-series GPUs. If not set, defaults to generic OpenCL codegen backend.
+PTX                 | [1]        | enable the specialized [PTX](https://docs.nvidia.com/cuda/parallel-thread-execution/) assembler for Nvidia GPUs. If not set, defaults to generic CUDA codegen backend.
 
 ## File Specific Variables
 


### PR DESCRIPTION
I found out that CUDA and PTX environment variables were not there in env_vars.md, thus I added them. It they were left out intentionally feel free to close.