### PR TITLE
remove gbarrier on const

### DIFF
--- a/tinygrad/engine/grouper.py
+++ b/tinygrad/engine/grouper.py
@@ -537,6 +537,8 @@ finalize_gbarrier = PatternMatcher([
   (UPat((Ops.GBARRIER, Ops.CONTIGUOUS), src=(UPat(Ops.GBARRIER),), name="x"), lambda x: x.src[0]),
   # add contiguous to VIEW before GBARRIER
   (UPat(Ops.GBARRIER, src=(UPat(Ops.VIEW,),), name="x"), lambda x: x.src[0].contiguous().gbarrier()),
+  # remove gbarrier on constants without a contiguous
+  (UPat(Ops.GBARRIER, src=(UPat(Ops.CONST),), name="x"), lambda x: x.src[0]),
 ])
 
 remove_tags = PatternMatcher([(UPat(GroupOp.All, name="x"), lambda x: x.replace(tag=None) if x.tag is not None else None)])


### PR DESCRIPTION
This is a part of removing the complexity in which ops can come before GBARRIER.

`ALWAYS_CONTIGUOUS` and gbarrier are describing the same thing. Instead of maintaining a list of ops, we can remove gbarriers if needed.

eg, a standalone VIEW or CONST node does not get stored.
GBARRIER(VIEW) needs to store a contiguous, or if possible, push the VIEW after gbarrier.
GBARRIER on a CONST is always removed, it can always fuses.