### PR TITLE
Revert "use RTLD_GLOBAL on macos"

### DIFF
--- a/autogen_stubs.sh
+++ b/autogen_stubs.sh
@@ -279,9 +279,9 @@ generate_llvm() {
     --clang-args="$(llvm-config-14 --cflags)" \
     -o "$BASE/llvm.py"
 
-  sed -i "s\import ctypes\import ctypes, tinygrad.runtime.support.llvm as llvm_support, tinygrad.helpers as helpers\g" "$BASE/llvm.py"
+  sed -i "s\import ctypes\import ctypes, tinygrad.runtime.support.llvm as llvm_support\g" "$BASE/llvm.py"
   sed -i "s\FIXME_STUB\llvm\g" "$BASE/llvm.py"
-  sed -i "s\FunctionFactoryStub()\ctypes.CDLL(llvm_support.LLVM_PATH, ctypes.RTLD_GLOBAL if helpers.OSX else ctypes.DEFAULT_MODE)\g" "$BASE/llvm.py"
+  sed -i "s\FunctionFactoryStub()\ctypes.CDLL(llvm_support.LLVM_PATH)\g" "$BASE/llvm.py"
 
   fixup "$BASE/llvm.py"
 }

--- a/tinygrad/runtime/autogen/llvm.py
+++ b/tinygrad/runtime/autogen/llvm.py
@@ -6,7 +6,7 @@
 # POINTER_SIZE is: 8
 # LONGDOUBLE_SIZE is: 16
 #
-import ctypes, tinygrad.runtime.support.llvm as llvm_support, tinygrad.helpers as helpers
+import ctypes, tinygrad.runtime.support.llvm as llvm_support
 
 
 class AsDictMixin:
@@ -146,7 +146,7 @@ class FunctionFactoryStub:
 # You can either re-run clan2py with -l /path/to/library.so
 # Or manually fix this by comment the ctypes.CDLL loading
 _libraries = {}
-_libraries['llvm'] = ctypes.CDLL(llvm_support.LLVM_PATH, ctypes.RTLD_GLOBAL if helpers.OSX else ctypes.DEFAULT_MODE) #  ctypes.CDLL('llvm')
+_libraries['llvm'] = ctypes.CDLL(llvm_support.LLVM_PATH) #  ctypes.CDLL('llvm')
 c_int128 = ctypes.c_ubyte*16
 c_uint128 = c_int128
 void = None


### PR DESCRIPTION
Breaks python3 -m tinygrad.device, but (in theory) fixes metal segfaults?

Will try to fix both today, but tinygrad.device being broken is a lesser evil than metal segfaulting.