### PR TITLE
reenable test_backward_sum_acc_dtype

### DIFF
--- a/test/unit/test_dtype_spec.py
+++ b/test/unit/test_dtype_spec.py
@@ -593,7 +593,6 @@ class TestAutoCastType(unittest.TestCase):
 
     dtypes.default_float = old_default_float
 
-  @unittest.skipIf(CI, "TODO: broken RuntimeError: Attempting to relocate against an undefined symbol 'fmaxf'")
   @unittest.skipUnless(is_dtype_supported(dtypes.half), "need half")
   def test_backward_sum_acc_dtype(self):
     # test acc of sum in the backward is upcasted to float


### PR DESCRIPTION
this fails with `RANGEIFY=1`