### PR TITLE
skip TestFloat64Dtype tests

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -52,7 +52,7 @@ class TestHalfDtype(unittest.TestCase):
   def test_half_matmul_upcast_float(self): _test_matmul_upcast(Tensor([[1,2],[3,4]], dtype=dtypes.float16), Tensor.eye(2, dtype=dtypes.float32), dtypes.float32, [[1,2],[3,4]])
   def test_int8_matmul_upcast_half(self): _test_matmul_upcast(Tensor([[1,2],[3,4]], dtype=dtypes.int8), Tensor.eye(2, dtype=dtypes.float16), dtypes.float16, [[1,2],[3,4]])
 
-@unittest.skipIf(OSX and Device.DEFAULT in ["GPU", "METAL"], "GPU on Mac doesn't support float64")
+@unittest.skip("integrated GPUs often don't support float64")
 class TestFloat64Dtype(unittest.TestCase):
   def test_float64_to_np(self): _test_to_np(Tensor([1,2,3,4], dtype=dtypes.float64), np.float64, [1,2,3,4])
   def test_float64_add(self): _test_add(Tensor([1,2,3,4], dtype=dtypes.float64), Tensor([1,2,3,4], dtype=dtypes.float64), dtypes.float64, [2,4,6,8])


### PR DESCRIPTION
float64 not often supported on integrated GPUs, so probably good to skip related tests as discussed here: https://github.com/geohot/tinygrad/issues/1087