### PR TITLE
return inf on remote exec exceptions

### DIFF
--- a/tinygrad/runtime/ops_remote.py
+++ b/tinygrad/runtime/ops_remote.py
@@ -204,7 +204,7 @@ class RemoteHandler:
             try:
               r = session.programs[(c.name, c.datahash)](*bufs, vals=c.vals, wait=c.wait, **extra_args)
               if r is not None: ret = str(r).encode()
-            except Exception as e:
+            except RuntimeError as e:
               if c.wait: ret = 'inf'.encode()
               else: raise e
           case GraphAlloc():


### PR DESCRIPTION
BEAM with remote currently stops (from the remote device) if the host device throws an exception. This catches exceptions on program exec and returns inf to the host, which will then ignore these kernels