### PR TITLE
uop: rewrite sqrt(f16|bf16) via f32; drop OpenCL override

### DIFF
--- a/test/test_uop_graph.py
+++ b/test/test_uop_graph.py
@@ -21,20 +21,25 @@ def to_uops_list(u:List[UOp]) -> List[UOp]:
   assert ret[-1].op is Ops.SINK
   return ret[:-1]
 
-def test_sqrt_cast_f16_bf16_to_f32():
-  from tinygrad.uop.decompositions import get_late_rewrite_patterns
-  pm = get_late_rewrite_patterns((Ops.SQRT,))
-  def rew(dt):
-    x = UOp(Ops.DEFINE_VAR, dt)
-    return graph_rewrite(UOp(Ops.SQRT, dt, (x,)), pm)
-  for dt in (dtypes.float16, dtypes.bfloat16):
-    r = rew(dt)
-    assert r.op is Ops.CAST and r.dtype == dt
-    s = r.src[0]
-    assert s.op is Ops.SQRT and s.dtype is dtypes.float32
-    assert s.src[0].op is Ops.CAST and s.src[0].dtype is dtypes.float32
-  r = rew(dtypes.float32)
-  assert r.op is Ops.SQRT and r.dtype is dtypes.float32
+class TestDecompositions(unittest.TestCase):
+  def test_sqrt_cast_f16_bf16_to_f32(self):
+    from tinygrad.uop.decompositions import get_late_rewrite_patterns
+    pm = get_late_rewrite_patterns((Ops.SQRT,))
+    def rew(dt):
+      x = UOp(Ops.DEFINE_VAR, dt)
+      return graph_rewrite(UOp(Ops.SQRT, dt, (x,)), pm)
+    for dt in (dtypes.float16, dtypes.bfloat16):
+      r = rew(dt)
+      self.assertIs(r.op, Ops.CAST)
+      self.assertIs(r.dtype, dt)
+      s = r.src[0]
+      self.assertIs(s.op, Ops.SQRT)
+      self.assertIs(s.dtype, dtypes.float32)
+      self.assertIs(s.src[0].op, Ops.CAST)
+      self.assertIs(s.src[0].dtype, dtypes.float32)
+    r = rew(dtypes.float32)
+    self.assertIs(r.op, Ops.SQRT)
+    self.assertIs(r.dtype, dtypes.float32)
 
 class TestGraphRewriteConst(unittest.TestCase):
   def test_gep_const(self):

--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -259,7 +259,6 @@ class OpenCLRenderer(CStyleLanguage):
   type_map = { dtypes.int8: "char", dtypes.uint8: "uchar", dtypes.uint32: "uint", dtypes.uint16: "ushort", dtypes.uint64: "ulong",
               dtypes.bfloat16: "ushort" }
 
-  code_for_op = {**CStyleLanguage.code_for_op}
   string_rewrite = PatternMatcher([
     (UPat(Ops.BITCAST, name="x"), lambda ctx,x: f"as_{ctx.render_dtype(x.dtype)}({ctx[x.src[0]]})"),
     # load/store image (OpenCL)


### PR DESCRIPTION
Moves sqrt promotion for half/bfloat16 into UOps decompositions.

For f16/bf16: rewrites to cast→sqrt(f32)→cast
For f32: unchanged

Removes OpenCL code_for_op override so all renderers inherit the IR behavior.
Adds test_sqrt_cast_f16_bf16_to_f32 asserting the UOp pattern.

Fixes ambiguous sqrt calls on OpenCL devices without cl_khr_fp16.

Fixes #12237, #11183.