### PR TITLE
dtypes: add int16, priority change, refactor

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -67,11 +67,9 @@ class TestFloat64Dtype(unittest.TestCase):
 class TestInt8Dtype(unittest.TestCase):
   def test_int8_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int8), np.int8, [1,2,3,4])
   def test_uint8_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.uint8), np.uint8, [1,2,3,4])
-  def test_int64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int64), np.int64, [1,2,3,4])
 
   def test_float_to_int8(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.int8, [1,2,3,4])
   def test_float_to_uint8(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.uint8, [1,2,3,4])
-  def test_float_to_int64(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.int64, [1,2,3,4])
 
   def test_int8_to_float(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.int8), dtypes.float32, [1,2,3,4])
   def test_int8_to_uint8(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.int8), dtypes.uint8, [1,2,3,4])
@@ -82,13 +80,10 @@ class TestInt8Dtype(unittest.TestCase):
   def test_uint8_to_int64(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.uint8), dtypes.int64, [1,2,3,4])
 
   def test_int8_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.int8), Tensor([1,2,3,4], dtype=dtypes.int8), dtypes.int8, [2,4,6,8])
-  def test_int64_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.int64),Tensor([1,2,3,4], dtype=dtypes.int64), dtypes.int64, [2,4,6,8])
 
   def test_int8_mul(self): _test_mul(Tensor([1,2,3,4], dtype=dtypes.int8), Tensor([1,2,3,4], dtype=dtypes.int8), dtypes.int8, [1,4,9,16])
-  def test_int64_mul(self): _test_mul(Tensor([1,2,3,4], dtype=dtypes.int64), Tensor([1,2,3,4], dtype=dtypes.int64), dtypes.int64, [1,4,9,16])
 
   def test_int8_matmul(self): _test_matmul(Tensor([[1,2],[3,4]], dtype=dtypes.int8), Tensor.eye(2, dtype=dtypes.int8), dtypes.int8, [[1,2],[3,4]])
-  def test_int64_matmul(self): _test_matmul(Tensor([[1,2],[3,4]], dtype=dtypes.int64), Tensor.eye(2, dtype=dtypes.int64), dtypes.int64, [[1,2],[3,4]])
 
   def test_int8_add_upcast_float(self): _test_add_upcast(Tensor([1,2,3,4], dtype=dtypes.int8), Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.float32, [2,4,6,8])
   def test_int8_mul_upcast_float(self): _test_mul_upcast(Tensor([1,2,3,4], dtype=dtypes.int8), Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.float32, [1,4,9,16])
@@ -102,6 +97,24 @@ class TestInt8Dtype(unittest.TestCase):
   def test_int8_to_uint8_negative(self): _test_op(lambda: Tensor([-1, -2, -3, -4], dtype=dtypes.int8).cast(dtypes.uint8), dtypes.uint8, [255, 254, 253, 252])
 
   def test_uint8_to_int8_overflow(self): _test_op(lambda: Tensor([255, 254, 253, 252], dtype=dtypes.uint8).cast(dtypes.int8), dtypes.int8, [-1, -2, -3, -4])
+
+class TestInt16Dtype(unittest.TestCase):
+  def test_int16_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int16), np.int16, [1,2,3,4])
+  def test_uint16_to_float(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.uint16), dtypes.float32, [1,2,3,4])
+
+  def test_int16_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.int16), Tensor([1,2,3,4], dtype=dtypes.int16), dtypes.int16, [2,4,6,8])
+  def test_int16_mul(self): _test_mul(Tensor([1,2,3,4], dtype=dtypes.int16), Tensor([1,2,3,4], dtype=dtypes.int16), dtypes.int16, [1,4,9,16])
+  def test_int16_matmul(self): _test_matmul(Tensor([[1,2],[3,4]], dtype=dtypes.int16), Tensor.eye(2, dtype=dtypes.int16), dtypes.int16, [[1,2],[3,4]])
+
+class TestInt64Dtype(unittest.TestCase):
+  def test_int64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int64), np.int64, [1,2,3,4])
+
+  def test_float_to_int64(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.float32), dtypes.int64, [1,2,3,4])
+
+  def test_int64_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.int64),Tensor([1,2,3,4], dtype=dtypes.int64), dtypes.int64, [2,4,6,8])
+  def test_int64_mul(self): _test_mul(Tensor([1,2,3,4], dtype=dtypes.int64), Tensor([1,2,3,4], dtype=dtypes.int64), dtypes.int64, [1,4,9,16])
+  def test_int64_matmul(self): _test_matmul(Tensor([[1,2],[3,4]], dtype=dtypes.int64), Tensor.eye(2, dtype=dtypes.int64), dtypes.int64, [[1,2],[3,4]])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -100,7 +100,7 @@ class TestInt8Dtype(unittest.TestCase):
 
 class TestInt16Dtype(unittest.TestCase):
   def test_int16_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.int16), np.int16, [1,2,3,4])
-  def test_uint16_to_float(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.uint16), dtypes.float32, [1,2,3,4])
+  def test_int16_to_float(self): _test_cast(Tensor([1,2,3,4], dtype=dtypes.int16), dtypes.float32, [1,2,3,4])
 
   def test_int16_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.int16), Tensor([1,2,3,4], dtype=dtypes.int16), dtypes.int16, [2,4,6,8])
   def test_int16_mul(self): _test_mul(Tensor([1,2,3,4], dtype=dtypes.int16), Tensor([1,2,3,4], dtype=dtypes.int16), dtypes.int16, [1,4,9,16])

--- a/test/test_specific_conv.py
+++ b/test/test_specific_conv.py
@@ -22,9 +22,9 @@ class TestSpecific(unittest.TestCase):
   @unittest.skipIf(Device.DEFAULT == "LLVM", "Broken on LLVM")
   def test_big_vec_mul(self):
     # from LLaMA
-    #   0 buffer<4096, dtypes.float>                      [View((1024, 1, 1, 4), (4, 0, 0, 1), 0, None)]
-    #   1 buffer<4096, dtypes.float>                      [View((1024, 1024, 4, 4), (0, 4, 1, 0), 0, None)]
-    #   2 buffer<16777216, dtypes.half>                   [View((1024, 1024, 4, 4), (16384, 4, 1, 4096), 0, None)]
+    #   0 buffer<4096, dtypes.float32>                      [View((1024, 1, 1, 4), (4, 0, 0, 1), 0, None)]
+    #   1 buffer<4096, dtypes.float32>                      [View((1024, 1024, 4, 4), (0, 4, 1, 0), 0, None)]
+    #   2 buffer<16777216, dtypes.float16>                   [View((1024, 1024, 4, 4), (16384, 4, 1, 4096), 0, None)]
     x = Tensor.randn(4096).realize()
     w = Tensor.randn(4096, 4096, device='cpu').cast(dtypes.float16).to(Device.DEFAULT).realize()
     (x @ w.T).realize()

--- a/tinygrad/codegen/assembly.py
+++ b/tinygrad/codegen/assembly.py
@@ -18,7 +18,7 @@ class Register(NamedTuple):
   def __repr__(self): return self.nm if self.off is None else f"{self.nm}:{self.off}"
   def subregs(self):
     if self.dtype == dtypes._float4:
-      return [Register(self.nm, dtypes.float, False, off=off) for off in range(4)]
+      return [Register(self.nm, dtypes.float32, False, off=off) for off in range(4)]
     return []
 class AssemblyInstruction(NamedTuple):
   op: UOps
@@ -50,7 +50,7 @@ class AssemblyCodegen(Linearizer):
       tor[tok] = ret = Register(f"%{type_to_letter((dtype, scalar))}{cnts[(dtype, scalar)]}", dtype, scalar)
       if dtype == dtypes._float4:
         for off in range(4):
-          tor[Token(tok.name, tok.dtype, off)] = Register(ret.nm, dtypes.float, ret.scalar, off)
+          tor[Token(tok.name, tok.dtype, off)] = Register(ret.nm, dtypes.float32, ret.scalar, off)
       cnts[(dtype, scalar)] += 1
       return ret
 

--- a/tinygrad/codegen/assembly_rdna.py
+++ b/tinygrad/codegen/assembly_rdna.py
@@ -79,7 +79,7 @@ class RDNACodegen(AssemblyCodegen):
             if arg[0][0] == dtypes._float4:
               for off in range(4):
                 reg_name = f"s{s_cnt-align+off}" if arg[0][1] else f"v{v_cnt-align+off}"
-                rtor[Register(f"%{arg[1]}{i}", dtypes.float, False, off=off)] = reg_name
+                rtor[Register(f"%{arg[1]}{i}", dtypes.float32, False, off=off)] = reg_name
         elif arg[0][0] == dtypes.bool:
           for i in range(arg[2]):
             reg_name = "scc" if arg[0][1] else "vcc_lo" # `_lo` suffix since we're running wavefront_size=32
@@ -111,7 +111,7 @@ class RDNACodegen(AssemblyCodegen):
         elif arg == float('-inf'): arg = "0xff800000"
         if out.dtype == dtypes._float4:
           for off in range(4):
-            ins.append(f"{'s_' if out.scalar else 'v_'}mov_b32 {reg_out(Register(out.nm, dtypes.float, False, off=off))}, {arg}")
+            ins.append(f"{'s_' if out.scalar else 'v_'}mov_b32 {reg_out(Register(out.nm, dtypes.float32, False, off=off))}, {arg}")
         else:
           ins.append(f"{'s_' if out.scalar else 'v_'}mov_b32 {reg_out(out)}, {arg}")
       elif uop == UOps.ALU:

--- a/tinygrad/codegen/linearizer.py
+++ b/tinygrad/codegen/linearizer.py
@@ -177,10 +177,10 @@ class Linearizer:
         # disallow unaligned access, fall back to float
         if idx.render() != ((idx//4)*4).render():
           idx, valid = self.sts[i].expr_idxs(_idx)
-          localtype = dtypes.float
+          localtype = dtypes.float32
       else:
         idx, valid = self.sts[i].expr_idxs(_idx)
-        localtype = dtypes.float
+        localtype = dtypes.float32
       key = f"{localtype}{idx.render()}{valid.render()}"
       if key not in cache:
         cache[key] = self.uop(UOps.LOAD, Token(f"val{mnum(i)}_{len(cache)}", localtype), [], MemOp(i, idx, valid)) if const is None else \
@@ -236,7 +236,7 @@ class Linearizer:
 
     # ssa
     _ssa:DefaultDict[str,int] = defaultdict(int)
-    def ssa(name, ltype=dtypes.float) -> Token:
+    def ssa(name, ltype=dtypes.float32) -> Token:
       _ssa[name] += 1
       return Token(f"{name}{_ssa[name]-1}", ltype)
 

--- a/tinygrad/codegen/llvmir.py
+++ b/tinygrad/codegen/llvmir.py
@@ -37,7 +37,7 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
   module = ir.Module(name=__file__)
 
   # create llvm function
-  func_dtypes = [{dtypes.float16:ir.HalfType(), dtypes.float32:ir.FloatType(), dtypes.float64:ir.DoubleType(), dtypes.bool: ir.IntType(1), dtypes.int8:ir.IntType(8), dtypes.uint8:ir.IntType(8), dtypes.int16:ir.IntType(16), dtypes.int32: ir.IntType(32), dtypes.int64: ir.IntType(64)}[buf.dtype] for buf in bufs]
+  func_dtypes = [{dtypes.float16:ir.HalfType(), dtypes.float32:ir.FloatType(), dtypes.float64:ir.DoubleType(), dtypes.bool:ir.IntType(1), dtypes.int8:ir.IntType(8), dtypes.uint8:ir.IntType(8), dtypes.int16:ir.IntType(16), dtypes.int32:ir.IntType(32), dtypes.int64:ir.IntType(64)}[buf.dtype] for buf in bufs]
   func = ir.Function(module, ir.FunctionType(ir.VoidType(), [x.as_pointer() for x in func_dtypes]), name='exec')
 
   # force llvmlite to allow us to add function attribute then add the attribute
@@ -88,7 +88,7 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
       else:
         val = bb[-1].load(bb[-1].gep(func.args[args.i], [idx], inbounds=True))
       if func_dtypes[args.i] != ir.FloatType():
-        if dtypes.is_signed_int(bufs[args.i].dtype):
+        if dtypes.is_int(bufs[args.i].dtype):
           val = bb[-1].uitofp(val, ir.FloatType()) if dtypes.is_unsigned_int(bufs[args.i].dtype) else bb[-1].sitofp(val, ir.FloatType())
         elif bufs[args.i].dtype == dtypes.float64:
           val = bb[-1].fptrunc(val, ir.FloatType())
@@ -100,7 +100,7 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
       idx = args.idx.render(render_llvm, bb[-1])
       element = lvars[vin[0]]
       if func_dtypes[0] != ir.FloatType():
-        if dtypes.is_signed_int(bufs[args.i].dtype):
+        if dtypes.is_int(bufs[args.i].dtype):
           element = bb[-1].fptoui(element, func_dtypes[0]) if dtypes.is_unsigned_int(bufs[args.i].dtype) else bb[-1].fptosi(element, func_dtypes[0])
         elif bufs[args.i].dtype == dtypes.float64:
           element = bb[-1].fpext(element, func_dtypes[0])

--- a/tinygrad/codegen/llvmir.py
+++ b/tinygrad/codegen/llvmir.py
@@ -37,7 +37,7 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
   module = ir.Module(name=__file__)
 
   # create llvm function
-  func_dtypes = [{dtypes.float16:ir.HalfType(), dtypes.float32:ir.FloatType(), dtypes.float64:ir.DoubleType(), dtypes.int8:ir.IntType(8), dtypes.uint8:ir.IntType(8), dtypes.bool: ir.IntType(1), dtypes.int64: ir.IntType(64), dtypes.int32: ir.IntType(32)}[buf.dtype] for buf in bufs]
+  func_dtypes = [{dtypes.float16:ir.HalfType(), dtypes.float32:ir.FloatType(), dtypes.float64:ir.DoubleType(), dtypes.bool: ir.IntType(1), dtypes.int8:ir.IntType(8), dtypes.uint8:ir.IntType(8), dtypes.int16:ir.IntType(16), dtypes.int32: ir.IntType(32), dtypes.int64: ir.IntType(64)}[buf.dtype] for buf in bufs]
   func = ir.Function(module, ir.FunctionType(ir.VoidType(), [x.as_pointer() for x in func_dtypes]), name='exec')
 
   # force llvmlite to allow us to add function attribute then add the attribute

--- a/tinygrad/codegen/llvmir.py
+++ b/tinygrad/codegen/llvmir.py
@@ -88,8 +88,8 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
       else:
         val = bb[-1].load(bb[-1].gep(func.args[args.i], [idx], inbounds=True))
       if func_dtypes[args.i] != ir.FloatType():
-        if dtypes.is_int(bufs[args.i].dtype):
-          val = bb[-1].uitofp(val, ir.FloatType()) if dtypes.is_unsigned(bufs[args.i].dtype) else bb[-1].sitofp(val, ir.FloatType())
+        if dtypes.is_signed_int(bufs[args.i].dtype):
+          val = bb[-1].uitofp(val, ir.FloatType()) if dtypes.is_unsigned_int(bufs[args.i].dtype) else bb[-1].sitofp(val, ir.FloatType())
         elif bufs[args.i].dtype == dtypes.float64:
           val = bb[-1].fptrunc(val, ir.FloatType())
         else:
@@ -100,8 +100,8 @@ def uops_to_llvm_ir(uops:List[UOp], bufs:List[LazyBuffer]) -> str:
       idx = args.idx.render(render_llvm, bb[-1])
       element = lvars[vin[0]]
       if func_dtypes[0] != ir.FloatType():
-        if dtypes.is_int(bufs[args.i].dtype):
-          element = bb[-1].fptoui(element, func_dtypes[0]) if dtypes.is_unsigned(bufs[args.i].dtype) else bb[-1].fptosi(element, func_dtypes[0])
+        if dtypes.is_signed_int(bufs[args.i].dtype):
+          element = bb[-1].fptoui(element, func_dtypes[0]) if dtypes.is_unsigned_int(bufs[args.i].dtype) else bb[-1].fptosi(element, func_dtypes[0])
         elif bufs[args.i].dtype == dtypes.float64:
           element = bb[-1].fpext(element, func_dtypes[0])
         else:

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -86,16 +86,16 @@ class dtypes:
   @staticmethod
   def is_signed_int(x)-> bool: return x in (dtypes.int8, dtypes.uint16, dtypes.int32, dtypes.int64)
   @staticmethod
-  def is_float(x) -> bool: return x in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes._float4)
-  @staticmethod
   def is_unsigned_int(x) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod
   def is_int(x) -> bool: return dtypes.is_signed_int(x) or dtypes.is_unsigned_int(x)
+  @staticmethod
+  def is_float(x) -> bool: return x in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes._float4)
   bool: Final[DType] = DType(0, 1, "bool", bool)
   int8: Final[DType] = DType(1, 1, "char", np.int8)
   uint8: Final[DType] = DType(2, 1, "uchar", np.uint8)
-  int16: Final[DType] = DType(3, 2, "int16", np.int16)
-  uint16: Final[DType] = DType(4, 2, "uint16", np.uint16)
+  int16: Final[DType] = DType(3, 2, "short", np.int16)
+  uint16: Final[DType] = DType(4, 2, "ushort", np.uint16)
   float16: Final[DType] = DType(5, 2, "half", np.float16)
   int32: Final[DType] = DType(6, 4, "int", np.int32)
   uint32: Final[DType] = DType(7, 4, "uint", np.uint32)

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -79,31 +79,32 @@ class ImageDType(DType):
   def __repr__(self): return f"dtypes.{self.name}({self.shape})"
 
 class dtypes:
-  @staticmethod # static methds on top, or bool in the type info will refer to dtypes.bool
-  def is_int(x: DType)-> bool: return x in (dtypes.int8, dtypes.uint8, dtypes.int32, dtypes.int64)
-  @staticmethod
-  def is_float(x: DType) -> bool: return x in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes._half4, dtypes._float4)
-  @staticmethod
-  def is_unsigned(x: DType) -> bool: return x in (dtypes.uint8, dtypes.uint32, dtypes.uint64)
   @staticmethod
   def from_np(x) -> DType: return DTYPES_DICT[np.dtype(x).name]
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
+  @staticmethod
+  def is_signed_int(x)-> bool: return x in (dtypes.int8, dtypes.uint16, dtypes.int32, dtypes.int64)
+  @staticmethod
+  def is_float(x) -> bool: return x in (dtypes.float16, dtypes.float32, dtypes.float64, dtypes._float4)
+  @staticmethod
+  def is_unsigned_int(x) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
+  @staticmethod
+  def is_int(x) -> bool: return dtypes.is_signed_int(x) or dtypes.is_unsigned_int(x)
   bool: Final[DType] = DType(0, 1, "bool", bool)
-  float16: Final[DType] = DType(0, 2, "half", np.float16)
-  half = float16
-  float32: Final[DType] = DType(4, 4, "float", np.float32)
-  float = float32
-  float64: Final[DType] = DType(5, 8, "double", np.float64)
-  int8: Final[DType] = DType(0, 1, "char", np.int8)
-  int32: Final[DType] = DType(1, 4, "int", np.int32)
-  int64: Final[DType] = DType(2, 8, "long", np.int64)
-  uint8: Final[DType] = DType(0, 1, "uchar", np.uint8)
-  uint32: Final[DType] = DType(1, 4, "uint", np.uint32)
-  uint64: Final[DType] = DType(2, 8, "ulong", np.uint64)
+  int8: Final[DType] = DType(1, 1, "char", np.int8)
+  uint8: Final[DType] = DType(2, 1, "uchar", np.uint8)
+  int16: Final[DType] = DType(3, 2, "int16", np.int16)
+  uint16: Final[DType] = DType(4, 2, "uint16", np.uint16)
+  float16: Final[DType] = DType(5, 2, "half", np.float16)
+  int32: Final[DType] = DType(6, 4, "int", np.int32)
+  uint32: Final[DType] = DType(7, 4, "uint", np.uint32)
+  float32: Final[DType] = DType(8, 4, "float", np.float32)
+  int64: Final[DType] = DType(9, 8, "long", np.int64)
+  uint64: Final[DType] = DType(10, 8, "ulong", np.uint64)
+  float64: Final[DType] = DType(11, 8, "double", np.float64)
 
   # NOTE: these are internal dtypes, should probably check for that
-  _half4: Final[DType] = DType(0, 2*4, "half4", None, 4)
   _float4: Final[DType] = DType(4, 4*4, "float4", None, 4)
 
 # HACK: staticmethods are not callable in 3.8 so we have to compare the class

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -84,7 +84,7 @@ class dtypes:
   @staticmethod
   def fields() -> Dict[str, DType]: return DTYPES_DICT
   @staticmethod
-  def is_signed_int(x)-> bool: return x in (dtypes.int8, dtypes.uint16, dtypes.int32, dtypes.int64)
+  def is_signed_int(x)-> bool: return x in (dtypes.int8, dtypes.int16, dtypes.int32, dtypes.int64)
   @staticmethod
   def is_unsigned_int(x) -> bool: return x in (dtypes.uint8, dtypes.uint16, dtypes.uint32, dtypes.uint64)
   @staticmethod

--- a/tinygrad/runtime/lib.py
+++ b/tinygrad/runtime/lib.py
@@ -39,7 +39,7 @@ class RawBufferMapped(RawBufferCopyIn):
 
 # this one is simple enough that i moved it out of the runtimes
 class RawMallocBuffer(RawBufferMapped):
-  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.float32: ctypes.c_float, dtypes.float16: ctypes.c_int16, dtypes.float64: ctypes.c_double, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.bool: ctypes.c_uint8, dtypes.int32: ctypes.c_int32, dtypes.int64: ctypes.c_int64}[dtype] * size)())
+  def __init__(self, size, dtype: DType): super().__init__(size, dtype, ({dtypes.bool: ctypes.c_uint8, dtypes.float16: ctypes.c_int16, dtypes.float32: ctypes.c_float,  dtypes.float64: ctypes.c_double, dtypes.int8: ctypes.c_int8, dtypes.uint8: ctypes.c_uint8, dtypes.int16: ctypes.c_int16, dtypes.uint16: ctypes.c_uint16, dtypes.int32: ctypes.c_int32, dtypes.int64: ctypes.c_int64}[dtype] * size)())
   def _buffer(self): return memoryview(self._buf)
 
 class RawBufferCopyInOut(RawBufferCopyIn):

--- a/tinygrad/runtime/ops_torch.py
+++ b/tinygrad/runtime/ops_torch.py
@@ -6,7 +6,7 @@ from tinygrad.runtime.ops_cpu import base_fxn_for_op, einsum_mulacc
 from tinygrad.runtime.lib import RawBuffer
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else ("mps" if getenv("MPS", 0) else "cpu"))
-type_map = {torch.float16: dtypes.float16, torch.float32: dtypes.float32, torch.float64: dtypes.float64, torch.double: dtypes.float64, torch.int8: dtypes.int8, torch.int32: dtypes.int32, torch.int64: dtypes.int64, torch.uint8: dtypes.uint8, torch.bool: dtypes.bool}
+type_map = {torch.float16: dtypes.float16, torch.float32: dtypes.float32, torch.float64: dtypes.float64, torch.double: dtypes.float64, torch.int8: dtypes.int8, torch.int16: dtypes.int16, torch.int32: dtypes.int32, torch.int64: dtypes.int64, torch.uint8: dtypes.uint8, torch.bool: dtypes.bool}
 inverse_type_map = {v:k for k,v in type_map.items()}
 
 torch_fxn_for_op: Dict[Op, Callable] = {**base_fxn_for_op, **{


### PR DESCRIPTION
Did the following changes:
- removed `float` and `half` dtypes alias for `float32` and `float16` respectively
- added `int16` and `uint16` dtypes (short, ushort)
- changed dtype priorities such that no dtype priority is the same (thus order of ops wont effect resulting dtype)
- renamed `is_int` to `is_signed_int`. renamed `is_unsigned` to `is_unsigned_int`. Added `is_int` which encapsulates both signed and unsigned.
- removed `_half4` type since not in use
- added some tests for int16, moved tests for int64 from int8 class to its own int64 test class