### PR TITLE
exclude .git from ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -35,6 +35,7 @@ lint.select = [
 line-length = 150
 
 exclude = [
+  ".git/",
   "docs/",
   "extra/",
   "tinygrad/runtime/autogen",


### PR DESCRIPTION
ruff shouldn't look at .git
<img width="1032" height="156" alt="image" src="https://github.com/user-attachments/assets/4998f0f5-3930-4080-9198-062fd21c3a3c" />

repro by having any file in .git with an unfortunately named extension e.g. `.git/logs/refs/remotes/origin/TYPED-equals-1-working-in-tensor.py` and ruff tries to lint it.
