### PR TITLE
Make cross_process use cloudpickle

### DIFF
--- a/datasets/imagenet_download.py
+++ b/datasets/imagenet_download.py
@@ -23,7 +23,7 @@ def imagenet_prepare_val():
   # Create folders and move files into those
   for co,dir in enumerate(labels):
     os.makedirs(Path(__file__).parent.parent / "datasets/imagenet/val" / dir, exist_ok=True)
-    os.replace(Path(__file__).parent.parent / "datasets/imagenet/val" / images[co], Path(__file__).parent.parent / "datasets/imagenet/val" / dir / images[co], exist_ok=True)
+    os.replace(Path(__file__).parent.parent / "datasets/imagenet/val" / images[co], Path(__file__).parent.parent / "datasets/imagenet/val" / dir / images[co])
   os.remove(Path(__file__).parent.parent / "datasets/imagenet/imagenet_2012_validation_synset_labels.txt")
 
 def imagenet_prepare_train():
@@ -45,7 +45,7 @@ if __name__ == "__main__":
   download_file("https://image-net.org/data/ILSVRC/2012/ILSVRC2012_img_val.tar", Path(__file__).parent.parent / "datasets/imagenet/ILSVRC2012_img_val.tar") # 7GB
   imagenet_extract(Path(__file__).parent.parent / "datasets/imagenet/ILSVRC2012_img_val.tar", Path(__file__).parent.parent / "datasets/imagenet/val")
   imagenet_prepare_val()
-  if os.getenv['IMGNET_TRAIN'] is not None:
+  if os.getenv('IMGNET_TRAIN', None) is not None:
     download_file("https://image-net.org/data/ILSVRC/2012/ILSVRC2012_img_train.tar", Path(__file__).parent.parent / "datasets/imagenet/ILSVRC2012_img_train.tar") #138GB!
     imagenet_extract(Path(__file__).parent.parent / "datasets/imagenet/ILSVRC2012_img_train.tar", Path(__file__).parent.parent / "datasets/imagenet/train")
     imagenet_prepare_train()

--- a/extra/helpers.py
+++ b/extra/helpers.py
@@ -40,8 +40,8 @@ class _CloudpickleFunctionWrapper:
   def __setstate__(self, pfn):
     self.fn = cloudpickle.loads(pfn)
 
-  def __call__(self) -> Any:
-    return self.fn()
+  def __call__(self, *args, **kwargs) -> Any:
+    return self.fn(*args, **kwargs)
 
 def cross_process(itermaker, maxsize=16):
   q: multiprocessing.Queue = multiprocessing.Queue(maxsize)

--- a/extra/helpers.py
+++ b/extra/helpers.py
@@ -32,10 +32,16 @@ def proc(itermaker, q) -> None:
 
 class _CloudpickleFunctionWrapper:
   def __init__(self, fn):
-    self.pfn = cloudpickle.dumps(fn)
+    self.fn = fn
+
+  def __getstate__(self):
+    return cloudpickle.dumps(self.fn)
+
+  def __setstate__(self, pfn):
+    self.fn = cloudpickle.loads(pfn)
 
   def __call__(self) -> Any:
-    return cloudpickle.loads(self.pfn)()
+    return self.fn()
 
 def cross_process(itermaker, maxsize=16):
   q: multiprocessing.Queue = multiprocessing.Queue(maxsize)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name='tinygrad',
             "tabulate",
             "safetensors",
             "types-PyYAML",
+            "cloudpickle",
         ],
       },
       include_package_data=True)

--- a/test/extra/test_helpers.py
+++ b/test/extra/test_helpers.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import multiprocessing
+import unittest
+from extra.helpers import cross_process
+
+class TestCrossProcess(unittest.TestCase):
+  def test_cross_process(self):
+    def _iterate():
+      for i in range(3): yield i
+    
+    ret = cross_process(lambda: _iterate())
+    assert len(list(ret)) == 3
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Update `cross_process` to use `cloudpickle`, as it fails on Python 3.9+:

Example:
```
% METAL=1 MODEL=resnet python3 examples/mlperf/model_eval.py
eval resnet
Traceback (most recent call last):
  File "/Users/dhipke/git/tinygrad/examples/mlperf/model_eval.py", line 244, in <module>
    globals()[nm]()
  File "/Users/dhipke/git/tinygrad/examples/mlperf/model_eval.py", line 35, in eval_resnet
    x,ny = next(iterator)
  File "/Users/dhipke/git/tinygrad/extra/helpers.py", line 45, in cross_process
    p.start()
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/context.py", line 224, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/context.py", line 288, in _Popen
    return Popen(process_obj)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/opt/homebrew/anaconda3/lib/python3.10/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
AttributeError: Can't pickle local object 'eval_resnet.<locals>.<lambda>'
```

Also, fix syntax errors in imagenet download script.