### PR TITLE
Perf/remove noop casts

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -51,8 +51,7 @@ class Tensor:
 
     # internal variables used for autograd graph construction
     self._ctx: Optional[Function] = None
-    if data.__class__ is LazyBuffer:
-      data = cast(LazyBuffer, data) # NOTE: this is a noop, it makes mypy happy
+    if isinstance(data, LazyBuffer):
       assert dtype is None or dtype == data.dtype, "dtype doesn't match, and casting isn't supported"
       self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
       return
@@ -64,8 +63,7 @@ class Tensor:
     if data.__class__ is list:
       data = np.array(data, dtype=(dtype or Tensor.default_type).np)
 
-    if data.__class__ is np.ndarray:
-      data = cast(np.ndarray, data)
+    if isinstance(data, np.ndarray):
       data = LazyBuffer.fromCPU(data)
       self.lazydata = data if data.device == device else LazyBuffer.loadop(LoadOps.FROM, data.shape, data.dtype, device, src=data)
       return


### PR DESCRIPTION
While removing `isinstance` calls, @rayanht added some noop casts to may mypy happy.

In my testing, the class check + the noop cast to satisfy mypy is slower than an isinstance call. 
In some cases, mypy can be satisfied with an assert, which means the optimized can run without the cast.

Very minor speedup, but mainly neater without the noop casts.

This branch
```
codegen         mean runtime:  139.25ms, runs:   164.62,  171.97,  133.90,  129.46,  135.23,  130.50,  128.49,  131.80,  132.25,  134.24
methodcache     mean runtime:  134.42ms, runs:   172.48,  124.85,  126.02,  124.91,  122.18,  122.96,  127.17,  130.37,  124.42,  168.88
```

Master
```
codegen         mean runtime:  147.10ms, runs:   168.93,  194.08,  144.76,  141.64,  132.99,  144.88,  130.67,  143.57,  135.97,  133.52
methodcache     mean runtime:  141.62ms, runs:   168.17,  125.07,  127.03,  128.15,  126.01,  122.48,  124.39,  128.67,  155.49,  210.71

```