### PR TITLE
Increase stack size limit in unified_rewrite

### DIFF
--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1017,7 +1017,7 @@ class RewriteContext:
     stack: collections.deque[tuple[UOp, int, UOp]] = collections.deque([(root, 0, root)])
     on_stack = {root}  # all UOps either on the stack or in self.replace, i.e. dont have to be placed again
     while stack:
-      if len(stack) >= 250000: raise RuntimeError("infinite loop in graph_rewrite (stack too big)")
+      if len(stack) >= 250001: raise RuntimeError("infinite loop in graph_rewrite (stack too big)")
       n, stage, new_n = stack.pop()
       if n in self.replace: continue  # skip any nodes we have seen
       try:


### PR DESCRIPTION
[Stable Diffusion training](https://github.com/tinygrad/tinygrad/pull/12315) reaches `len(stack)` of 203717, above the current limit of 200000, which triggers `RuntimeError("infinite loop in graph_rewrite (stack too big)")`. This PR bumps the limit up to 250000 for additional headroom.

The below PR introduced the change that causes SD training rewrite stack size to surpass 200000: https://github.com/tinygrad/tinygrad/pull/12320/files