### PR TITLE
fix process replay diff in PYTHON device [pr]

### DIFF
--- a/test/external/process_replay/process_replay.py
+++ b/test/external/process_replay/process_replay.py
@@ -43,6 +43,7 @@ def replay_kernelize(ret:dict[UOp, UOp], big_sink:UOp) -> tuple[str, str, tuple[
 def replay_get_program(p:ProgramSpec, ast:UOp, renderer:Renderer) -> tuple[str, str, tuple[Any, ...]]:
   p2 = get_program(ast.replace(arg=KernelInfo(opts_to_apply=p.applied_opts, name=p.name)) if ast.arg is None else ast, renderer)
   def to_str(ret:ProgramSpec) -> str:
+    # PYTHON renderer pickles UOps, first unpickle and decode here
     if p.device.startswith("PYTHON"): return "\n".join([str(x) for x in pickle.loads(base64.b64decode(ret.src))])
     return ret.src
   return to_str(p2), to_str(p), (p.ast, renderer, p.applied_opts)


### PR DESCRIPTION
The PYTHON backend pickles and encodes UOps, the encoded binary can't be directly diffed in process replay.
It first has to decode and unpickle the renderer output.

![image](https://github.com/user-attachments/assets/6e23c28b-3fb6-4f5c-8e1f-acaa99afaf3b)

Currently output of `base64.b64encode(pickle.dumps(lops)).decode()` is not deterministic. 