### PR TITLE
remove unused lib directory from viz setup [pr]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(name='tinygrad',
       packages = ['tinygrad', 'tinygrad.runtime.autogen', 'tinygrad.runtime.autogen.am', 'tinygrad.codegen', 'tinygrad.nn',
                   'tinygrad.renderer', 'tinygrad.engine', 'tinygrad.viz', 'tinygrad.runtime', 'tinygrad.runtime.support',
                   'tinygrad.runtime.support.am', 'tinygrad.runtime.graph', 'tinygrad.shape', 'tinygrad.uop'],
-      package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'perfetto.html', 'assets/**/*', 'js/*', 'lib/**/*']},
+      package_data = {'tinygrad': ['py.typed'], 'tinygrad.viz': ['index.html', 'perfetto.html', 'assets/**/*', 'js/*']},
       classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License"


### PR DESCRIPTION
Complete tinygrad VIZ tree in installation:
```
├── assets
│   ├── cdnjs.cloudflare.com
│   │   └── ajax
│   │       └── libs
│   │           └── highlight.js
│   │               └── 11.10.0
│   │                   ├── highlight.min.js
│   │                   ├── languages
│   │                   │   ├── cpp.min.js
│   │                   │   └── python.min.js
│   │                   └── styles
│   │                       └── default.min.css
│   ├── d3js.org
│   │   └── d3.v7.min.js
│   ├── dagrejs.github.io
│   │   └── project
│   │       └── dagre
│   │           └── latest
│   │               └── dagre.min.js
│   └── unpkg.com
│       └── @highlightjs
│           └── cdn-assets@11.10.0
│               └── styles
│                   └── tokyo-night-dark.min.css
├── index.html
├── js
│   ├── index.js
│   └── worker.js
├── perfetto.html
└── serve.py

19 directories, 12 files
```
3 javascript dependancies in assets/ + the js directory for layout WebWorker + main app.