### PR TITLE
viz: switch llvm mca info to tabulate

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -315,15 +315,6 @@
     font-size: 0.95em;
     letter-spacing: 0.03em;
   }
-  .legend {
-    display: flex;
-    align-items: center;
-  }
-  .legend > div {
-    width: 0.95em;
-    height: 0.95em;
-    margin-right: 4px;
-  }
   </style>
 </head>
 <body>

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -165,8 +165,8 @@ const drawLine = (ctx, x, y, opts) => {
 }
 
 function tabulate(rows) {
-  const root = d3.create("div").style("display", "grid").style("grid-template-columns", `${Math.max(...rows.map(x => x[0].length), 0)}ch 1fr`);
-  for (const [k,v] of rows) { root.append("div").text(k); root.append("div").text(v); }
+  const root = d3.create("div").style("display", "grid").style("grid-template-columns", `${Math.max(...rows.map(x => x[0].length), 0)}ch 1fr`).style("gap", "0.2em");
+  for (const [k,v] of rows) { root.append("div").text(k); root.append("div").node().append(v); }
   return root;
 }
 
@@ -654,17 +654,10 @@ async function main() {
           }
         }
       }
-      const summary = metadata.appendChild(document.createElement("table"));
-      for (const s of ret.summary) {
-        const tr = summary.appendChild(document.createElement("tr"));
-        tr.className = "main-row";
-        const td = tr.appendChild(document.createElement("td"));
-        const div = td.appendChild(document.createElement("div"));
-        div.className = "legend";
-        div.appendChild(document.createElement("div")).style.background = cycleColors(colorScheme.CATEGORICAL, s.idx);
-        div.appendChild(document.createElement("p")).textContent = s.label;
-        appendTd(tr, s.value);
-      }
+      metadata.appendChild(tabulate(ret.summary.map(s => {
+        const div = d3.create("div").style("background", cycleColors(colorScheme.CATEGORICAL, s.idx)).style("width", "24px").style("height", "100%");
+        return [s.label.trim(), div.node()];
+      })).node());
     } else root.appendChild(codeBlock(ret.src, "x86asm"));
     return document.querySelector(".disasm").replaceChildren(root);
   }

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -206,7 +206,7 @@ def get_llvm_mca(asm:str, mtriple:str, mcpu:str) -> dict:
   # disassembly output can include headers / metadata, skip if llvm-mca can't parse those lines
   data = json.loads(subprocess.check_output(["llvm-mca","-skip-unsupported-instructions=parse-failure","--json","-"]+target_args, input=asm.encode()))
   cr = data["CodeRegions"][0]
-  resource_labels = data["TargetInfo"]["Resources"]
+  resource_labels = [repr(x)[1:-1] for x in data["TargetInfo"]["Resources"]]
   rows:list = [[instr] for instr in cr["Instructions"]]
   # add scheduler estimates
   for info in cr["InstructionInfoView"]["InstructionList"]: rows[info["Instruction"]].append(info["Latency"])


### PR DESCRIPTION
On the mac they add these hidden characters for the hw unit names:
<img width="3840" height="822" alt="image" src="https://github.com/user-attachments/assets/8cb057aa-3307-4dce-b592-1e0653c05496" />
we'll render the literal representation. The terminal printout makes them look the same:
<img width="3840" height="822" alt="image" src="https://github.com/user-attachments/assets/7ee4a638-354a-49bc-a1fb-d48af939e2a3" />
This can share the UI stuff with the buffer/DEBUG=2 stats.