### PR TITLE
Fix evaluation stage in examples/transformer.py when using CUDA

### DIFF
--- a/examples/transformer.py
+++ b/examples/transformer.py
@@ -20,7 +20,7 @@ def make_dataset():
   ds_Y = np.copy(ds[:, 1:])
   ds_X_train, ds_X_test = ds_X[0:8000], ds_X[8000:]
   ds_Y_train, ds_Y_test = ds_Y[0:8000], ds_Y[8000:]
-  return ds_X_train, ds_Y_train, np.ascontiguousarray(ds_X_test), np.ascontiguousarray(ds_Y_test)
+  return ds_X_train, ds_Y_train, ds_X_test, ds_Y_test
 
 if __name__ == "__main__":
   model = Transformer(10, 6, 2, 128, 4, 32)

--- a/examples/transformer.py
+++ b/examples/transformer.py
@@ -20,7 +20,7 @@ def make_dataset():
   ds_Y = np.copy(ds[:, 1:])
   ds_X_train, ds_X_test = ds_X[0:8000], ds_X[8000:]
   ds_Y_train, ds_Y_test = ds_Y[0:8000], ds_Y[8000:]
-  return ds_X_train, ds_Y_train, ds_X_test, ds_Y_test
+  return ds_X_train, ds_Y_train, np.ascontiguousarray(ds_X_test), np.ascontiguousarray(ds_Y_test)
 
 if __name__ == "__main__":
   model = Transformer(10, 6, 2, 128, 4, 32)

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -49,7 +49,7 @@ else:
   import pycuda.driver as cuda # type: ignore
   class RawCUDABuffer(RawBufferCopyInOut): # type: ignore
     def __init__(self, size, dtype): super().__init__(size, dtype, cuda.mem_alloc(size * dtype.itemsize)) # type: ignore
-    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, x, stream) # type: ignore
+    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, np.ascontiguousarray(x), stream) # type: ignore
     def _copyout(self, x:np.ndarray): cuda.memcpy_dtoh(x, self._buf) # type: ignore
 
 class CUDAProgram:

--- a/tinygrad/runtime/ops_cuda.py
+++ b/tinygrad/runtime/ops_cuda.py
@@ -49,7 +49,7 @@ else:
   import pycuda.driver as cuda # type: ignore
   class RawCUDABuffer(RawBufferCopyInOut): # type: ignore
     def __init__(self, size, dtype): super().__init__(size, dtype, cuda.mem_alloc(size * dtype.itemsize)) # type: ignore
-    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, np.ascontiguousarray(x), stream) # type: ignore
+    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, x.ravel(), stream) # type: ignore
     def _copyout(self, x:np.ndarray): cuda.memcpy_dtoh(x, self._buf) # type: ignore
 
 class CUDAProgram:


### PR DESCRIPTION
**Problem Statement**
Running `examples/transformer.py` using CUDA crashes at the evaluation stage, error:
```
loss 0.38 accuracy 0.86: 100%|████████████████████████████████████████████████████████████████| 50/50 [00:04<00:00, 11.68it/s]
  0%|                                                                                                  | 0/16 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/home/bdn/Desktop/Modules/tinygrad/examples/transformer.py", line 32, in <module>
    acc, Y_test_preds = evaluate(model, X_test, Y_test, num_classes=10, return_predict=True)
  File "/home/bdn/Desktop/Modules/tinygrad/extra/training.py", line 60, in evaluate
    acc, Y_test_pred = numpy_eval(Y_test, num_classes)
  File "/home/bdn/Desktop/Modules/tinygrad/extra/training.py", line 53, in numpy_eval
    out = model.forward(x) if hasattr(model, 'forward') else model(x)
  File "/home/bdn/Desktop/Modules/tinygrad/models/transformer.py", line 63, in forward
    xnp = x.cpu().numpy().astype(np.int32)
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/tensor.py", line 112, in numpy
    def numpy(self) -> np.ndarray: return self.lazydata.toCPU()
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 188, in toCPU
    realized = self.cast(dtypes.from_np(self.dtype.np)).contiguous().realize().realized
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 144, in realize
    elif self.optype is LoadOps: LOAD_OPS_DISPATCHER[cast(LoadOps, self.op.op)](self)
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 336, in _realize_contiguous
    realized = buffer.op.src[0].realize().realized
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 144, in realize
    elif self.optype is LoadOps: LOAD_OPS_DISPATCHER[cast(LoadOps, self.op.op)](self)
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 349, in _realize_from
    rawbuf = buffer.op.src[0].realize()
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 144, in realize
    elif self.optype is LoadOps: LOAD_OPS_DISPATCHER[cast(LoadOps, self.op.op)](self)
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/lazy.py", line 355, in _realize_from
    buffer.realized = Device[buffer.device].buffer.fromCPU(rawbuf.toCPU(), **buffer._device_extra_args())
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/runtime/lib.py", line 31, in fromCPU
    ret._copyin(x)
  File "/home/bdn/Desktop/Modules/tinygrad/tinygrad/runtime/ops_cuda.py", line 52, in _copyin
    def _copyin(self, x:np.ndarray, stream:Optional[cuda.Stream]=None): cuda.memcpy_htod_async(self._buf, x, stream) # type: ignore
ValueError: ndarray is not contiguous
```

**Issue**
Dummy test set is not stored as a contiguous array, so CUDA is unable to transfer the data to GPU.

**Resolution**
Store dummy test set data as a contiguous array.

**Additional Notes**
Did a train run comparison with `CPU=1 python examples/transformer.py`, test set accuracy results between CPU and CUDA are identical after the fix.

CUDA version: 12.0