### PR TITLE
visualize tile script

### DIFF
--- a/extra/viz_tile.py
+++ b/extra/viz_tile.py
@@ -6,54 +6,71 @@ from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.shape.view import View, unravel, canonicalize_strides
 from tinygrad.codegen.kernel import Kernel
 
+# TODO: address masking/padding
+# TODO: generic shapetracker layout viz
+# TODO: remove tabulate dependency
+
+VIZ_TILE_DEBUG = getenv("VIZ_TILE_DEBUG", 0)
+VIZ_TILE_MAX_WIDTH = getenv("VIZ_TILE_MAX_WIDTH", 32)
+VIZ_TILE_LIDX = getenv("VIZ_TILE_LIDX", -1)
 
 def _viz(ctx: Kernel, uop: UOp):
-  st, buf = uop.st_arg, uop.src[0].src[0]
+  st, buf = uop.st_arg, uop.src[0].base
   print(f"\nBuf [{buf.arg}] (op: {'st' if uop.op is Ops.STORE else 'ld'} {'global' if buf.op is Ops.DEFINE_GLOBAL else 'shared'})")
-  # shrink global, reduce and broadcasted upcast dims and expand local dims
+
+  # shrink global, reduce and broadcasted upcast dims
+  # expand local dims
   st = st.shrink(tuple((0, 1) if i < ctx.global_dims or (ctx.first_reduce <= i < ctx.first_upcast) else (0, s) for i, s in enumerate(st.shape)))
   st = st.shrink(tuple((0, 1) if (ctx.first_upcast <= i and s == 0) else (0, st.shape[i]) for i, s in enumerate(st.real_strides(True))))
   st = st.expand(tuple(ctx.full_shape[i] if ctx.global_dims <= i < ctx.first_reduce else s for i, s in enumerate(st.shape)))
 
   # thread and upcast indices increment in col-major order
   colmajor_strides = canonicalize_strides(st.shape, tuple(itertools.accumulate(st.shape, operator.mul, initial=1)))
-  tile_st = ShapeTracker((View.create(shape=st.shape, strides=colmajor_strides),))
+  threads_st = ShapeTracker((View.create(shape=st.shape, strides=colmajor_strides),))
+
+  if VIZ_TILE_DEBUG:
+    print(f"{uop.st_arg=} {uop.st_arg.size=} {uop.st_arg.real_size()=}")
+    print(f"{st=} {st.size=} {st.real_size()=}")
+    print(f"{threads_st=} {threads_st.size=} {threads_st.real_size()=}")
 
   layout: dict = {}
-  # print(f"{uop.st_arg}{uop.st_arg.size} {uop.st_arg.real_size()}\n{st}{st.size} {st.real_size()}\n{tile_st}{tile_st.size} {tile_st.real_size()}")
   with Context(TRACK_MATCH_STATS=0):
-    for i in range(0, tile_st.real_size()):
-      logical_coords: tuple[UOp, ...] = tuple(sint_to_uop(c) for c in unravel(tile_st.shape, i))
+    for i in range(0, threads_st.real_size()): # match logial coord to thread/upcast index
+      logical_coords: tuple[UOp, ...] = tuple(sint_to_uop(c) for c in unravel(threads_st.shape, i))
       idx, idx_valid = st.to_indexed_uops(logical_coords)
-      tile_idx, tile_idx_valid = tile_st.to_indexed_uops(logical_coords)
-      if idx_valid.arg and tile_idx_valid.arg:
-        layout.setdefault(idx.arg, []).append(tile_idx.arg)
+      threads_idx, threads_idx_valid = threads_st.to_indexed_uops(logical_coords)
+      if idx_valid.arg and threads_idx_valid.arg:
+        layout.setdefault(idx.arg, []).append(threads_idx.arg)
 
-  matrix, elems, width, tidx = None, [], 1, getenv("VIZ_TILE_TIDX", -1)
-  local_size = prod(s for s in tile_st.shape[ctx.global_dims : ctx.first_reduce])
-  upcast_size = prod(s for s in tile_st.shape[ctx.first_upcast :])
+  local_size = prod(s for s in threads_st.shape[ctx.global_dims : ctx.first_reduce])
+  upcast_size = prod(s for s in threads_st.shape[ctx.first_upcast :])
   local_w, upcast_w = len(str(local_size - 1)), len(str(upcast_size - 1))
 
   def ansi(t: int) -> str:
     _R, _G, _B = (int(x * 5 + 0.5) for x in colorsys.hsv_to_rgb(t / 32, 0.65, 0.80))
-    return f"\x1b[38;5;{17 + 36 * _R + 6 * _G + _B}m{t:0{local_w}d}\x1b[0m" if tidx == -1 or tidx == t else f"{t:0{local_w}d}"
+    return f"\x1b[38;5;{17 + 36 * _R + 6 * _G + _B}m{t:0{local_w}d}\x1b[0m" if VIZ_TILE_LIDX in (-1, t) else f"{t:0{local_w}d}"
 
+  elems = []
   for i, coords in sorted(layout.items()):
     thread_idxs = tuple(sorted(set(cs % local_size for cs in coords)))
     upcast_idx = tuple(set(cs // local_size for cs in coords))[0]
     elems += [f"T({','.join((f'{chr(10)}  ' if i > 0 and i % 4 == 0 else '') + ansi(thread_idx) for i, thread_idx in enumerate(thread_idxs))})\n"
             + f"V[{upcast_idx:0{upcast_w}d}]"]
 
-  for stride, shape in sorted((stride, shape) for stride, shape in zip(st.real_strides(True), st.shape) if stride != 0):
-    if width == stride and width * shape <= getenv("VIZ_TILE_MAX_WIDTH", 32): width *= shape
-    else: break
+  if buf.op is Ops.DEFINE_LOCAL: # set width to 128 bytes (32 floats) to simulate smem layout and visualize bank conflicts
+    width = 32 * 4 // buf.dtype.itemsize
+  else: # set witdh based on contiguous strides
+    width = 1
+    for stride, shape in sorted((stride, shape) for stride, shape in zip(st.real_strides(True), st.shape) if stride != 0):
+      if width == stride and width * shape <= VIZ_TILE_MAX_WIDTH:
+        width *= shape
+      else:
+        break
+    if len(elems) % width != 0: # fallback to width 1
+      width = 1
 
-  if buf.op is Ops.DEFINE_LOCAL: width = 32 * 4 // buf.dtype.itemsize  # override width to visualize smem banks
-  elif len(elems) % width != 0: width = 1  # fallback to width 1
-
-  matrix = [elems[i : i + width] for i in range(0, len(elems), width)]
-  if matrix:
-    print(tabulate.tabulate(matrix, tablefmt="simple_grid", showindex=True, headers=tuple(str(i) for i in range(width))))
+  if tile := [elems[i : i + width] for i in range(0, len(elems), width)]:
+    print(tabulate.tabulate(tile, tablefmt="simple_grid", showindex=True, headers=tuple(str(i) for i in range(width))))
   else:
     print("<< failed to viz tile >>")
 
@@ -61,4 +78,22 @@ def _viz(ctx: Kernel, uop: UOp):
 
 
 def viz_tile(kernel: Kernel, ast: UOp) -> None:
+  """
+  Visualize LOAD/STORE tiles.
+
+  The function walks the `ast` with `graph_rewrite`, dispatching `_viz`
+  on each matching UOp to emit an ANSI-coloured table of the buffer
+  region accessed.  It is completely side-effectful (prints to stdout)
+  and returns `None`.
+
+  Typical integration (add inside `Kernel.linearize` **after** you've
+  produced the final AST you want to run):
+
+  ```
+  modified_ast = self.get_optimized_ast(name_override)
+  if ast_transform is not None:modified_ast = ast_transform(self, modified_ast)
+  from extra import viz_tile              # 1 import helper
+  viz_tile.viz_tile(self, modified_ast)   # 2 show tiles
+  ```
+  """
   graph_rewrite(ast, PatternMatcher([(UPat((Ops.LOAD, Ops.STORE), name="uop"), _viz)]), ctx=kernel)


### PR DESCRIPTION
This still needs some cleanup/docs. I'm also planning on writing this week some docs on tiled-algos/kernel-opts/tc using this tool.

Also, for small enough shapetrackers, the viz might also be useful, I'll play with it and if I find it useful I'll upstream it too.

One way of using this script is by plugging it within the linearize pipeline in the following way:
``` diff
  @track_rewrites()
  def linearize(self, name_override:Optional[str]=None, ast_transform:Optional[Callable]=None) -> Kernel:
    [...]
    modified_ast = self.get_optimized_ast(name_override)
    if ast_transform is not None: modified_ast = ast_transform(self, modified_ast)
+   from extra import viz_tile              # 1 import helper
+   viz_tile.viz_tile(self, modified_ast)   # 2 show tiles
    [...]
```

### Examples
`TC=1`
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/72144e82-2264-4d92-8ac7-fb45688c498c" />
`TC=2 highlighting thread 7`
<img width="1137" alt="image" src="https://github.com/user-attachments/assets/98e341a6-8a1c-44ee-bb62-d3ebf77d9921" />
`TC=3`
<img width="1664" alt="image" src="https://github.com/user-attachments/assets/efcc0f98-f585-40d9-91d3-c5b32944cb7b" />

