### PR TITLE
viz: fix Specificity for rect styling

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -102,10 +102,10 @@
     fill: none;
     stroke-width: 1.4px;
   }
-  .highlight rect, .edgePath.highlight, g.port circle {
+  g.node.highlight rect, .edgePath.highlight, g.port circle {
     stroke: #89C9A2;
   }
-  .highlight.child rect, .edgePath.highlight.child {
+  g.highlight.child rect, .edgePath.highlight.child {
     stroke: #C888B0;
   }
   #edge-labels g.port.highlight {


### PR DESCRIPTION
master vs branch


<img width="320" height="139" alt="image" src="https://github.com/user-attachments/assets/4c912c20-5c06-422b-adf9-cf4f38314199" />
<img width="325" height="147" alt="image" src="https://github.com/user-attachments/assets/c85757be-99d4-48c3-b658-7e9db1ee7df9" />

