### PR TITLE
Added torch.meshgrid functionality in tensor.py

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -81,7 +81,12 @@ class TestOps(unittest.TestCase):
     helper_test_op([], lambda: torch.ones_like(b), lambda: Tensor.ones_like(a), forward_only=True)
   def test_eye(self):
     helper_test_op([], lambda: torch.eye(10), lambda: Tensor.eye(10), forward_only=True)
-
+  def test_meshgrid(self):
+    a = torch.meshgrid((torch.tensor([1,2,3]), torch.tensor([4,5,6,7])))
+    b =  Tensor.meshgrid(Tensor([1,2,3]), Tensor([4,5,6,7]))  
+    for (t1, t2) in zip(a, b):
+      helper_test_op([], lambda: t1, lambda: t2, forward_only=True)
+    
   def test_arange(self):
     helper_test_op([], lambda: torch.arange(10), lambda: Tensor.arange(10), forward_only=True)
     helper_test_op([], lambda: torch.arange(5, 10, 3), lambda: Tensor.arange(10, 5, 3), forward_only=True)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -166,6 +166,17 @@ class Tensor:
   @staticmethod
   def eye(dim, **kwargs): return Tensor([1], **kwargs).slice(((0,dim+1),)).reshape(1, dim+1).expand(dim, dim+1).reshape(dim*(dim+1)).slice(((0,dim*dim),)).reshape(dim, dim)
 
+  @staticmethod
+  def meshgrid(*tensors):
+      accum = []
+      for curr_idx, tensor in enumerate(tensors):
+          assert(type(tensor) == Tensor) # doesn't support scalars
+          assert(len(tensor.shape) == 1) # currently only supports 1-D tensors
+          brod_to = [1 if (i != curr_idx) else tensor.shape[0] for i in range(len(tensors))]
+          repeat_tensor = [1 if (i == curr_idx) else tensors[i].shape[0] for i in range(len(tensors)) ]
+          accum.append(tensor.reshape(brod_to).repeat(repeat_tensor))
+      return accum
+
   def where(self:Tensor, input_:Union[Tensor, float], other:Union[Tensor, float]):
     cond = (self != 0.0)
     return cond * input_ + (1.0 - cond) * other

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -170,11 +170,11 @@ class Tensor:
   def meshgrid(*tensors):
     accum = []
     for curr_idx, tensor in enumerate(tensors):
-        assert(type(tensor) == Tensor) # doesn't support scalars
-        assert(len(tensor.shape) == 1) # currently only supports 1-D tensors
-        brod_to = [1 if (i != curr_idx) else tensor.shape[0] for i in range(len(tensors))]
-        repeat_tensor = [1 if (i == curr_idx) else tensors[i].shape[0] for i in range(len(tensors)) ]
-        accum.append(tensor.reshape(brod_to).repeat(repeat_tensor))
+      assert(type(tensor) == Tensor) # doesn't support scalars
+      assert(len(tensor.shape) == 1) # currently only supports 1-D tensors
+      brod_to = [1 if (i != curr_idx) else tensor.shape[0] for i in range(len(tensors))]
+      repeat_tensor = [1 if (i == curr_idx) else tensors[i].shape[0] for i in range(len(tensors)) ]
+      accum.append(tensor.reshape(brod_to).repeat(repeat_tensor))
     return accum
 
   def where(self:Tensor, input_:Union[Tensor, float], other:Union[Tensor, float]):

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -168,14 +168,14 @@ class Tensor:
 
   @staticmethod
   def meshgrid(*tensors):
-      accum = []
-      for curr_idx, tensor in enumerate(tensors):
-          assert(type(tensor) == Tensor) # doesn't support scalars
-          assert(len(tensor.shape) == 1) # currently only supports 1-D tensors
-          brod_to = [1 if (i != curr_idx) else tensor.shape[0] for i in range(len(tensors))]
-          repeat_tensor = [1 if (i == curr_idx) else tensors[i].shape[0] for i in range(len(tensors)) ]
-          accum.append(tensor.reshape(brod_to).repeat(repeat_tensor))
-      return accum
+    accum = []
+    for curr_idx, tensor in enumerate(tensors):
+        assert(type(tensor) == Tensor) # doesn't support scalars
+        assert(len(tensor.shape) == 1) # currently only supports 1-D tensors
+        brod_to = [1 if (i != curr_idx) else tensor.shape[0] for i in range(len(tensors))]
+        repeat_tensor = [1 if (i == curr_idx) else tensors[i].shape[0] for i in range(len(tensors)) ]
+        accum.append(tensor.reshape(brod_to).repeat(repeat_tensor))
+    return accum
 
   def where(self:Tensor, input_:Union[Tensor, float], other:Union[Tensor, float]):
     cond = (self != 0.0)


### PR DESCRIPTION
Added https://pytorch.org/docs/stable/generated/torch.meshgrid.html. Currently only supports 1-D `Tensors` as inputs (no scalars yet) and doesn't have an indexing argument.