### PR TITLE
multi device and copy tracing for NULL device

### DIFF
--- a/tinygrad/runtime/ops_null.py
+++ b/tinygrad/runtime/ops_null.py
@@ -21,11 +21,13 @@ class NullAllocator(Allocator['NullDevice']):
   def _alloc(self, size, options): pass
   def _copyin(self, dest, src:memoryview): pass
   def _copyout(self, dest:memoryview, src): pass
-  def _transfer(self, dest, src, sz:int, src_dev, dest_dev): pass
+  def _transfer(self, dest, src, sz:int, src_dev, dest_dev):
+    with cpu_profile(f"{src_dev.device} -> {dest_dev.device}", self.dev.device): pass
   def _offset(self, buf, offset:int, size:int): pass
 
 class NullGraph(MultiGraphRunner):
   def __call__(self, input_rawbuffers, var_vals, wait=False) -> float|None: return 1e-3
 
 class NullDevice(Compiled):
-  def __init__(self, device:str): super().__init__(device, NullAllocator(self), NullRenderer(), Compiler(), functools.partial(NullProgram, device), NullGraph)
+  def __init__(self, device:str): super().__init__(device, NullAllocator(self), NullRenderer(), Compiler(), functools.partial(NullProgram, device),
+                                                   NullGraph)


### PR DESCRIPTION
This allows for grouping events in the timeline:
`DP=4 DEBUG=2 VIZ=1 NULL=1 SAMPLES=100 FAKEDATA=1 NULL=1 BS=16 DEFAULT_FLOAT=bfloat16 OPTIM_DTYPE=bfloat16 LLAMA3_SIZE=8B SEQLEN=8192 PYTHONPATH=. MODEL=llama3 python3 examples/mlperf/model_train.py`
<img width="2560" height="875" alt="image" src="https://github.com/user-attachments/assets/171f82ed-e3f9-45f8-8dbf-a625541999f4" />