### PR TITLE
Implement "TODO: test_scheduler, but just in uint" in unit/test_attention.py

### DIFF
--- a/test/unit/test_attention.py
+++ b/test/unit/test_attention.py
@@ -9,7 +9,6 @@ class TestAttention(unittest.TestCase):
     attn = q.scaled_dot_product_attention(k, v)
     sched = attn.schedule()
     return attn, sched
-    
   def test_half_qkv_buffers(self):
     _, sched = self._get_attn_and_scheduler()
     # attention has 5 kernels now
@@ -17,15 +16,12 @@ class TestAttention(unittest.TestCase):
     softmax_inputs = sched[1:4]
     for si in softmax_inputs:
       assert all(b.dtype == dtypes.half for b in si.bufs), f"non half {si.bufs=}"
-
   def test_uint_qkv_buffers(self):
     _, sched = self._get_attn_and_scheduler(dtype=dtypes.uint)
     # attention has 6 kernels now
     self.assertEqual(len(sched), 6)
-
     qkv_uint_scheds = [si for si in sched if all(b.dtype == dtypes.uint for b in si.bufs)]
     assert len(qkv_uint_scheds) >= 1, f"no uint found in scheduler buffers {sched[0].bufs=} "
-
     found_cast_uint_to_float = any(
         any(b.dtype == dtypes.uint for b in si.bufs) and any(b.dtype == dtypes.float for b in si.bufs)
         for si in sched


### PR DESCRIPTION
This code uses assertions on lengths instead of direct indices to ensure less fragile tests.
If you prefer, I can use direct indices since the pure uint buffer exists at the 0th index.

Here is some example data of the ‘bufs’: [[dtypes.uint, dtypes.uint, dtypes.uint], [dtypes.float, dtypes.uint], [dtypes.uint, dtypes.uint], [dtypes.float, dtypes.uint, dtypes.uint], [dtypes.float, dtypes.uint, dtypes.uint, dtypes.float], [dtypes.float, dtypes.float, dtypes.float]].

I also created the method `_get_attn_and_scheduler` to avoid breaking DRY principles, as with my addition some code can be refactored to a single method.

Thanks for looking at this!
