### PR TITLE
Perf/cache string ops

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -290,9 +290,10 @@ class _Device:
     self.DEFAULT: str = functools.reduce(lambda val, ele: ele if getenv(ele) == 1 else val, self._buffers, None) or self._default_device()
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
   def canonicalize(self, device:Optional[str]) -> str: return (device.split(":", 1)[0].upper() + ((":"+device.split(":", 1)[1]) if ':' in device else '')).replace(":0", "") if device is not None else self.DEFAULT
-  def __getitem__(self, x:str) -> Union[Interpreted, Compiled]: return self._get_device(x.split(":")[0].upper())
   @functools.lru_cache(maxsize=None)  # this class is a singleton, pylint: disable=method-cache-max-size-none
-  def _get_device(self, x:str) -> Union[Interpreted, Compiled]: return [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._buffers][0]
+  def __getitem__(self, x:str) -> Union[Interpreted, Compiled]: 
+    x = x.split(":")[0].upper()
+    return [cls for cname, cls in inspect.getmembers(importlib.import_module(f'tinygrad.runtime.ops_{x.lower()}')) if (cname.lower() == x.lower() + "buffer") and x in self._buffers][0]
   def _default_device(self) -> str:
     for device in ["METAL", "CUDA", "GPU"]:
       try:

--- a/tinygrad/shape/symbolic.py
+++ b/tinygrad/shape/symbolic.py
@@ -18,8 +18,10 @@ class Node:
     return ops[type(self)](self, ops, ctx)
   @functools.cached_property
   def key(self) -> str: return self.render(ctx="DEBUG")
+  @functools.cached_property
+  def hash(self) -> int: return hash(self.key)
   def __repr__(self): return "<"+self.key+">"
-  def __hash__(self): return hash(self.__repr__())
+  def __hash__(self): return self.hash
   def __eq__(self, other:object) -> bool:
     if not isinstance(other, Node): return NotImplemented
     return self.key == other.key


### PR DESCRIPTION
* `getitem` was uncached and gets hit often.
* only compute hash once per Node. This will become important once we start caching node operations (incoming)

this branch
```
codegen         mean runtime:  140.45ms, runs:   159.52,  127.21,  160.59,  134.36,  132.79,  130.65,  128.03,  134.19,  131.52,  165.66
methodcache     mean runtime:  132.99ms, runs:   132.94,  130.45,  122.93,  124.74,  130.47,  124.58,  120.56,  120.10,  184.96,  138.16
profile         mean runtime:  568.68ms, runs:   657.05,  546.74,  538.03,  552.64,  589.43,  559.45,  548.08,  550.50,  556.92,  587.93

706.71 lazy.py
557.83 tensor.py
154.16 shapetracker.py
13.52 ops.py
47.79 symbolic.py
374.19 helpers.py
8.62 lib.py
1862.81 total
```

master


```
codegen         mean runtime:  143.37ms, runs:   165.84,  141.58,  168.71,  132.82,  137.16,  131.48,  130.21,  128.91,  130.37,  166.60
methodcache     mean runtime:  132.13ms, runs:   130.96,  134.70,  129.90,  125.40,  125.76,  124.29,  124.63,  124.62,  169.28,  131.80
profile         mean runtime:  589.58ms, runs:   671.35,  580.40,  595.32,  559.58,  596.33,  569.90,  565.23,  619.70,  579.99,  557.96

721.38 lazy.py
572.08 tensor.py
155.33 shapetracker.py
14.80 ops.py
54.84 symbolic.py
385.14 helpers.py
9.43 lib.py
1913.00 total
```
