### PR TITLE
faster backward_slice

### DIFF
--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -123,8 +123,8 @@ class UOp(MathTrait, metaclass=UOpMetaClass):
 
   @functools.cached_property
   def backward_slice(self:UOp) -> dict[UOp, None]:
-    res: dict[UOp, None] = {}
-    for x in self.src: res.update(x.toposort())
+    res: dict[UOp, None] = self.toposort()
+    res.pop(self)
     return res
 
   @property


### PR DESCRIPTION
the original `backward_slice` is n^2, since update copies all nodes. now it's o(n) for n results

it's a bit faster on a tinybox
old:
```
    0 58678.92 ms run, 58670.55 ms python,   0.46 ms fetch data,    7.92 ms NULL * 6,  0.00 loss, 0.000000 LR, 5.67 GB used,    338.83 GFLOPS
    1 44547.80 ms run, 44539.09 ms python,   0.49 ms fetch data,    8.22 ms NULL * 6,  0.00 loss, 0.000000 LR, 21.39 GB used,    446.35 GFLOPS
```
new:
```
    0 55795.72 ms run, 55780.02 ms python,   0.44 ms fetch data,   15.25 ms NULL * 6,  0.00 loss, 0.000000 LR, 5.67 GB used,    356.34 GFLOPS
    1 47333.38 ms run, 47317.28 ms python,   0.49 ms fetch data,   15.61 ms NULL * 6,  0.00 loss, 0.000000 LR, 21.39 GB used,    420.08 GFLOPS
```

and a bit slower on mac
old:
```
    0 21696.26 ms run, 21692.57 ms python,   0.16 ms fetch data,    3.53 ms NULL * 6,  0.00 loss, 0.000000 LR, 5.67 GB used,    916.39 GFLOPS
    1 18123.12 ms run, 18118.52 ms python,   0.18 ms fetch data,    4.43 ms NULL * 6,  0.00 loss, 0.000000 LR, 21.39 GB used,   1097.15 GFLOPS
```
new:
```
    0 23980.29 ms run, 23973.06 ms python,   0.16 ms fetch data,    7.07 ms NULL * 6,  0.00 loss, 0.000000 LR, 5.67 GB used,    829.11 GFLOPS
    1 20220.18 ms run, 20212.58 ms python,   0.19 ms fetch data,    7.42 ms NULL * 6,  0.00 loss, 0.000000 LR, 21.39 GB used,    983.36 GFLOPS
```
