### PR TITLE
removed unnecessary `isinstance(data, UOp)` check

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -163,7 +163,7 @@ class Tensor(MathTrait):
     # data might be on a different device
     if isinstance(device, str): self.lazydata:UOp = data if data.device == device else data.copy_to_device(device)
     # if device is a tuple, we should have/construct a MultiLazyBuffer
-    elif isinstance(data, UOp) and isinstance(data.device, str): self.lazydata = Tensor(data).shard(device).lazydata
+    elif isinstance(data.device, str): self.lazydata = Tensor(data).shard(device).lazydata
     else:
       assert data.device == device, f"MultiLazyBuffer device mismatch, {data.device} != {device}"
       self.lazydata = data


### PR DESCRIPTION
removed unnecessary `isinstance(data, UOp)` check on [line 166](https://github.com/tinygrad/tinygrad/blob/07de095b27eb35ee0d5d3dc17d11856e3f97a2e8/tinygrad/tensor.py#L166) because [line 161](https://github.com/tinygrad/tinygrad/blob/07de095b27eb35ee0d5d3dc17d11856e3f97a2e8/tinygrad/tensor.py#L161) already checks for `not isinstance(data, UOp)`