### PR TITLE
ONNX external_test_onnx_backend use PYTHON device for model

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -30,7 +30,7 @@ class TinygradBackend(Backend):
     input_initializer = [x.name for x in model.graph.initializer]
     net_feed_input = [x for x in input_all if x not in input_initializer]
     print("prepare", cls, device, net_feed_input)
-    model = Tensor(model.SerializeToString(), device="PYTHON") # test
+    model = Tensor(model.SerializeToString(), device="PYTHON")
     run_onnx = OnnxRunner(onnx_load(model))
     return TinygradModel(run_onnx, net_feed_input)
 


### PR DESCRIPTION
I just want to see how much slower this is.
This seems to be one potential fix for the flaky `test/external/external_test_onnx_backend.py` (fixes the os errors I'm having locally 😃 , but is quite a bit slower locally)

another potential fix I might try is manual file management instead of tmpfile