### PR TITLE
Create COCO data directory if it doesn't exist.

### DIFF
--- a/datasets/coco.py
+++ b/datasets/coco.py
@@ -13,6 +13,7 @@ merge       = _mask.merge
 frPyObjects = _mask.frPyObjects
 
 BASEDIR = pathlib.Path(__file__).parent.parent / "datasets/COCO"
+BASEDIR.mkdir(exist_ok=True)
 
 def create_dict(key_row, val_row, rows): return {row[key_row]:row[val_row] for row in rows}
 

--- a/datasets/coco.py
+++ b/datasets/coco.py
@@ -12,7 +12,7 @@ iou         = _mask.iou
 merge       = _mask.merge
 frPyObjects = _mask.frPyObjects
 
-BASEDIR = pathlib.Path(__file__).parent.parent / "datasets/COCO"
+BASEDIR = pathlib.Path(__file__).parent.parent / "datasets" / "COCO"
 BASEDIR.mkdir(exist_ok=True)
 
 def create_dict(key_row, val_row, rows): return {row[key_row]:row[val_row] for row in rows}


### PR DESCRIPTION
Fix issue when trying to eval mrcnn:

```
% METAL=1 MODEL=mrcnn python3 examples/mlperf/model_eval.py
eval mrcnn
Traceback (most recent call last):
  File "/Users/dhipke/git/tinygrad/examples/mlperf/model_eval.py", line 244, in <module>
    globals()[nm]()
  File "/Users/dhipke/git/tinygrad/examples/mlperf/model_eval.py", line 201, in eval_mrcnn
    from datasets.coco import BASEDIR, images, convert_prediction_to_coco_bbox, convert_prediction_to_coco_mask, accumulate_predictions_for_coco, evaluate_predictions_on_coco, iterate
  File "/Users/dhipke/git/tinygrad/datasets/coco.py", line 22, in <module>
    download_file('http://images.cocodataset.org/zips/val2017.zip',fn)
  File "/Users/dhipke/git/tinygrad/extra/utils.py", line 42, in download_file
    with tempfile.NamedTemporaryFile(dir=pathlib.Path(fp).parent, delete=False) as f:
  File "/opt/homebrew/anaconda3/lib/python3.9/tempfile.py", line 545, in NamedTemporaryFile
    (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
  File "/opt/homebrew/anaconda3/lib/python3.9/tempfile.py", line 255, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
FileNotFoundError: [Errno 2] No such file or directory: '/Users/dhipke/git/tinygrad/datasets/COCO/tmpw7u4t292'
```

Discovered while trying to run `mrcnn` inference on Metal.