### PR TITLE
Add RDNA3 assembler `UOps.CAST` partial support + other fixes/improvements

### DIFF
--- a/test/external/external_test_image.py
+++ b/test/external/external_test_image.py
@@ -7,7 +7,6 @@ if 'IMAGE' not in os.environ:
 os.environ['GPU'] = '1'
 os.environ['OPT'] = '2'
 from tinygrad.tensor import Tensor
-from tinygrad.runtime.ops_gpu import CLImage
 from tinygrad.nn import Conv2d
 Tensor.no_grad = True
 
@@ -16,16 +15,14 @@ class TestImage(unittest.TestCase):
     t = Tensor.ones(128, 128, 1)
     t = t.reshape(128, 32, 4) + 3
     t.realize()
-    assert isinstance(t.lazydata.realized._buf, CLImage)
     np.testing.assert_array_equal(t.numpy(), np.ones((128,32,4))*4)
 
   def test_sum_image(self):
     t1 = Tensor.ones(16, 16, 1).reshape(16, 4, 4) + 3
     t1.realize()
-    assert isinstance(t1.lazydata.realized._buf, CLImage)
     t1 = t1.sum()
     t1.realize()
-    assert t1.numpy()[0] == 16*4*4*4, f"got {t1.numpy()}"
+    assert t1.numpy() == 16*4*4*4, f"got {t1.numpy()}"
   
   def test_add_image(self):
     t1 = Tensor.ones(16, 16, 1).reshape(16, 4, 4) + 3
@@ -34,7 +31,6 @@ class TestImage(unittest.TestCase):
     t2.realize()
     t3 = t1 + t2
     t3.realize()
-    assert isinstance(t3.lazydata.realized._buf, CLImage)
     np.testing.assert_array_equal(t3.numpy(), np.ones((16,4,4))*9)
 
   def test_padded_conv(self):


### PR DESCRIPTION
 * Adds support for casting from `bool` -> `float32`.  Seems like a very common operation that is required in many places.
 * Fix bool register definition for vector operations
   * Use `vcc_lo` instead of `vcc` which seems to be required since it's configured to use wavefront_size=32
 * Add vector support for some places that were scalar only in register definition and comparison ops
 * Fix some issues in what seems to be defunct `external_test_image.py`
   * Some tests still don't pass for other reasons, but it at least runs now and one broken test is now fixed
 * Refactor RDNA3 assembler register definition
   * Unify multi-registor code between dtypes and combine with single-register allocation since they're all untyped registers at the end of the day

----

My main goal starting out today was to train a small neural net from scratch using the RDNA3 backend.  Here's the code I have for that so far:

<details>
<summary>expand</summary>

```py
import numpy as np
import time
from tinygrad.tensor import Tensor, dtypes
from tinygrad.nn import Linear
from tinygrad.nn.optim import Adam, SGD
from tinygrad.state import get_parameters

nclasses = 10
nsamples = 3000000
bsize = nsamples // 20
bcount = nsamples // bsize
inp_units = 100


class MLP:
    def __init__(self):
        self.l1 = Linear(inp_units, 2500)
        # self.l2 = Linear(2500, 2500)
        self.l3 = Linear(2500, 250)
        self.l4 = Linear(250, nclasses)

    def __call__(self, x):
        x = self.l1(x).relu()
        # x = self.l2(x).relu()
        x = self.l3(x).relu()
        x = self.l4(x).softmax()
        return x


mod = MLP()

Tensor.training = True

trainable_params = get_parameters(mod)
# print("trainable params", trainable_params)
# opt = Adam(trainable_params, lr=0.001)
opt = SGD(trainable_params, lr=0.001)


def sparse_categorical_crossentropy(out, Y):
    num_classes = out.shape[-1]
    YY = Y.flatten().astype(np.int32)
    y = np.zeros((YY.shape[0], num_classes), np.float32)
    # correct loss for NLL, torch NLL loss returns one per row
    y[range(y.shape[0]), YY] = -1.0 * num_classes
    y = y.reshape(list(Y.shape) + [num_classes])
    y = Tensor(y)
    return out.mul(y).mean()


data = np.random.rand(nsamples, inp_units).astype(np.float32)
data = Tensor(data, dtype=dtypes.float32, requires_grad=False)

for epoch in range(20):
    start = time.perf_counter()

    for batch_ix in range(bcount):
        batch = data[batch_ix * bsize : (batch_ix + 1) * bsize]
        labels = np.random.randint(0, nclasses - 1, bsize)

        out = mod(batch)
        print("out", out)

        loss = sparse_categorical_crossentropy(out, labels)
        print("loss", loss)

        # zero gradients
        opt.zero_grad()

        # backward pass
        loss.backward()

        opt.step()

        pred = np.argmax(out.numpy(), axis=-1)
        acc = (pred == labels).mean()

        if batch_ix % 10 == 0:
            print(f"step {epoch} batch {batch_ix} loss {loss.numpy()} acc {acc}")

    end = time.perf_counter()
    print(f"epoch {epoch} took {end - start} seconds")
```
</details>

I wrote a tiny test case that was failing before but seems to be working now:

```py
from tinygrad.tensor import Tensor
from tinygrad.helpers import dtypes
import numpy as np

x = Tensor(np.array([1]), dtype=dtypes.float32)
y = Tensor(np.array([1]), dtype=dtypes.float32)
z = Tensor(np.array([-0.2]), dtype=dtypes.float32)

res = (x.eq(y).cast(dtypes.float32).numpy(), y.eq(z).cast(dtypes.float32).numpy())
print(res) # (array([1.], dtype=float32), array([0.], dtype=float32))

# RDNA=1 DEBUGCL=5 DEBUG=5 GPU=1 OPTLOCAL=1 PRINT_KERNEL=1 python3 test_cmp.py
```

I didn't see any existing test cases for the RDNA3 assembler, but if there are some I'd be happy to add this.  That being said, idk how it would even be possible to test RDNA3 stuff since it would require running it on an actual RDNA3 GPU theoretically, for the E2E experience at least.  Could get some mileage out of just making sure codegen and/or assembly works, though.

----

When testing training of a simple neural network using the RDNA3 backend, I encountered some other issues.  The assembler is running out of registers in some cases:

```
<stdin>:316:11: error: register index is out of range
v_sub_f32 v256, v11, v226
          ^
<stdin>:317:11: error: register index is out of range
v_sub_f32 v257, v11, v227
          ^
<stdin>:318:11: error: register index is out of range
v_sub_f32 v258, v11, v228
          ^
<stdin>:346:16: error: register index is out of range
v_add_f32 v10, v256, v10
               ^
<stdin>:347:16: error: register index is out of range
v_add_f32 v10, v257, v10
               ^
<stdin>:348:16: error: register index is out of range
v_add_f32 v10, v258, v10
```

This is fixed when I disable loop unrolling [in the linearizer](https://github.com/geohot/tinygrad/blob/master/tinygrad/codegen/linearizer.py#L528-L536), but that's obviously not a real solution.  I know register allocation is, like, something people devote their research careers to, so the solution here might not be easy.

The final issue I ran into is `NotImplementedError: UOps.DEFINE_LOCAL`.  Idk if this will require working with scratch memory on the GPU or what, but it's definitely not something I'm going to tackle now.

----

That all being said, the RDNA3 assembler as it is is already doing an impressive job.  The whole forward pass through the network is working and things seem to be failing in the optimizer.  So it might be quite close!

Anyway, I'd be happy to add in some small test cases for some of these things.  If you have some direction on how you want those structured, where you want them placed, etc. just lmk.

One last note is that the code in the RDNA3 assembler is quite terse and hard to follow.  Most of this could be fixed by using variable names rather than `arg[0][1]` etc. and maybe adding a few comments in key places.  I'd be happy to make some PRs to start on that if that sounds good to you.  I think it would be an important step to make development of this component easier for others to contribute to.