### PR TITLE
refactor: print formatting for llama timing

### DIFF
--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -1,9 +1,9 @@
 # NOTE: this only tests the speed of the LLaMA codegen, it doesn't actually run the net
 import unittest, time
+from statistics import median
 from examples.llama import Transformer, args_7B
 from test.test_net_speed import start_profile, stop_profile
 from tinygrad.tensor import Tensor
-from tinygrad.helpers import getenv
 from tinygrad.lazy import Device
 from tinygrad.state import get_state_dict
 from tinygrad.ops import Compiled
@@ -30,10 +30,11 @@ class TestLLaMASpeed(unittest.TestCase):
       #print(f"clearing {len(Device['fake'].method_cache)} from method cache")
       if empty_method_cache: Device['fake'].method_cache.clear()
       tms = [time.perf_counter()]
-      for i in range(5):
+      for i in range(10):
         model(Tensor([[2]]), i).realize()
         tms.append(time.perf_counter())
-      print(f"{st:15s} runtime in ms:", ', '.join("%.2f"%((tms[i+1]-tms[i])*1000) for i in range(len(tms)-1)))
+      timings = [(tms[i+1]-tms[i])*1000 for i in range(len(tms)-1)]
+      print(f"{st:15s}runtime (median): {median(timings):7.2f}ms, runs: ", ", ".join(f'{x:7.2f}' for x in timings))
 
     run_llama("codegen")
     run_llama("methodcache", False)

--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -1,6 +1,5 @@
 # NOTE: this only tests the speed of the LLaMA codegen, it doesn't actually run the net
 import unittest, time
-from statistics import median
 from examples.llama import Transformer, args_7B
 from test.test_net_speed import start_profile, stop_profile
 from tinygrad.tensor import Tensor
@@ -34,7 +33,8 @@ class TestLLaMASpeed(unittest.TestCase):
         model(Tensor([[2]]), i).realize()
         tms.append(time.perf_counter())
       timings = [(tms[i+1]-tms[i])*1000 for i in range(len(tms)-1)]
-      print(f"{st:15s}runtime (median): {median(timings):7.2f}ms, runs: ", ", ".join(f'{x:7.2f}' for x in timings))
+      print(f"{st:15s}runtime: {sum(timings)/len(timings):7.2f}ms , runs: ", ", ".join(f'{x:7.2f}' for x in timings))
+
 
     run_llama("codegen")
     run_llama("methodcache", False)

--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -35,7 +35,6 @@ class TestLLaMASpeed(unittest.TestCase):
       timings = [(tms[i+1]-tms[i])*1000 for i in range(len(tms)-1)]
       print(f"{st:15s}runtime: {sum(timings)/len(timings):7.2f}ms , runs: ", ", ".join(f'{x:7.2f}' for x in timings))
 
-
     run_llama("codegen")
     run_llama("methodcache", False)
 

--- a/test/external/external_test_speed_llama.py
+++ b/test/external/external_test_speed_llama.py
@@ -33,7 +33,7 @@ class TestLLaMASpeed(unittest.TestCase):
         model(Tensor([[2]]), i).realize()
         tms.append(time.perf_counter())
       timings = [(tms[i+1]-tms[i])*1000 for i in range(len(tms)-1)]
-      print(f"{st:15s}runtime: {sum(timings)/len(timings):7.2f}ms , runs: ", ", ".join(f'{x:7.2f}' for x in timings))
+      print(f"{st:15s} mean runtime: {sum(timings)/len(timings):7.2f}ms, runs: ", ", ".join(f'{x:7.2f}' for x in timings))
 
     run_llama("codegen")
     run_llama("methodcache", False)


### PR DESCRIPTION
Would changing the amount of runs to 10 be okay? I see quite some variation locally.

Changes output from this:
```
using <class 'tinygrad.runtime.ops_gpu.CLCodegen'>
testing llama python run time
built model
assigned empty tensors, doing warmup
codegen         runtime in ms: 301.48, 232.38, 226.40, 242.69, 227.07, 233.93, 263.47, 228.38, 221.30, 219.61
methodcache     runtime in ms: 211.98, 261.42, 216.48, 219.08, 214.98, 205.48, 214.63, 211.68, 267.02, 216.87
profile         runtime in ms: 1340.62, 1154.90, 1118.25, 1090.96, 1188.29, 1103.09, 1149.75, 1176.59, 1108.89, 1205.75
```



To this:

```
using <class 'tinygrad.runtime.ops_gpu.CLCodegen'>
testing llama python run time
built model
assigned empty tensors, doing warmup
codegen        runtime:  234.29ms , runs:   301.52,  212.94,  247.08,  233.68,  218.72,  233.77,  259.32,  211.46,  207.98,  216.43
methodcache    runtime:  215.78ms , runs:   209.85,  240.21,  205.44,  199.33,  210.56,  221.49,  198.30,  202.85,  255.61,  214.20
profile        runtime: 1145.40ms , runs:  1391.09, 1084.30, 1104.05, 1090.71, 1166.80, 1105.70, 1103.81, 1113.91, 1111.82, 1181.78
```