### PR TITLE
merge TestIndexing with TestSchedule + remove duplicate tests

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -14,7 +14,7 @@ from tinygrad.dtype import DType, ImageDType
 from tinygrad.shape.shapetracker import ShapeTracker
 from tinygrad.uop.ops import PatternMatcher, UOp, Ops, GroupOp, UPat, graph_rewrite, track_rewrites
 from tinygrad.uop.symbolic import symbolic_simple
-from tinygrad.helpers import CI, DEBUG, FUSE_ARANGE, SPLIT_REDUCEOP, GlobalCounters, Context, getenv, all_same, temp
+from tinygrad.helpers import CI, DEBUG, SPLIT_REDUCEOP, GlobalCounters, Context, getenv, all_same, temp
 from tinygrad.schedule.kernelize import merge_views, get_kernelize_map, Kernel
 from tinygrad.engine.schedule import create_schedule_with_vars
 from tinygrad.engine.realize import CompiledRunner, run_schedule, lower_schedule


### PR DESCRIPTION
FUSE_ARANGE=1 is default now, so we don't need that complex setUp in the test class.
There were tests that duplicated the same behavior, this diff also gets rid of those.

- test_argmin_multireduce_fusion / argmax -> TestSchedule.test_argmin / test_argmax exist.
- `test_arange_childless_*`,  `test_arange_shrink*` -> these are just normal TestOps.test_arange.
- test_dont_fold_arange_contiguous_view -> Tests user contiguous, not arange.