### PR TITLE
fix serve uncontrolled data used in path expression

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -225,9 +225,14 @@ class Handler(BaseHTTPRequestHandler):
       with open(os.path.join(os.path.dirname(__file__), "index.html"), "rb") as f: ret = f.read()
     elif self.path.startswith(("/assets/", "/js/")) and '/..' not in self.path:
       try:
-        with open(os.path.join(os.path.dirname(__file__), self.path.strip('/')), "rb") as f: ret = f.read()
-        if url.path.endswith(".js"): content_type = "application/javascript"
-        if url.path.endswith(".css"): content_type = "text/css"
+        static_dir = os.path.abspath(os.path.dirname(__file__))
+        requested_path = os.path.normpath(os.path.join(static_dir, self.path.lstrip('/')))
+        if not requested_path.startswith(static_dir + os.sep):
+          status_code = 403
+        else:
+          with open(requested_path, "rb") as f: ret = f.read()
+          if url.path.endswith(".js"): content_type = "application/javascript"
+          if url.path.endswith(".css"): content_type = "text/css"
       except FileNotFoundError: status_code = 404
     elif (query:=parse_qs(url.query)):
       if url.path == "/disasm": ret, content_type = get_disassembly(**query), "application/json"


### PR DESCRIPTION
https://github.com/tinygrad/tinygrad/blob/8ff03806e81970cf589c0aa3f3f9e90254caefa7/tinygrad/viz/serve.py#L228-L230

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix the problem, we need to ensure that the file path constructed from user input cannot escape the intended static directory. The best way to do this is to:

1. Normalize the constructed path using `os.path.normpath` to resolve any `..` or redundant separators.
2. Ensure that the normalized path is still within the intended static directory (i.e., it starts with the static directory's absolute path).
3. Optionally, reject any absolute paths or paths containing suspicious characters before normalization.

In this case, the static files are served from the same directory as the script (`os.path.dirname(__file__)`). We should:
- Join the static directory with the user-supplied path (after stripping the leading slash).
- Normalize the resulting path.
- Check that the normalized path starts with the static directory's absolute path.
- Only then open the file.

This change should be made in the `Handler.do_GET` method, specifically in the block starting at line 228.

[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)