### PR TITLE
remove validate_kernel, it is asserting implementation details [pr]

### DIFF
--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -49,14 +49,9 @@ buffer_spec = PatternMatcher([
   (UPat(Ops.VIEW), lambda: True),
 ])
 
-def validate_kernel(k:UOp):
-  assert k.arg.ast.op in {Ops.COPY, Ops.BUFFER_VIEW, Ops.SINK}, f"must end with SINK/COPY/BUFFER_VIEW {k.arg}"
-  if k.arg.ast.op is Ops.SINK: assert all(s.op is Ops.STORE for s in k.arg.ast.src), f"SINK must end with STORE {k.arg.ast}"
-  return True
-
 assign_spec = PatternMatcher([
   # KERNEL can attach to an ASSIGN to describe the compute required to realize a BUFFER
-  (UPat(Ops.KERNEL, src=UPat((Ops.BUFFER, Ops.BUFFER_VIEW, Ops.ASSIGN, Ops.MSELECT, Ops.MSTACK)), name="k"), validate_kernel),
+  (UPat(Ops.KERNEL, src=UPat((Ops.BUFFER, Ops.BUFFER_VIEW, Ops.ASSIGN, Ops.MSELECT, Ops.MSTACK))), lambda: True),
 
   # ASSIGN has a target and a value. It can also optionally depend on other assigns
   (UPat(Ops.ASSIGN, name="x"), lambda x: len(x.src) >= 2 and all(s.op is Ops.ASSIGN for s in x.src[2:])),


### PR DESCRIPTION
These UOp specs should be asserting properties that are fundamental to the UOp's nature. Not how it's currently used.

COPY being inside a KERNEL is a pure implementation detail and there is no fundamental reason for it.
BUFFER_VIEW should not be a KERNEL once subbuffers are first-class.