### PR TITLE
Tensor.arange() bug fix

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -84,6 +84,9 @@ class TestOps(unittest.TestCase):
 
   def test_arange(self):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
+    helper_test_op([], lambda: torch.arange(5, 10, 3), lambda: Tensor.arange(10, 5, 3), forward_only=True)
+    helper_test_op([], lambda: torch.arange(10, 5, -3), lambda: Tensor.arange(5, 10, -3), forward_only=True)
+    helper_test_op([], lambda: torch.arange(11, 5, -3), lambda: Tensor.arange(5, 11, -3), forward_only=True)
   def test_where(self):
     helper_test_op(
       [(100,)],

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -151,7 +151,7 @@ class Tensor:
   def ones(*shape, **kwargs): return Tensor.full(argfix(*shape), 1, **kwargs)
 
   @staticmethod
-  def arange(stop, start=0, step=1, **kwargs): return Tensor.full(((stop-start)//step,), step, **kwargs).cumsum() + (start - step)
+  def arange(stop, start=0, step=1, **kwargs): return Tensor.full((ceil((stop-start)/step),), step, **kwargs).cumsum() + (start - step)
 
   @staticmethod
   def full_like(tensor, fill_value, dtype:Optional[DType]=None, **kwargs):


### PR DESCRIPTION
I think there was a tinybug in Tensor.arange() when step != 1? 

```
Previously:
In [5]: torch.arange(5,10,3)
Out[5]: tensor([5, 8])

In [3]: Tensor.arange(10,5,3).numpy()
Out[3]: array([5.], dtype=float32)


after fix:
In [4]: Tensor.arange(10,5,3).numpy()
Out[4]: array([5., 8.], dtype=float32)
```