### PR TITLE
remove UPat.__repr__ [pr]

### DIFF
--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -773,13 +773,6 @@ class UPat(MathTrait):
     asrc = (self,)+src
     return UPat(op, dtypes.bool if op in {Ops.CMPLT, Ops.CMPNE} else asrc[-1].dtype, list(asrc) if op in GroupOp.Commutative else asrc)
 
-  def __repr__(self):
-    def rep(x):
-      form = "UPat(%s, %s, name=%s, dtype=%s, allow_any_len=%s, src=%s)"
-      return form % (None if x.op is None else ('(%s)'%', '.join(map(str, x.op))), x.arg, repr(x.name),
-        set(x.dtype) if x.dtype else None, not x.strict_length, "[%s]" if x.src and len(x.src)>1 else ("(%s)" if x.src else "%s"))
-    return pretty_print(self, rep, srcfn=lambda x:None if x.src is None else [next(x.src[0])] if isinstance(x.src[0], itertools.repeat) else x.src[0])
-
   def match(self:UPat, uop:UOp, store:dict[str, UOp]) -> list[dict[str, UOp]]:
     if (self.op is not None and uop.op not in self.op) or \
        (self.name is not None and store.setdefault(self.name, uop) is not uop) or \


### PR DESCRIPTION
It's not used anywhere and it's kind of unusable in the current state anyways. For example:
```
>>> from tinygrad.uop.symbolic import sym
... print(sym.patterns[0])
...
(UPat((Ops.IDIV), None, name='alu', dtype=None, allow_any_len=False, src=(
  UPat((Ops.WHERE), None, name=None, dtype=None, allow_any_len=False, src=(
    UPat(None, None, name='cond', dtype=None, allow_any_len=True, src=None),
    UPat(None, None, name='x', dtype=None, allow_any_len=True, src=None),
    UPat((Ops.CONST), Invalid, name='i', dtype=None, allow_any_len=True, src=None),)),
  UPat(None, None, name='y', dtype=None, allow_any_len=True, src=None),)), <function <genexpr>.<lambda> at 0x10236a840>)
  ```
  viz and match_stats tooling get the source code lines:
  ```
  >>> from tinygrad.uop.symbolic import sym
... from tinygrad.uop.ops import printable
... print(printable(sym.patterns[0][0].location))
...
*((invalid_gate.alu(op, UPat.var("y")).named("alu"), lambda cond,x,y,alu,i: cond.where(x.alu(alu.op,y), i))
```