### PR TITLE
allow less kernels in external_test_opt

### DIFF
--- a/test/external/external_test_opt.py
+++ b/test/external/external_test_opt.py
@@ -106,7 +106,7 @@ class TestOptBinOp(unittest.TestCase):
   def test_no_binop_rerun(self): return self._test_no_binop_rerun(lambda a,b: a*b, lambda a,b: (a*b).reshape(16, 16, 1))
   def test_no_binop_rerun_alt(self): return self._test_no_binop_rerun(lambda a,b: (a*b).reshape(16, 16, 1), lambda a,b: a*b)
   def test_no_binop_rerun_reduce_broadcast(self):
-    return self._test_no_binop_rerun(lambda a,b: a.sum()+b, lambda a,b: a.sum().reshape(1,1)+b, allowed=1 if RANGEIFY else 2)
+    return self._test_no_binop_rerun(lambda a,b: a.sum()+b, lambda a,b: a.sum().reshape(1,1)+b, allowed=2)
 
   @unittest.skip("this test started failing with the new change, based movementop issue")
   def test_no_binop_rerun_transposed(self): return self._test_no_binop_rerun(lambda a,b: (a.T*b.T).T, lambda a,b: a*b)


### PR DESCRIPTION
rangeify also doesn't fuse TestOptBinOp.test_no_binop_rerun_reduce_broadcast anymore.
`~/code/tinygrad ((HEAD detached at 0dad6cc51)) > VIZ=1 CL=1 PYTHONPATH=. RANGEIFY=1 python test/external/external_test_opt.py TestOptBinOp.test_no_binop_rerun_reduce_broadcast` is 1 kernel, in master it's 2:
<img width="3840" height="1350" alt="image" src="https://github.com/user-attachments/assets/db9f3b5b-560f-4cf2-a102-9bdafccfced3" />
