### PR TITLE
cpu: add disassembler err message

### DIFF
--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -326,7 +326,7 @@ def cpu_objdump(lib, objdump_tool='objdump'):
 
 def capstone_flatdump(lib: bytes):
   try: import capstone
-  except ImportError as e:
+  except ImportError:
     print("Disassembler Error: Capstone not installed.")
     return
   match platform.machine():


### PR DESCRIPTION
If you pip uninstall capstone, running `CPU=1 DEBUG=7 python test/test_ops.py TestOps.test_9_gemm` throws an error.
Since VIZ just captures the stdout of disassembler this works:
<img width="2556" height="973" alt="image" src="https://github.com/user-attachments/assets/3cff8f06-ff4e-40ae-8c5b-c8bcfe0b3356" />
