### PR TITLE
viz: format tuple tags

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -44,7 +44,7 @@ function intersectRect(r1, r2) {
 
 function addTags(root) {
   root.selectAll("circle").data(d => [d]).join("circle").attr("r", 5);
-  root.selectAll("text").data(d => [d]).join("text").text(d => Array.isArray(d) ? `(${d})` : d).attr("dy", "0.35em");
+  root.selectAll("text").data(d => [d]).join("text").text(d => d).attr("dy", "0.35em");
 }
 
 let [workerUrl, worker] = [null, null];

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -90,7 +90,7 @@ def uop_to_json(x:UOp) -> dict[int, dict]:
     # NOTE: kernel already has metadata in arg
     if TRACEMETA >= 2 and u.metadata is not None and u.op is not Ops.KERNEL: label += "\n"+repr(u.metadata)
     graph[id(u)] = {"label":label, "src":[(i,id(x)) for i,x in enumerate(u.src) if x not in excluded], "color":uops_colors.get(u.op, "#ffffff"),
-                    "ref":ref, "tag":u.tag}
+                    "ref":ref, "tag":repr(u.tag) if u.tag is not None else None}
   return graph
 
 @functools.cache


### PR DESCRIPTION
By default [1].toString() produces the same representation as 1.toString() in JavaScript, so a tuple tag is indistinguishable.


Tested with `RANGIFY=1 VIZ=1 python test/test_schedule.py TestIndexing.test_assign_non_contiguous_alt` on https://github.com/tinygrad/tinygrad/pull/12110/commits/e80b726cad293a4d7fc17112bb5269924ae83462
<img width="3024" height="1710" alt="image" src="https://github.com/user-attachments/assets/7ee22f45-257e-4e88-9bb8-5de0a3d2a952" />
