### PR TITLE
Make stripper script less tiny :c

### DIFF
--- a/strip_whitespace.sh
+++ b/strip_whitespace.sh
@@ -3,8 +3,8 @@
 # find all Python files in the staging area using git diff
 # and filter for Added or Modified files (AM) that match the "*.py" pattern
 git diff --cached --name-only --diff-filter=AM | grep '\.py$' | while read -r file; do
-    # Strip trailing whitespace from the file
+    # strip trailing whitespace from the file
     sed -i '' 's/ *$//' "$file"
-    # Stage the modified file
+    # stage the modified file
     git add "$file"
 done


### PR DESCRIPTION
while ruff --fix is cool
our stripper could be cooler!

this new stripper handles whitespaces on staged python files before ruff check is triggered
makes pre-commit workflow smoother I think
idk

I'll close PR if unnecessary