### PR TITLE
fix limit_bufs with kernelize

### DIFF
--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -496,7 +496,7 @@ def limit_bufs(ctx:RangeifyContext, root:UOp):
   bufs: set[UOp] = set()
   def gate_input(u:UOp):
     # TODO: add cache to fix n^2
-    if is_load:=(u.op in {Ops.BUFFERIZE, Ops.BUFFER, Ops.MSELECT, Ops.MSTACK, Ops.DEFINE_VAR}): bufs.add(u)
+    if is_load:=(u.op in {Ops.BUFFERIZE, Ops.ASSIGN, Ops.BUFFER, Ops.MSELECT, Ops.MSTACK, Ops.DEFINE_VAR}): bufs.add(u)
     return not is_load
   root.toposort(gate=gate_input)
 


### PR DESCRIPTION
It should stop recursing when there's an ASSIGN in the graph:
<img width="3814" height="1982" alt="image" src="https://github.com/user-attachments/assets/c60bfbb6-0ef7-419b-851c-3a37bfebee1c" />
Since kernelized assigns don't get rebufferized.
