### PR TITLE
viz: update ansi regex

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -16,7 +16,7 @@ const darkenHex = (h, p = 0) =>
 const ANSI_COLORS = ["#b3b3b3", "#ff6666", "#66b366", "#ffff66", "#6666ff", "#ff66ff", "#66ffff", "#ffffff"];
 const ANSI_COLORS_LIGHT = ["#d9d9d9","#ff9999","#99cc99","#ffff99","#9999ff","#ff99ff","#ccffff","#ffffff"];
 const parseColors = (name, defaultColor="#ffffff") => Array.from(name.matchAll(/(?:\u001b\[(\d+)m([\s\S]*?)\u001b\[0m)|([^\u001b]+)/g),
-  ([_, code, colored_st, st]) => ({ st: colored_st ?? st, color: code != null ? (parseInt(code) >= 90 ? ANSI_COLORS_LIGHT : ANSI_COLORS)[(parseInt(code)-30+60)%60] : defaultColor }));
+  ([_, code, colored_st, st]) => ({ st: colored_st ?? st, color: code != null ? (code>=90 ? ANSI_COLORS_LIGHT : ANSI_COLORS)[(parseInt(code)-30+60)%60] : defaultColor }));
 
 const rect = (s) => (typeof s === "string" ? document.querySelector(s) : s).getBoundingClientRect();
 


### PR DESCRIPTION
It's in ANSI_COLORS_LIGHT so we can change them easier.
Looks like this in VIZ:
<img width="1744" height="72" alt="image" src="https://github.com/user-attachments/assets/965437fc-5d45-40a4-abc5-00e81433edb2" />
On terminal it's:
<img width="1082" height="36" alt="image" src="https://github.com/user-attachments/assets/41557ce7-83db-4710-8747-6c4ee15ba1d3" />

I think LOCAL and WARP are pretty readable in VIZ now.