### PR TITLE
viz: pick the largest rect for proxy fillColor

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -203,8 +203,9 @@ async function renderProfiler() {
         for (let jlod = lodIdx - 1; jlod >= 0; jlod--) {
           const ix = Math.floor((e.st-st) / timelineLODThresholds[jlod + 1]);
           const iy = offsetY+levelHeight*e.depth;
-          ((((tempProxiesBuilder[i] ??= {})[jlod]) ??= {})[ix] ??= {})[iy] ??= { x: e.st-st, y: iy, h: levelHeight, pct: 0, fillColor };
-          tempProxiesBuilder[i][jlod][ix][iy].pct += e.dur / timelineLODThresholds[jlod + 1];
+          const proxy = ((((tempProxiesBuilder[i] ??= {})[jlod]) ??= {})[ix] ??= {})[iy] ??= { x: e.st-st, y: iy, h: levelHeight, pct: 0, fillColor, fillVal:e.dur };
+          proxy.pct += e.dur / timelineLODThresholds[jlod + 1];
+          if (e.dur > proxy.fillVal) proxy.fillColor = fillColor; proxy.fillVal = e.dur;
         }
       }
     }


### PR DESCRIPTION
I think it's a more consistent experience, currently master picks the first color:
<img width="5120" height="642" alt="image" src="https://github.com/user-attachments/assets/aba4e405-dd4a-4f17-9f6c-9c20bc023416" />
suggesting the Compiler is dominant, but actually it's get_program when you zoom in.

This diff's view for the same profile trace:
<img width="5120" height="642" alt="image" src="https://github.com/user-attachments/assets/52575275-a4fb-4532-9615-8a1411af7e6c" />

Overhead looks pretty minimal, test on llama train:
<img width="5120" height="346" alt="image" src="https://github.com/user-attachments/assets/39566d74-cd00-4b20-8630-d45551f5d6e6" />
