### PR TITLE
Improvement on CIFAR-10 hlb_cifar10_torch.py 89%

### DIFF
--- a/examples/hlb_cifar10_torch.py
+++ b/examples/hlb_cifar10_torch.py
@@ -96,9 +96,9 @@ def train_cifar():
   # non_bias_lr = 1.64 / 512
   # momentum = .85
   # weight_decay = 1.08 * 6.45e-4 * batchsize
-  optimizer = optim.SGD(model.parameters(), lr=1.75/512, momentum=0.85, nesterov=True, weight_decay=1.08 * 6.45e-4 * BS)
+  optimizer = optim.SGD(model.parameters(), lr=1.75/BS, momentum=0.85, nesterov=True, weight_decay=1.08 * 6.45e-4 * BS)
   initial_div_factor, final_lr_ratio = 1e16, .07
-  lr_sched = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=1.64/512, pct_start=.25, 
+  lr_sched = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=1.75/BS, pct_start=.25, 
                                                 div_factor=initial_div_factor, final_div_factor=1./(initial_div_factor*final_lr_ratio), 
                                                 total_steps=STEPS, anneal_strategy='linear', cycle_momentum=False)
   X, Y = fetch_batch(X_train, Y_train, BS=BS)


### PR DESCRIPTION
Since both torch and tinygrad implemented the same model and pipeline, I started with comparing to [https://github.com/tysam-code/hlb-CIFAR10/blob/main/main.py#L274](url) as suggested. 

Two major differences:
1. Whitening layer where the weight is frozen for better data distribution
2. LR scheduler (OneCycleLR) for more efficient training

By just adding the OneCycleLR, I was able to get as high as 89% without spending too much time tuning all the parameters inside OneCycleLR, I do believe once the whitening is applied, reaching 90% should be easily reachable since the space is much cleaner.