### PR TITLE
viz: add View Program option

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -142,7 +142,7 @@
     inset: 0;
     z-index: 1;
   }
-  .profiler, .disasm {
+  .profiler, .render {
     flex: 1 1 auto;
     min-width: 0;
     width: 100%;
@@ -332,7 +332,7 @@
     <div id="progress-message"></div>
     <div class="container ctx-list-parent"><div class="ctx-list"></div></div>
     <div class="view profiler"></div>
-    <div class="view disasm"></div>
+    <div class="view render"></div>
     <div class="view graph">
       <svg id="graph-svg" preserveAspectRatio="xMidYMid meet">
         <g id="render">

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -630,9 +630,9 @@ async function main() {
     ret = cache[ckey];
   }
   // ** Disassembly view
-  if (ckey.startsWith("/disasm")) {
+  if (ckey.startsWith("/render")) {
     if (!(ckey in cache)) cache[ckey] = ret = await (await fetch(ckey)).json();
-    displayGraph("disasm");
+    displayGraph("render");
     const root = document.createElement("div");
     root.className = "raw-text";
     const metadata = document.querySelector(".metadata");
@@ -666,8 +666,8 @@ async function main() {
         const div = d3.create("div").style("background", cycleColors(colorScheme.CATEGORICAL, s.idx)).style("width", "24px").style("height", "100%");
         return [s.label.trim(), div.node()];
       })).node());
-    } else root.appendChild(codeBlock(ret.src, "x86asm"));
-    return document.querySelector(".disasm").replaceChildren(root);
+    } else root.appendChild(codeBlock(ret.src, ret.lang));
+    return document.querySelector(".render").replaceChildren(root);
   }
   // ** UOp view (default)
   // if we don't have a complete cache yet we start streaming rewrites in this step
@@ -691,7 +691,7 @@ async function main() {
   renderDag(ret[currentRewrite].graph, ret[currentRewrite].changed_nodes ?? [], currentRewrite === 0);
   // ** right sidebar code blocks
   const metadata = document.querySelector(".metadata");
-  const [code, lang] = ctx.fmt != null ? [ctx.fmt, "cpp"] : [ret[currentRewrite].uop, "python"];
+  const [code, lang] = [ret[currentRewrite].uop, "python"];
   metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }), codeBlock(code, lang, { wrap:false }));
   // ** rewrite steps
   if (step.match_count >= 1) {


### PR DESCRIPTION
This replaces the old sidebar view of the program that had two downsides:
1. Too small for complex kernels
2. Didn't change when rewrites were applied

This diff moves the rendered code to the main view between "Linearizer" and "Disassembly":
<img width="3840" height="2006" alt="image" src="https://github.com/user-attachments/assets/75ead2f6-0084-4b3f-957d-7c0a97cfb624" />
Moving forward, the sidebar shows the input UOp at the time of rewrite. This is in general a more useful option for the workflow of people iterating on symbolic stuff, since you can just copy the AST and use it as an input to the specific rewrite rule / matcher.