### PR TITLE
Skip test that counts Ops.LOAD on CLANG+AMX (upcasts up to float16)

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -1,7 +1,7 @@
 from typing import List
 import unittest, time
 from tinygrad import dtypes, Device
-from tinygrad.helpers import DEBUG
+from tinygrad.helpers import DEBUG, AMX
 from tinygrad.ops import Ops, UOp, KernelInfo, UPat, PatternMatcher
 from tinygrad.renderer import Renderer
 from tinygrad.codegen.lowerer import rewrite_shapetracker_with_index
@@ -602,6 +602,7 @@ class TestLoadStoreFolder(unittest.TestCase):
     sink = float4_rewrite(sink.sink())
     assert len([x for x in sink.toposort if x.op is Ops.LOAD]) == 1
 
+  @unittest.skipIf(Device.DEFAULT in {"CLANG"} and AMX, "CLANG with AMX upcasts float up to size 16")
   def test_two_load_fold(self):
     buf = UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr())
     load = [UOp(Ops.LOAD, dtypes.float, (buf.index(UOp.const(dtypes.int, i)),)) for i in range(8)]


### PR DESCRIPTION
This test assumes that float4 is the max upcast and tests that 8 float loads are upcasted to 2 float4 loads, however on CLANG+AMX upcasts can be up to float16 and in this test we get one float8 load instead.

The @unittest.skipIf line is copied from test_linearizer.py where a bunch of tests make similar assumptions about upcasts.

What this test assumes and tests for:
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/df5c86ab-746c-4d4e-b26c-d2d914ab5ece" />

What actually happens on CLANG+AMX:
<img width="949" alt="image" src="https://github.com/user-attachments/assets/21134795-72e8-4183-9dc5-ec9688753c15" />

With this (and #8460) all CLANG+AMX tests pass on my laptop, however i expect it to break again quite soon if there isn't a full test suite running in CI. I thought about making a quick MOCKAMX implementation but it requires writeable global state (amx regs) and clang jit doesn't (and probably shouldn't) support it.