### PR TITLE
Adding `lr_mult` directly to `Tensor` class, making it available in `Optimizer`

### DIFF
--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -93,5 +93,33 @@ class TestOptim(unittest.TestCase):
 
       np.testing.assert_allclose(losses[0], losses[1], atol=1e-4, rtol=0)
 
+  def test_lr_mult(self):
+    for Opt in [Adam, AdamW, SGD]:
+      lr_losses = []
+      lr_damp = []
+      w = Tensor(x_init.copy())
+      opt = Opt([w], lr=0.1)
+
+      loss = None
+      for _ in range(3):
+        loss = w.sum()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+      lr_losses.append(loss.numpy())
+
+      w = Tensor(x_init.copy())
+      w.lr_mult = 0.01
+      opt = Opt([w], lr=0.1)
+
+      loss = None
+      for _ in range(3):
+        loss = w.sum()
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+      lr_damp.append(loss.numpy())
+      np.testing.assert_array_less(lr_losses, lr_damp)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -35,7 +35,7 @@ class SGD(Optimizer):
       if self.momentum:
         self.b[i].assign(self.momentum * self.b[i] + g).realize()  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
-      t.assign(t.detach() - g * self.lr)
+      t.assign(t.detach() - g * (self.lr * t.lr_mult))
     self.realize(self.b)
 
 # LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
@@ -65,5 +65,5 @@ class LAMB(Optimizer):
         r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
       else:
         r = 1.0
-      t.assign(t.detach() - self.lr * r * up)
+      t.assign(t.detach() - (self.lr * t.lr_mult) * r * up)
     self.realize([self.t] + self.m + self.v)

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -35,7 +35,7 @@ class SGD(Optimizer):
       if self.momentum:
         self.b[i].assign(self.momentum * self.b[i] + g).realize()  # NOTE: self.b[i] is zero on the first run, no if required
         g = (g + self.momentum * self.b[i]) if self.nesterov else self.b[i]
-      t.assign(t.detach() - g * (self.lr * t.lr_mult))
+      t.assign(t.detach() - g * ((self.lr * t.lr_mult) if hasattr(t, 'lr_mult') else self.lr))
     self.realize(self.b)
 
 # LAMB is essentially just the trust ratio part of LARS applied to Adam/W so if we just set the trust ratio to 1.0 its just Adam/W.
@@ -65,5 +65,5 @@ class LAMB(Optimizer):
         r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
       else:
         r = 1.0
-      t.assign(t.detach() - (self.lr * t.lr_mult) * r * up)
+      t.assign(t.detach() - ((self.lr * t.lr_mult) if hasattr(t, 'lr_mult') else self.lr) * r * up)
     self.realize([self.t] + self.m + self.v)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -45,7 +45,6 @@ class Tensor:
     device = Device.canonicalize(device)
     # tensors have gradients, buffers do not
     self.grad: Optional[Tensor] = None
-    self.lr_mult = float(1.0)
 
     # NOTE: this can be in three states. False and None: no gradient, True: gradient
     # None (the default) will be updated to True if it's put in an optimizer

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -34,7 +34,7 @@ import tinygrad.mlops as mlops
 # **** start with two base classes, Tensor and Function ****
 
 class Tensor:
-  __slots__ = "lazydata", "requires_grad", "grad", "_ctx"
+  __slots__ = "lazydata", "requires_grad", "grad", "_ctx", "lr_mult"
   __deletable__ = ('_ctx',)
   training: ClassVar[bool] = False
   no_grad: ClassVar[bool] = False
@@ -45,6 +45,7 @@ class Tensor:
     device = Device.canonicalize(device)
     # tensors have gradients, buffers do not
     self.grad: Optional[Tensor] = None
+    self.lr_mult = float(1.0)
 
     # NOTE: this can be in three states. False and None: no gradient, True: gradient
     # None (the default) will be updated to True if it's put in an optimizer


### PR DESCRIPTION
Adding a learning-rate multiplier for Tensors/Optim. This isn't necessarily 1:1 with `pytorch` as you need to set it during the parameter collection process - but it is 1:1 with `mxnet` - and having used `mxnet` internally at `AWS`, this was a nice thing about the library. 

examples:
`pytorch` method
```
import timm
import torch.optim as optim
model = timm.create_model('resnet18', num_classes = 100)
lr = 0.001
lr_mult = 0.01

parameters = []
for param in model.named_parameters:
  
  if param.requires_grad:
    param_dict = dict()
    param_dict['params'] = param
    param_dict['lr'] = lr * lr_mult
    parameters.append(param_dict)

optimizer = optim.Adam(parameters)
```
`mxnet` method

```
from mxnet import gluon
from gluoncv.model_zoo import get_model
net = get_model('resnet18, pretrained=True)
for v in net.collect_params().values():
  if 'conv' in v.name:
    setattr(v, 'lr_mult', 0.01)
optimizer = gluon.Trainer(net.collect_params(), 'sgd', {
        'learning_rate': lr, 'momentum': momentum, 'wd': wd})
```

thus, my proposal is this:


add `lr_mult` to Tensor
```
class Tensor:
  __slots__ = "lazydata", "requires_grad", "grad", "_ctx", "lr_mult"
  __deletable__ = ('_ctx',)
  training: ClassVar[bool] = False
  no_grad: ClassVar[bool] = False
  default_type: ClassVar[DType] = dtypes.float32

  def __init__(self, data:Union[int, float, list, tuple, LazyBuffer, np.ndarray], device:Optional[str]=None, dtype:Optional[DType]=None, requires_grad:Optional[bool]=None):
    assert dtype is None or isinstance(dtype, DType), f"invalid dtype {dtype}"
    device = Device.canonicalize(device)
    # tensors have gradients, buffers do not
    self.lr_mult = float(1.0)
   ...
```
use `lr_mult` in the optimizer
```
class LAMB(Optimizer):
  def __init__(self, params: List[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, wd=0.0, adam=False):
    super().__init__(params)
    self.lr, self.b1, self.b2, self.eps, self.wd, self.adam, self.t = lr, b1, b2, eps, wd, adam, Tensor([0], requires_grad=False).realize()
    self.m = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]
    self.v = [Tensor.zeros(*t.shape, device=t.device, requires_grad=False) for t in self.params]

  def step(self) -> None:
    self.t.assign(self.t + 1).realize()
    for i, t in enumerate(self.params):
      assert t.grad is not None
      g = t.grad.realize()
      self.m[i].assign(self.b1 * self.m[i] + (1.0 - self.b1) * g).realize()
      self.v[i].assign(self.b2 * self.v[i] + (1.0 - self.b2) * (g * g)).realize()
      m_hat = self.m[i] / (1.0 - self.b1**self.t)
      v_hat = self.v[i] / (1.0 - self.b2**self.t)
      up = (m_hat / (v_hat.sqrt() + self.eps)) + self.wd * t.detach()
      if not self.adam:
        r1 = t.detach().square().sum().sqrt()
        r2 = up.square().sum().sqrt()
        r = Tensor.where(r1 > 0, Tensor.where(r2 > 0, r1 / r2, 1.0), 1.0)
      else:
        r = 1.0
      t.assign(t.detach() - (self.lr * t.lr_mult) * r * up)
    self.realize([self.t] + self.m + self.v)

```
use `lr_mult` to dampen effects on pretrained layers
```
# Use a smaller learning rate for pre-trained convolutional layers.

from tinygrad.state import get_parameters
from models.resnet import ResNet50
from custom_model import EmbeddingNet

feature_net = ResNet50()
feature_net.load_from_pretrained()

feature_params = get_parameters(feature_net)
for param in feature_params:
    setattr(param, 'lr_mult', 0.01)

embedding_net = EmbeddingNet(feature_net)
```

