### PR TITLE
viz: enter key only expands steps

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -456,7 +456,7 @@ document.addEventListener("keydown", async function(event) {
     if (currentCtx === -1) {
       return setState({ currentCtx:0, expandSteps:true });
     }
-    return setState({ currentStep:0, currentRewrite:0, expandSteps:!expandSteps });
+    return setState({ expandSteps:!expandSteps });
   }
   // left and right go through rewrites in a single UOp
   if (event.key == "ArrowLeft") {


### PR DESCRIPTION
It shouldn't be changing any step or context state. Those are handled explicitly by the arrow keys (or clicking).