### PR TITLE
use dict to keep track of axes offsets and counts [pr]

### DIFF
--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import itertools, functools, math
 from dataclasses import dataclass
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from typing import Optional, cast, Final, Callable, Sequence
 
 from tinygrad.uop.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, resolve, Variable, sint, graph_rewrite, smax
@@ -68,7 +68,7 @@ class Kernel:
     self.dont_use_locals: bool = False
 
     reduces = [i for i,(s,n) in enumerate(zip(self.full_shape, self.output_shape)) if resolve(s != n)]
-    self.axes = OrderedDict((("global", self.shape_len - len(reduces)), ("local", 0), ("reduce", len(reduces)), ("upcast", 0)))
+    self.axes = {"global": self.shape_len - len(reduces), "local": 0, "reduce": len(reduces), "upcast": 0}
 
     # group simplifies
     self.simplify_ones()


### PR DESCRIPTION
### yellow before red

this is the beginning of the refactor towards yellow before red. This will increase lines in the short term as I'm trying not to early optimize and keep the prs as small and readable as possible. I think this whole refactor will make `kernel.py` more readable and maintainable for the future.

**the challenge**

moving upcast dimensions before reduce dimensions introduces 3 major changes in how axes are organized:

1. upcast are moved before reduce (yellow before red)
2. group and reduce are split
3. upcast and unroll are split

currently, identifying if an axis is global, local, reduce, group or upcast is calculated through offset and counts. `first_reduce` is the base for most calculations in conjunction with `local_dims`(count), `upcasted`(count) and `group_for_reduce`(count) (`first_reduce` is obtained through checking sts for difference).

some examples:
  `global_dims = first_reduce - local_dims`
  `first_local = global_dims`
  `first_upcast = shape_len - upcasted`

I initially tried to stick to current paradigm, but quickly realized that this 3 changes make sticking to the current way of calculating offsets and count verbose, complicated and error-prone.

in order to workaround this issue, I propose this new way of keeping track of axes and their offsets.

``` python
self.axes = {"global": g, "local": l, "reduce": r, "upcast": u}
```

with this new approach, calculating offsets becomes trivial, as it just accumulating over values. 

``` python
self.get_offset(axis_name) # offset
self.axes[axis_name] # count
```

offsets and counts are now exposed through this simpler api, instead of the uneven first_reduce (for reduce and group) / first_upcast (for upcast) / global_dims (for locals), ...

let me know if you like the direction of this refactor

---

after yellow before red, axes will be configured in the following way.

``` python
self.axes = {
  "global": gl, 
  "local": l, 
  "upcast": up,
  "group": gr,
  "reduce": r, 
  "unroll": un,
}
```

---

NOTE: keeping as a draft for now as I didn't identified yet what is breaking pr

---

UPDATE: I just saw group should still be next to reduce; so one of the points is now outdated. I'll evaluate if this refactor still makes sense now as that the splitting of group/reduce was one of the challenges that introduced more changes.

<img width="643" alt="image" src="https://github.com/user-attachments/assets/33ab0879-386c-49d2-8255-bd770240b3a8" />

this introduces a new split between local and group, before, those two were contiguous, now, they have upcast in between



