### PR TITLE
refactor: more efficient syntax [pr]

### DIFF
--- a/tinygrad/codegen/uopgraph.py
+++ b/tinygrad/codegen/uopgraph.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Tuple, Dict, List, TYPE_CHECKING, Any, DefaultDict, Callable
+from typing import Optional, Tuple, Dict, List, TYPE_CHECKING, Any, DefaultDict, Callable, Set
 import functools, itertools, operator
 from collections import defaultdict
 from tinygrad.dtype import dtypes, ImageDType, PtrDType
@@ -33,7 +33,7 @@ def fold_expanded(ex, buf):
 
   # then rewrite everything we can
   lengths = [4] if is_image else ([8,4,2] if buf.dtype.base == dtypes.half and getenv("ALLOW_HALF8") else ([16,8,4,2] if AMX else [4,2]))
-  used = set()
+  used: Set[Tuple[UOp, UOp]] = set()
   for rootsrc, offsets in offsets_rootsrc.items():
     for o in offsets:
       for fold_length in lengths:
@@ -59,7 +59,7 @@ def fold_expanded(ex, buf):
             for i in range(fold_length): new_srcs[offsets[o+i]] = new_load.gep(i)
           else:
             for i in range(fold_length): new_srcs[offsets[o+i]] = UOp(Ops.STORE, dtypes.void, tuple(new_src)) if i == 0 else None
-          for i in range(fold_length): used.add((rootsrc,o+i))
+          used.update((rootsrc,o+i) for i in range(fold_length))
 
   # dedup expand for LOAD
   if is_load and len(old_new_srcs) != len(ex.src): new_srcs = [new_srcs[old_new_srcs.index(s)] for s in ex.src]

--- a/tinygrad/engine/jit.py
+++ b/tinygrad/engine/jit.py
@@ -262,7 +262,7 @@ class TinyJit(Generic[ReturnType]):
         for ei in jit_cache:
           if any(b in depends for b in ei.bufs):
             if isinstance(ei.prg, CompiledRunner):
-              for out in ei.prg.p.outs: depends.add(cast(Buffer, ei.bufs[out]))
+              depends.update(cast(Buffer, ei.bufs[out]) for out in ei.prg.p.outs)
         pruned, onetime = partition(jit_cache,
                                     lambda ei: not isinstance(ei.prg, CompiledRunner) or any(ei.bufs[out] in depends for out in ei.prg.p.outs))
         if DEBUG >= 1: print(f"pruned from {len(jit_cache)} -> {len(pruned)} kernels")

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -104,10 +104,8 @@ def swizzle_r(r:UOp, src:UOp, st:ShapeTracker) -> UOp:
   tmp, rshape = permute_reduce(ShapeTracker.from_shape(unwrap(src.st).shape), r.axis_arg)
   prshape = prod(rshape)
   strides = strides_for_shape(rshape)
-  nv: List[View] = []
-  for v in st.views:
-    nv.append(View.create(v.shape+rshape, tuple(x*prshape for x in v.strides)+strides,
-                          v.offset*prshape, v.mask+tuple((0,s) for s in rshape) if v.mask is not None else None))
+  nv = [View.create(v.shape+rshape, tuple(x*prshape for x in v.strides)+strides,
+                    v.offset*prshape, v.mask+tuple((0,s) for s in rshape) if v.mask is not None else None) for v in st.views]
   # update input_st and axis
   new_input_st = tmp + ShapeTracker(tuple(nv))
   _, new_rshape = permute_reduce(new_input_st, r.axis_arg)

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -554,7 +554,7 @@ class UPat(MathTrait):
     if custom_early_reject is not None: self.early_reject = custom_early_reject
     else:
       upat_match = [src] if isinstance(src, UPat) else ([] if src is None else self.src[0])
-      self.early_reject = set(pp.op[0] for pp in upat_match if pp.op is not None and len(pp.op) == 1)
+      self.early_reject = {pp.op[0] for pp in upat_match if pp.op is not None and len(pp.op) == 1}
 
   def named(self, name:str): return UPat(self.op, self.dtype, self._in_src, self.arg, name, self.allowed_len == -1, self.custom_early_reject)
 
@@ -647,7 +647,7 @@ class PatternMatcher:
   def __add__(self, more:PatternMatcher): return PatternMatcher(self.patterns+more.patterns)
 
   def rewrite(self, uop:UOp, ctx=None) -> Optional[UOp]:
-    ler = set(u.op for u in uop.src)
+    ler = {u.op for u in uop.src}
     for p,fxn,early_reject,has_ctx in self.pdict.get(uop.op, []):
       if not early_reject.issubset(ler): continue
       for match in p.match(uop, {}):
@@ -688,7 +688,7 @@ class TrackedPatternMatcher(PatternMatcher):
 
   def rewrite(self, uop:UOp, ctx=None) -> Optional[UOp]:
     ret = None
-    ler = set(u.op for u in uop.src)
+    ler = {u.op for u in uop.src}
     for p,fxn,early_reject,has_ctx in self.pdict.get(uop.op, []):
       st = time.perf_counter()
       if not early_reject.issubset(ler):


### PR DESCRIPTION
3 changes:
* update a set once, not in a for loop
* use set comprehension directly
* create the list using list comprehension instead of `for ... append`


The only change that matters to the performance is the direct set comprehension in the busy rewrite.
`ler = set(u.op for u in uop.src)` -> ` ler = {u.op for u in uop.src}`.

Master best out of 5
```
(.venv) (base) ➜  tinygrad git:(master) PROFILE=0 python test/external/external_benchmark_schedule.py
***** model tensor in     19.29 ms
***** model schedule in   86.85 ms
***** model opts(31) in  165.09 ms
***** model lower in      14.08 ms
***** model rewrite in   414.20 ms
***** model linearize in 138.50 ms
19675
all 840.01 ms
```


Branch best out of 5
```
(.venv) (base) ➜  tinygrad git:(refactor/syntax) PROFILE=0 python test/external/external_benchmark_schedule.py
***** model tensor in     19.40 ms
***** model schedule in   82.85 ms
***** model opts(31) in  159.00 ms
***** model lower in      13.58 ms
***** model rewrite in   403.06 ms
***** model linearize in 135.58 ms
19675
all 815.40 ms
```