### PR TITLE
specify metal threadgroup size at compile time

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -281,7 +281,7 @@ class MetalRenderer(CStyleLanguage):
   def __init__(self): self.tensor_cores = tc.metal if hasattr(os, 'uname') and os.uname().machine == "arm64" else []
 
   # language options
-  kernel_typedef = "kernel void"
+  kernel_typedef = "[[kernel, max_total_threads_per_threadgroup({launch_bounds})]] void"
   buffer_prefix = "device "
   smem_prefix = "threadgroup __attribute__((aligned(16))) "
   arg_int_prefix = "constant int&"


### PR DESCRIPTION
(first commit of this pr is #10617)

previously the metal compiler would use some amount of registers, then when the program is created the api would return the maximum threadgroup size allowed given that amount of registers is used by a shader and throw if the local_size is more than that

this makes it do the limiting the other way around, tinygrad would add the attribute to the kernel source that it must be launchable with some amount of threads in a threadgroup and the metal compiler would limit itself to using the amount of registers available with that in mind