### PR TITLE
Reduce tensor dot line count and fixed 1d tensor dot

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -279,12 +279,13 @@ class TestOps(unittest.TestCase):
       return x*torch.tanh(torch.nn.functional.softplus(x))
     helper_test_op([(45,65)], _mish_pytorch, Tensor.mish, atol=1e-4)
     helper_test_op([()], _mish_pytorch, Tensor.mish, atol=1e-4)
-  def test_dot(self):
+  @unittest.skipIf(IMAGE>0, "no 1d dot for images")
+  def test_dot_1d(self):
     helper_test_op([(65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(65), (65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+  def test_dot(self):
     helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
-    helper_test_op([(32,45,65), (32,65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     with self.assertRaises(RuntimeError):
       a = Tensor(3.14)
       a.matmul(a)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -284,8 +284,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([(65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(65), (65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(32,45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(65), (32,65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
   def test_dot(self):
     helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(32,45,65), (32,65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     with self.assertRaises(RuntimeError):
       a = Tensor(3.14)
       a.matmul(a)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -280,7 +280,11 @@ class TestOps(unittest.TestCase):
     helper_test_op([(45,65)], _mish_pytorch, Tensor.mish, atol=1e-4)
     helper_test_op([()], _mish_pytorch, Tensor.mish, atol=1e-4)
   def test_dot(self):
+    helper_test_op([(65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(65), (65,45)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(45,65), (65)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     helper_test_op([(45,65), (65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
+    helper_test_op([(32,45,65), (32,65,100)], lambda x,y: x.matmul(y), Tensor.dot, atol=1e-4)
     with self.assertRaises(RuntimeError):
       a = Tensor(3.14)
       a.matmul(a)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -469,8 +469,8 @@ class Tensor:
 
   def dot(self, w:Tensor) -> Tensor:
     if (n1:=len(self.shape))*(n2:=len(w.shape)) == 0: raise RuntimeError(f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D")
-    x = self.reshape(*self.shape[0:-1], *[1 for _ in range(min(n2-1, 1))], self.shape[-1])
-    w = w.reshape(*w.shape[0:-2], *[1 for _ in range(min(n1-1, 1))], *w.shape[-min(n2, 2):]).transpose(-1, -min(n2, 2))
+    x = self.reshape(*self.shape[0:-1], *[1]*min(n1-1, n2-1, 1), self.shape[-1])
+    w = w.reshape(*w.shape[0:-2], *[1]*min(n1-1, n2-1, 1), *w.shape[-min(n2, 2):]).transpose(-1, -min(n2, 2))
     return (x*w).sum(-1)
 
   def cumsum(self, axis=0):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -469,10 +469,9 @@ class Tensor:
 
   def dot(self, w:Tensor) -> Tensor:
     if (n1:=len(self.shape))*(n2:=len(w.shape)) == 0: raise RuntimeError(f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D")
-    x = self.reshape(*self.shape[0:-1], 1, self.shape[-1])
-    w = w.reshape(*w.shape[0:-2], 1, w.shape[-2], w.shape[-1]).transpose(-1, -2)
-    r = (x*w).sum(-1)
-    return r.reshape((*r.shape[:-2], r.shape[-1])) if len(self.shape) == 1 else r
+    x = self.reshape(*self.shape[0:-1], *[1 for _ in range(min(n2-1, 1))], self.shape[-1])
+    w = w.reshape(*w.shape[0:-2], *[1 for _ in range(min(n1-1, 1))], *w.shape[-min(n2, 2):]).transpose(-1, -min(n2, 2))
+    return (x*w).sum(-1)
 
   def cumsum(self, axis=0):
     x = self.permute(*(i for i in range(self.ndim) if i != axis), axis)


### PR DESCRIPTION
Reduced line counts for tensor.dot by 1 while also supporting 1d tensors as input (previously broken). 
Now should work in all the following cases: 

- 1d @ 1d
- 1d @ Nd
- Nd @ 1d
- Nd @ Nd

Also added the corresponding tests. 

Eventually we could reduce duplicated code like: 
```
  def dot(self, w:Tensor) -> Tensor:
    if (n1:=len(self.shape))*(n2:=len(w.shape)) == 0: raise RuntimeError(f"both arguments to matmul need to be at least 1D, but they are {n1}D and {n2}D")
    x = self.reshape(*self.shape[0:-1], *(m1:=[1]*min(n1-1, n2-1, 1)), self.shape[-1])
    w = w.reshape(*w.shape[0:-2], *m1, *w.shape[-(m2:=min(n2, 2)):]).transpose(-1, -m2)
    return (x*w).sum(-1)
```

Let me know!