### PR TITLE
Fold expand preceding reduce if the reduction is on the same axis as the expansion

### DIFF
--- a/tinygrad/lazy.py
+++ b/tinygrad/lazy.py
@@ -39,11 +39,11 @@ def _simplify_sum_reshape_expand_sum(self:LazyBuffer, src: Any, prev_src: Any) -
 # **** realize functions ****
 def _ast_reduceops(self:LazyBuffer) -> LazyOp:
   # TODO: this can also corealize a binary op after the reduce, not just before
-  # NOTE: mypy doesn't know that if src.realized, then src.op must be a LazyOp so we have to ignore a bunch of warnings
+  # NOTE: mypy doesn't know that if not src.realized, then src.op must be a LazyOp so we have to ignore a bunch of warnings
   src = self.op.src[0]
   if not src.realized:
-    # When a tensor is reduced, reshaped/expanded back and then reduced again along the same axis, 
-    # it's equivalent to performing the initial reduction and multiplying the result 
+    # When a tensor is reduced, reshaped/expanded back and then reduced again along the same axis,
+    # it's equivalent to performing the initial reduction and multiplying the result
     # by the size of the expanded dimension.
     if SIMPLIFY_SUM_RESHAPE_EXPAND_SUM and src.op.op == MovementOps.EXPAND: # type: ignore
       expanded = src.op.src[0] # type: ignore


### PR DESCRIPTION
New test case:

```
  def test_fold_expand_reduce(self):
    with CLCache(1):
      a = Tensor.randn(16, 1)
      a = a.expand((16, 16)).sum(-1)
      a.realize()
      assert len(GlobalCounters.cache) == 1, "optimizer didn't fold expand/reduce"
 ```
 
 This generates two kernels on master, including a reduction kernel
 
 ```
 ***    0 E_4_4                         arg   2 sz []                 [4]          OPs      0M/   0.00G  mem  0.00 GB tm     14.71us/     0.01ms (    0.00 GFLOPS,    0.01 GB/s)
***    1 r_16_16                       arg   2 sz [16]               [16]         OPs      0M/   0.00G  mem  0.00 GB tm     10.75us/     0.03ms (    0.02 GFLOPS,    0.01 GB/s)
```

<img width="670" alt="Screenshot 2023-07-05 at 04 56 43" src="https://github.com/geohot/tinygrad/assets/42040895/4a17bbce-d67c-45fb-8805-52c9757be7b5">

With these changes we have:

```
***    0 E_4_4                         arg   2 sz []                 [4]          OPs      0M/   0.00G  mem  0.00 GB tm     12.71us/     0.01ms (    0.00 GFLOPS,    0.01 GB/s)
```

<img width="673" alt="Screenshot 2023-07-05 at 04 56 25" src="https://github.com/geohot/tinygrad/assets/42040895/97bb9737-2f7d-4c68-adac-1c23200ca840">
