### PR TITLE
am: disable page migration

### DIFF
--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -666,9 +666,9 @@ class PCIIface:
     except OSError as e: raise RuntimeError(f"Cannot resize BAR: {e}. Ensure the resizable BAR option is enabled on your system.") from e
 
     # Disable migartion of locked pages.
-    if first_dev and FileIOInterface(reloc_sysfs:="/proc/sys/vm/compact_unevictable_allowed", os.O_RDONLY).read() != "0":
+    if first_dev and FileIOInterface(reloc_sysfs:="/proc/sys/vm/compact_unevictable_allowed", os.O_RDONLY).read()[0] != "0":
       os.system(cmd:=f"sudo sh -c 'echo 0 > {reloc_sysfs}'")
-      assert FileIOInterface(reloc_sysfs, os.O_RDONLY).read() == "0", f"Failed to disable migration of locked pages. Please run {cmd} manually."
+      assert FileIOInterface(reloc_sysfs, os.O_RDONLY).read()[0] == "0", f"Failed to disable migration of locked pages. Please run {cmd} manually."
 
     # Try to init vfio. Use it if success.
     if getenv("VFIO", 0):


### PR DESCRIPTION
this patch disables locked page migration on the system.

this potentially could lead to nan issues and hangs when `AMD_ALLOC_QUEUE_DEV_MEM=0`