### PR TITLE
cat loop splitting

### DIFF
--- a/test/test_loop_splitting.py
+++ b/test/test_loop_splitting.py
@@ -1,0 +1,137 @@
+import unittest
+from tinygrad import Tensor
+from tinygrad.codegen import apply_rewrites, get_rewrites_for_renderer
+from tinygrad.device import Device
+from tinygrad.dtype import dtypes
+from tinygrad.helpers import CI
+from tinygrad.uop.ops import Ops, UOp
+
+class TestLoopSplittingGood(unittest.TestCase):
+  def setUp(self) -> None:
+    rewrites = list(get_rewrites_for_renderer(Device.default.renderer))
+    while rewrites[0].name != "lowerer": rewrites.pop(0)
+    rewrites.pop(0)
+    rewrites = list(reversed(rewrites))
+    while rewrites[0].name != "split_loop": rewrites.pop(0)
+    self.rewrites = list(reversed(rewrites))
+
+  def test_basic_cat(self):
+    sink = UOp(Ops.SINK, dtypes.void, arg=None, src=(
+      UOp(Ops.STORE, dtypes.void, arg=None, src=(
+        UOp(Ops.INDEX, dtypes.float.ptr(128), arg=None, src=(
+          UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(128), arg=0, src=()),
+          x3:=UOp(Ops.RANGE, dtypes.int, arg=0, src=(
+            UOp(Ops.CONST, dtypes.int, arg=128, src=()),)),)),
+        UOp(Ops.ADD, dtypes.float, arg=None, src=(
+          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
+            UOp(Ops.INDEX, dtypes.float.ptr(64), arg=None, src=(
+              UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(64), arg=1, src=()),
+               x3,
+              x9:=UOp(Ops.CMPLT, dtypes.bool, arg=None, src=(
+                 x3,
+                UOp(Ops.CONST, dtypes.int, arg=64, src=()),)),)),)),
+          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
+            UOp(Ops.INDEX, dtypes.float.ptr(64), arg=None, src=(
+              UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(64), arg=2, src=()),
+              UOp(Ops.ADD, dtypes.int, arg=None, src=(
+                 x3,
+                UOp(Ops.CONST, dtypes.int, arg=-64, src=()),)),
+              UOp(Ops.CMPNE, dtypes.bool, arg=None, src=(
+                 x9,
+                UOp(Ops.CONST, dtypes.bool, arg=True, src=()),)),)),)),)),)),))
+
+    self.check_range_splits(sink, 1, 2)
+
+  def test_cat_2d(self):
+    sink = UOp(Ops.SINK, dtypes.void, arg=None, src=(
+      UOp(Ops.STORE, dtypes.void, arg=None, src=(
+        UOp(Ops.INDEX, dtypes.float.ptr(8192), arg=None, src=(
+          UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(8192), arg=0, src=()),
+          x3:=UOp(Ops.ADD, dtypes.int, arg=None, src=(
+            UOp(Ops.MUL, dtypes.int, arg=None, src=(
+              x5:=UOp(Ops.RANGE, dtypes.int, arg=0, src=(
+                UOp(Ops.CONST, dtypes.int, arg=128, src=()),)),
+              x7:=UOp(Ops.CONST, dtypes.int, arg=64, src=()),)),
+            UOp(Ops.RANGE, dtypes.int, arg=1, src=(
+               x7,)),)),)),
+        UOp(Ops.ADD, dtypes.float, arg=None, src=(
+          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
+            UOp(Ops.INDEX, dtypes.float.ptr(4096), arg=None, src=(
+              UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(4096), arg=1, src=()),
+               x3,
+              x13:=UOp(Ops.CMPLT, dtypes.bool, arg=None, src=(
+                 x5,
+                 x7,)),)),)),
+          UOp(Ops.LOAD, dtypes.float, arg=None, src=(
+            UOp(Ops.INDEX, dtypes.float.ptr(4096), arg=None, src=(
+              UOp(Ops.DEFINE_GLOBAL, dtypes.float.ptr(4096), arg=2, src=()),
+              UOp(Ops.ADD, dtypes.int, arg=None, src=(
+                 x3,
+                UOp(Ops.CONST, dtypes.int, arg=-4096, src=()),)),
+              UOp(Ops.CMPNE, dtypes.bool, arg=None, src=(
+                 x13,
+                UOp(Ops.CONST, dtypes.bool, arg=True, src=()),)),)),)),)),)),))
+
+    sink = self.check_range_splits(sink, 1, 2)
+    self.assertEqual(len(sink.src), 2)
+
+  def check_range_splits(self, sink: UOp, n_ranges_removed: int, n_ranges_added: int):
+    ranges_before = set(uop for uop in sink.parents if uop.op is Ops.RANGE)
+    sink = apply_rewrites(sink, self.rewrites)
+    ranges_after = set(uop for uop in sink.parents if uop.op is Ops.RANGE)
+
+    self.assertEqual(len(ranges_before - ranges_after), n_ranges_removed)
+    self.assertEqual(len(ranges_after - ranges_before), n_ranges_added)
+
+    return sink
+
+@unittest.skipIf(CI, "bad tests, need to clean up")
+class TestLoopSplitting(unittest.TestCase):
+  def test_basic_cat(self):
+    a = Tensor.empty(64)
+    b = Tensor.empty(64)
+
+    self.verify_schedule(a.cat(b))
+
+  def test_cat_2d(self):
+    a = Tensor.empty(64, 64)
+    b = Tensor.empty(64, 64)
+
+    self.verify_schedule(a.cat(b))
+
+  def test_cat_reduce1(self): # TODO: this is a shitty test
+    a = Tensor.empty(64, 64)
+    b = Tensor.empty(64, 64)
+
+    # TODO: make this nice!
+    with self.assertRaises(AssertionError):
+      self.verify_schedule(a.cat(b, dim=0).sum(1)) # this can not be split!
+
+  def test_cat_reduce2(self):
+    a = Tensor.empty(64, 64)
+    b = Tensor.empty(64, 64)
+
+    self.verify_schedule(a.cat(b, dim=1).sum(1))
+
+  def test_add_pad(self):
+    a = Tensor.empty(64, 64)
+    b = Tensor.empty(128, 128)
+
+    self.verify_schedule((a.pad([(0, 64), (0, 64)]) + b))
+
+  def verify_schedule(self, t: Tensor):
+    for si in t.schedule():
+      rewrites = list(get_rewrites_for_renderer(Device.default.renderer))
+      sink = si.ast
+      while rewrites[0].name != "split_loop": sink = rewrites.pop(0)(sink)
+      initial_ranges = set(uop for uop in sink.toposort() if uop.op is Ops.RANGE)
+
+      if len(initial_ranges) > 0:
+        sink = rewrites.pop(0)(sink)
+        new_ranges = set(uop for uop in sink.toposort() if uop.op is Ops.RANGE)
+        self.assertNotEqual(initial_ranges, new_ranges) # if loop splitting worked, we expect new ranges to exist
+
+        while rewrites and rewrites[0].name != "split_loop": sink = rewrites.pop(0)(sink)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tinygrad/codegen/__init__.py
+++ b/tinygrad/codegen/__init__.py
@@ -42,15 +42,15 @@ def _get_rewrites_for_renderer(opts:Renderer, linearizer:bool, _QUANTIZE, _DEVEC
   ret.append(RewriteStep(pm_store_ignore, name="store_ignore"))
   ret.append(RewriteStep(pm_move_ignore, name="move_ignore"))
 
-  # loop splitting
-  ret.append(RewriteStep(pm_split_loop+sym, name="split_loop"))
-
   # expand + remove surviving ignores
   ret.append(RewriteStep(pm_delete_ignore+sym+expander, name="expander"))
 
   # ** devectorizer (full_graph_rewrite) **
   # remove reduce
   ret.append(RewriteStep(pm_reduce+gep_pushing, lambda _: ReduceContext(), name="remove_reduce"))
+
+  # loop splitting
+  ret.append(RewriteStep(sym+pm_split_loop, name="split_loop"))
 
   # devectorize (TODO: does this need opts?)
   if _DEVECTORIZE >= 2: pm_devectorize = sym+load_store_folding+load_store_indexing

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -115,7 +115,7 @@ class Ops(FastEnum):
   REDUCE_AXIS = auto(); REDUCE = auto(); ALLREDUCE = auto() # noqa: E702
 
   # helper ops
-  GEP = auto(); VECTORIZE = auto(); CAT = auto(); PTRCAT = auto() # noqa: E702
+  GEP = auto(); VECTORIZE = auto(); CAT = auto(); PTRCAT = auto(); SPLIT = auto(); SPLITSELECT = auto() # noqa: E702
 
   # UnaryOps
   CAST = auto(); BITCAST = auto(); EXP2 = auto(); LOG2 = auto(); SIN = auto(); SQRT = auto(); RECIP = auto(); NEG = auto() # noqa: E702


### PR DESCRIPTION
bounty: Fix cat at high level by implementing loop splitting

approach:
- find pivot by searching for cmplt
- duplicate store and substitute new ranges
- apply sym and constant fold the cmplt

---
```python
from tinygrad import Tensor

a = Tensor.rand(64).realize()
b = Tensor.rand(128).realize()
c = (a.pad((0, 64)) + b).realize()
```
becomes
```c
void E_32_4n1(float* restrict data0, float* restrict data1, float* restrict data2) {
  for (int ridx16384 = 0; ridx16384 < 16; ridx16384++) {
    int alu0 = ((ridx16384<<2)+64);
    float4 val0 = *((float4*)((data2+alu0)));
    *((float4*)((data0+alu0))) = val0;
  }
  for (int ridx32768 = 0; ridx32768 < 16; ridx32768++) {
    int alu3 = (ridx32768<<2);
    float4 val1 = *((float4*)((data1+alu3)));
    float4 val2 = *((float4*)((data2+alu3)));
    *((float4*)((data0+alu3))) = (float4){(val1[0]+val2[0]),(val1[1]+val2[1]),(val1[2]+val2[2]),(val1[3]+val2[3])};
  }
}
```