### PR TITLE
do not emit loop end code for global+local loops in assembly kernel

### DIFF
--- a/tinygrad/codegen/assembly.py
+++ b/tinygrad/codegen/assembly.py
@@ -125,7 +125,7 @@ class AssemblyCodegen(Linearizer):
               ins.append(AssemblyInstruction(UOps.CONST, newreg(var, dtype=dtypes.int32, scalar=True), [], 0))
               ins.append(AssemblyInstruction(UOps.LABEL, None, [], "$loop_"+var.expr))
       elif uop == UOps.ENDLOOP:
-        if args[1] not in ["global", "local"]:
+        if args[1] not in ["global", "local", "global+local"]:
           for var in reversed(args[0]):
             if not isinstance(var, NumNode):  # TODO: why is this coming through?
               ins.append(AssemblyInstruction(UOps.ALU, tor[var], [tor[var], 1], BinaryOps.ADD))


### PR DESCRIPTION
Don't emit loop end code for global+local loop in assembly kernel, since this is handled by the GPU runtime.

A recent change broke PTX:

```
$ PTX=1 DEBUG=4 ENABLE_METHOD_CACHE=0 python ./test/test_nn.py TestNN.test_conv2d
***       0.00 GB    0.02 ms op: BinaryOps.MUL        out(float): (64, 16, 7, 7)                 in(2): [(64, 16, 7, 7)] 
*** exec  0.00 GB    0.01 ms op: BinaryOps.ADD        out(float): (64, 16, 7, 7)                 in(2): [(64, 16, 7, 7)] 
float4 merging axis : [(2, 2, 0, 4)]
   0 buffer<50176, dtypes.float>                     [View((392, 32, 4), (128, 4, 1), 0, None)]
   1 buffer<1, dtypes.float>                         [View((392, 32, 4), (0, 0, 0), 0, None)]
   2 buffer<50176, dtypes.float>                     [View((392, 32, 4), (128, 4, 1), 0, None)]
   3 buffer<1, dtypes.float>                         [View((392, 32, 4), (0, 0, 0), 0, None)]
 392   32    4
UOps.LOOP           :                           []                               ([<gidx0[0-391]>], 'global')
UOps.LOOP           :                           []                               ([<lidx1[0-31]>], 'local')
UOps.LOAD           : <val1_0>                  []                               MemOp(i=1, idx=<0>, valid=<1>)
UOps.LOAD           : <val2_0>                  []                               MemOp(i=2, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4))>, valid=<1>)
UOps.LOAD           : <val2_1>                  []                               MemOp(i=2, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+1)>, valid=<1>)
UOps.LOAD           : <val2_2>                  []                               MemOp(i=2, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+2)>, valid=<1>)
UOps.LOAD           : <val2_3>                  []                               MemOp(i=2, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+3)>, valid=<1>)
UOps.LOAD           : <val3_0>                  []                               MemOp(i=3, idx=<0>, valid=<1>)
UOps.ALU            : <alu0>                    [<val1_0>, <val2_0>]             BinaryOps.MUL
UOps.ALU            : <alu1>                    [<val1_0>, <val2_1>]             BinaryOps.MUL
UOps.ALU            : <alu2>                    [<val1_0>, <val2_2>]             BinaryOps.MUL
UOps.ALU            : <alu3>                    [<val1_0>, <val2_3>]             BinaryOps.MUL
UOps.ALU            : <alu4>                    [<alu0>, <val3_0>]               BinaryOps.ADD
UOps.ALU            : <alu5>                    [<alu1>, <val3_0>]               BinaryOps.ADD
UOps.ALU            : <alu6>                    [<alu2>, <val3_0>]               BinaryOps.ADD
UOps.ALU            : <alu7>                    [<alu3>, <val3_0>]               BinaryOps.ADD
UOps.STORE          :                           [<alu4>]                         MemOp(i=0, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4))>, valid=<1>)
UOps.STORE          :                           [<alu5>]                         MemOp(i=0, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+1)>, valid=<1>)
UOps.STORE          :                           [<alu6>]                         MemOp(i=0, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+2)>, valid=<1>)
UOps.STORE          :                           [<alu7>]                         MemOp(i=0, idx=<((gidx0[0-391]*128)+(lidx1[0-31]*4)+3)>, valid=<1>)
UOps.ENDLOOP        :                           []                               ([<gidx0[0-391]>, <lidx1[0-31]>], 'global+local')
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.ulong, True), 'B', 4))
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.int, False), 'i', 5))
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.int, True), 'I', 1))
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.ulong, False), 'b', 6))
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.float, False), 'f', 14))
AssemblyInstruction(op=<UOps.DEFINE_REGISTER: 11>, out=None, vin=[], arg=((dtypes.bool, False), 'p', 2))
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%B0, vin=[], arg='buf0')
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%B1, vin=[], arg='buf1')
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%B2, vin=[], arg='buf2')
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%B3, vin=[], arg='buf3')
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%i0, vin=[], arg='gid0')
AssemblyInstruction(op=<UOps.SPECIAL: 10>, out=%i1, vin=[], arg='lid0')
AssemblyInstruction(op=<UOps.CONST: 5>, out=%I0, vin=[], arg=0)
AssemblyInstruction(op=<UOps.CAST: 8>, out=%b0, vin=[%I0], arg=None)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%b1, vin=[%b0, %B1], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f0, vin=[%b1], arg=(0, 'global'))
AssemblyInstruction(op=<UOps.ALU: 4>, out=%i2, vin=[%i0, 512], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%i3, vin=[%i1, 16], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%i4, vin=[%i2, %i3], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.CAST: 8>, out=%b2, vin=[%i4], arg=None)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%b3, vin=[%b2, %B2], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f1, vin=[%b3], arg=(0, 'global'))
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f2, vin=[%b3], arg=(4, 'global'))
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f3, vin=[%b3], arg=(8, 'global'))
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f4, vin=[%b3], arg=(12, 'global'))
AssemblyInstruction(op=<UOps.ALU: 4>, out=%b4, vin=[%b0, %B3], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.LOAD: 3>, out=%f5, vin=[%b4], arg=(0, 'global'))
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f6, vin=[%f0, %f1], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f7, vin=[%f0, %f2], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f8, vin=[%f0, %f3], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f9, vin=[%f0, %f4], arg=<BinaryOps.MUL: 3>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f10, vin=[%f6, %f5], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f11, vin=[%f7, %f5], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f12, vin=[%f8, %f5], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%f13, vin=[%f9, %f5], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%b5, vin=[%b2, %B0], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.STORE: 7>, out=None, vin=[%b5, %f10], arg=(0, 'global'))
AssemblyInstruction(op=<UOps.STORE: 7>, out=None, vin=[%b5, %f11], arg=(4, 'global'))
AssemblyInstruction(op=<UOps.STORE: 7>, out=None, vin=[%b5, %f12], arg=(8, 'global'))
AssemblyInstruction(op=<UOps.STORE: 7>, out=None, vin=[%b5, %f13], arg=(12, 'global'))
AssemblyInstruction(op=<UOps.ALU: 4>, out=%i1, vin=[%i1, 1], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%p0, vin=[%i1, 32], arg=<BinaryOps.CMPLT: 9>)
AssemblyInstruction(op=<UOps.COND_BRANCH: 13>, out=None, vin=[%p0], arg=('$loop_lidx1', True))
AssemblyInstruction(op=<UOps.ALU: 4>, out=%i0, vin=[%i0, 1], arg=<BinaryOps.ADD: 1>)
AssemblyInstruction(op=<UOps.ALU: 4>, out=%p1, vin=[%i0, 392], arg=<BinaryOps.CMPLT: 9>)
AssemblyInstruction(op=<UOps.COND_BRANCH: 13>, out=None, vin=[%p1], arg=('$loop_gidx0', True))
E
======================================================================
ERROR: test_conv2d (__main__.TestNN)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/tinygrad/./test/test_nn.py", line 88, in test_conv2d
    torch_layer.weight[:] = torch.tensor(layer.weight.numpy(), dtype=torch.float32)
  File "/home/ubuntu/tinygrad/tinygrad/tensor.py", line 111, in numpy
    def numpy(self) -> np.ndarray: return self.lazydata.toCPU()
  File "/home/ubuntu/tinygrad/tinygrad/lazy.py", line 158, in toCPU
    realized = self.cast(dtypes.from_np(self.dtype.np)).contiguous().realize().realized
  File "/home/ubuntu/tinygrad/tinygrad/lazy.py", line 114, in realize
    elif self.optype is LoadOps: LOAD_OPS_DISPATCHER[cast(LoadOps, self.op.op)](self)
  File "/home/ubuntu/tinygrad/tinygrad/lazy.py", line 306, in _realize_contiguous
    realized = buffer.op.src[0].realize().realized
  File "/home/ubuntu/tinygrad/tinygrad/lazy.py", line 127, in realize
    self.realized = Device[self.device].exec_ast(self.op, output=self, **self._device_extra_args())
  File "/home/ubuntu/tinygrad/tinygrad/ops.py", line 187, in exec_ast
    prg = k.codegen().build(self.runtime)
  File "/home/ubuntu/tinygrad/tinygrad/ops.py", line 133, in build
    self.clprg = runtime(self.name, self.prg, **self.runtime_args)
  File "/home/ubuntu/tinygrad/tinygrad/runtime/ops_cuda.py", line 58, in __init__
    self.prg = cuda.module_from_buffer(prg.encode('utf-8')).get_function(prg.split(".visible .entry ")[1].split("(")[0])
pycuda._driver.LogicError: cuModuleLoadDataEx failed: a PTX JIT compilation failed - ptxas application ptx input, line 47; error   : Unknown symbol '$loop_lidx1'
ptxas application ptx input, line 50; error   : Unknown symbol '$loop_gidx0'
ptxas fatal   : Ptx assembly aborted due to errors

```