### PR TITLE
Fix integer overflow in bitwise shift ops by casting base to float

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -461,8 +461,8 @@ tiny_backend_out = {**{f"aten.{x}.out":getattr(Tensor,x) for x in simple_tensor_
   # TODO: this might result in overflow issues
   "aten.round.decimals_out": lambda self,decimals: (self*10**decimals).round()/10**decimals,
   # TODO: support this in tinygrad
-  "aten.bitwise_left_shift.Tensor_out": lambda x,y: x*(2**y),
-  "aten.bitwise_right_shift.Tensor_out": lambda x,y: x//(2**y),
+  "aten.bitwise_left_shift.Tensor_out": lambda x,y: x*(2.0**y),
+  "aten.bitwise_right_shift.Tensor_out": lambda x,y: x//(2.0**y),
   # not in tinygrad. are there decomps for these?
   "aten.log10.out": lambda self: self.log2() * (math.log(2) / math.log(10)),
   "aten.log1p.out": lambda self: (self+1).log(),


### PR DESCRIPTION
Replaces `2**y` with `2.0**y` in left and right shift emulations to avoid integer overflow.
Ensures consistent behavior for large y values on non-integer tensor types.

Ran into this issue while testing left and right shift emulations. Happy to provide minimum replication samples.