### PR TITLE
hotfix: disable process replay in REMOTE=1 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -510,7 +510,7 @@ jobs:
         run: CPU=1 PYTHONPATH=. python3 test/test_quantize_onnx.py
       - name: Run REMOTE=1 Test (without process replay)
         run: |
-          # TODO: fix this, remote schedule opens devices
+          # TODO: re enable process replay, currently remote schedule opens devices
           CAPTURE_PROCESS_REPLAY=0 REMOTEDEV=CPU REMOTE=1 python3 -m pytest test/test_tiny.py test/test_jit.py test/test_multitensor.py
       - name: Run process replay tests
         uses: ./.github/actions/process-replay


### PR DESCRIPTION
https://github.com/tinygrad/tinygrad/pull/11177 opens devices in graph_rewrite. This isn't actually allowed in the rest of tinygrad. The Device.group_id thing looks like some global state, can it be factored out to a context in graph_rewrite (or as mentioned [here](https://github.com/tinygrad/tinygrad/pull/11310#issuecomment-3102103848), containing state in the DEVICE UOp)? Like how lowerer handles these.