### PR TITLE
change tensor default print behavior

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -75,6 +75,9 @@ class Tensor:
   def __repr__(self):
     return f"<Tensor {self.lazydata!r} on {self.device} with grad {(self.grad.lazydata if self.grad else None)!r}>"
 
+  def __str__(self):
+    return np.array2string(self.lazydata.toCPU())
+
   # Python has a non moving GC, so this should be okay
   def __hash__(self): return id(self)
 


### PR DESCRIPTION
I thought the default print behavior for a tensor was confusing. Changed it so by default
```
t1 = Tensor([1,2,3,4,5])
print(t1)

[1. 2. 3. 4. 5.]
```

outputs the same as Tensor.numpy()