### PR TITLE
viz: sum all buffers in zoomed out memory graph

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -137,7 +137,7 @@ const formatUnit = (d, unit="") => d3.format(".3~s")(d)+unit;
 
 const colorScheme = {TINY:["#1b5745", "#354f52", "#354f52", "#1d2e62", "#63b0cd"],
   DEFAULT:["#2b2e39", "#2c2f3a", "#31343f", "#323544", "#2d303a", "#2e313c", "#343746", "#353847", "#3c4050", "#404459", "#444862", "#4a4e65"],
-  BUFFER:["#3A57B7","#5066C1","#6277CD","#7488D8","#8A9BE3","#A3B4F2"],
+  BUFFER:["#342483", "#3E2E94", "#4938A4", "#5442B4", "#5E4CC2", "#674FCA"],
   CATEGORICAL:["#ff8080", "#F4A261", "#C8F9D4", "#8D99AE", "#F4A261", "#ffffa2", "#ffffc0", "#87CEEB"],}
 const cycleColors = (lst, i) => lst[i%lst.length];
 
@@ -289,7 +289,7 @@ async function renderProfiler() {
           }
         }
       }
-      const sum = {x:[], y0:[], y1:[], fillColor:"#2F4AA8"};
+      const sum = {x:[], y0:[], y1:[], fillColor:"#2B1B72"};
       for (let i=0; i<allX.length-1; i++) {
         sum.x.push(allX[i], allX[i+1]);
         const y = maxY.get(allX[i]); sum.y1.push(y, y); sum.y0.push(base0, base0);


### PR DESCRIPTION
The memory graph is the main bottleneck in a lot of the large VIZ profiler traces because it's trying to draw every single allocation, and whenever there is a dellocation, every alive Buffer's graph has to update its path geometry.
This diff switches the zoomed out memory graph to a single path for total memory usage, which is what we want most of the time. It is still possible to view the per-buffer detailed view and it's one click away.

Default:
<img width="2496" height="646" alt="image" src="https://github.com/user-attachments/assets/b28c0c80-5c1a-403e-9bba-52d71fc13a87" />
Per buffer details toggles by clicking on "METAL Memory"
<img width="2496" height="1186" alt="image" src="https://github.com/user-attachments/assets/ed0a2fe0-b42a-497c-bce5-2de918c34b7a" />

This is faster because fundamentally we're just drawing one `sum(nbytes_allocated)` path, instead of N paths * N alloc/dealloc event path changes.