### PR TITLE
viz: make SINK node grey

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -18,8 +18,8 @@ uops_colors = {Ops.LOAD: "#ffc0c0", Ops.STORE: "#87CEEB", Ops.CONST: "#e0e0e0", 
                Ops.INDEX: "#e8ffa0", Ops.WMMA: "#efefc0", Ops.VIEW: "#C8F9D4", Ops.MULTI: "#f6ccff", Ops.KERNEL: "#3e7f55",
                **{x:"#D8F9E4" for x in GroupOp.Movement}, **{x:"#ffffc0" for x in GroupOp.ALU}, Ops.THREEFRY:"#ffff80", Ops.BUFFER_VIEW: "#E5EAFF",
                Ops.BLOCK: "#C4A484", Ops.BLOCKEND: "#C4A4A4", Ops.BUFFER: "#B0BDFF", Ops.COPY: "#a040a0", Ops.FUSE: "#FFa500",
-               Ops.ALLREDUCE: "#ff40a0", Ops.MSELECT: "#d040a0", Ops.MSTACK: "#d040a0", Ops.CONTIGUOUS: "#FFC14D", Ops.SINK: "#cccccc",
-               Ops.CHILD: "#80fff0"}
+               Ops.ALLREDUCE: "#ff40a0", Ops.MSELECT: "#d040a0", Ops.MSTACK: "#d040a0", Ops.CONTIGUOUS: "#FFC14D",
+               Ops.CHILD: "#80fff0", Ops.SINK: "#cccccc"}
 
 # VIZ API
 


### PR DESCRIPTION
Kernel LOOP axes are coloured white, which is invisible on a white SINK node.
Before:
<img width="1814" height="1047" alt="Screenshot From 2025-08-06 13-46-09" src="https://github.com/user-attachments/assets/7a0ceab9-de41-40bc-b2cb-0247f84b44b1" />
After:
<img width="1814" height="1047" alt="Screenshot From 2025-08-06 13-46-54" src="https://github.com/user-attachments/assets/ef64f5b9-1e89-493d-8ea9-f9d20779306b" />
After (real kernel):
<img width="1783" height="630" alt="Screenshot From 2025-08-06 13-49-38" src="https://github.com/user-attachments/assets/9005a776-1e29-41cf-b968-4c505e79e6f1" />
I'm aware that this is a nitpick, but it just looked a bit unpolished imo

