### PR TITLE
Dedup params in `Optimizer`

### DIFF
--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -1,5 +1,6 @@
 # sorted in order of increasing complexity
-from typing import List, Set
+from typing import List
+from tinygrad.helpers import dedup
 from tinygrad.tensor import Tensor
 
 class Optimizer:
@@ -8,9 +9,8 @@ class Optimizer:
     for x in params:
       if x.requires_grad is None: x.requires_grad = True
 
-    deduped_params: Set[Tensor] = set(params)
-    self.params: List[Tensor] = [x for x in deduped_params if x.requires_grad]
-    self.buffers: List[Tensor] = [x for x in deduped_params if not x.requires_grad]   # buffers are still realized
+    self.params: List[Tensor] = dedup([x for x in params if x.requires_grad])
+    self.buffers: List[Tensor] = dedup([x for x in params if not x.requires_grad])   # buffers are still realized
 
   def zero_grad(self):
     for param in self.params: param.grad = None

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -8,6 +8,7 @@ class Optimizer:
     for x in params:
       if x.requires_grad is None: x.requires_grad = True
 
+    params = set(params)
     self.params: List[Tensor] = [x for x in params if x.requires_grad]
     self.buffers: List[Tensor] = [x for x in params if not x.requires_grad]   # buffers are still realized
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -1,5 +1,5 @@
 # sorted in order of increasing complexity
-from typing import List
+from typing import List, Set
 from tinygrad.tensor import Tensor
 
 class Optimizer:
@@ -8,7 +8,7 @@ class Optimizer:
     for x in params:
       if x.requires_grad is None: x.requires_grad = True
 
-    params = set(params)
+    params: Set[Tensor] = set(params)
     self.params: List[Tensor] = [x for x in params if x.requires_grad]
     self.buffers: List[Tensor] = [x for x in params if not x.requires_grad]   # buffers are still realized
 

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -8,9 +8,9 @@ class Optimizer:
     for x in params:
       if x.requires_grad is None: x.requires_grad = True
 
-    params: Set[Tensor] = set(params)
-    self.params: List[Tensor] = [x for x in params if x.requires_grad]
-    self.buffers: List[Tensor] = [x for x in params if not x.requires_grad]   # buffers are still realized
+    deduped_params: Set[Tensor] = set(params)
+    self.params: List[Tensor] = [x for x in deduped_params if x.requires_grad]
+    self.buffers: List[Tensor] = [x for x in deduped_params if not x.requires_grad]   # buffers are still realized
 
   def zero_grad(self):
     for param in self.params: param.grad = None


### PR DESCRIPTION
Passing the same tensor multiple times in the set of learnable params passed to optimizers can result in models completely failing to learn, but no errors are produced.  De-duping the passed tensors avoids the problem.

I ran into this when porting some of my TensorFlow code to work with Tinygrad.  Had a maddening few hours before I finally tracked down the issue.

I also noticed that the `Optimizer.realize()`'s `extra` arg doesn't seem to ever be set when calling it from within the tinygrad project.  Makes sense if it's meant to be a public API, or maybe I missed something, but if not it might be possible to remove that and get rid of some code.