### PR TITLE
Revert "nv: check if jitlink is avail"

### DIFF
--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -69,9 +69,7 @@ class PTXCompiler(Compiler):
   def disassemble(self, lib:bytes): cuda_disassemble(lib, self.arch)
 
 class NVPTXCompiler(PTXCompiler):
-  def __init__(self, arch:str):
-    nvrtc.nvJitLinkVersion(ctypes.byref(ctypes.c_int()), ctypes.byref(ctypes.c_int())) # try to get version to check if jitlink is available
-    super().__init__(arch, cache_key="nv_ptx")
+  def __init__(self, arch:str): super().__init__(arch, cache_key="nv_ptx")
   def compile(self, src:str) -> bytes:
     jitlink_check(nvrtc.nvJitLinkCreate(handle := nvrtc.nvJitLinkHandle(), 1, to_char_p_p([f'-arch={self.arch}'.encode()])), handle)
     jitlink_check(nvrtc.nvJitLinkAddData(handle, nvrtc.NVJITLINK_INPUT_PTX, ptxsrc:=super().compile(src), len(ptxsrc), "<null>".encode()), handle)


### PR DESCRIPTION
breaking benchmark. tho it's fine on systems