### PR TITLE
[Bounty] Remove Tensor._pool alternative implementation and verify kernels remain the same

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2556,7 +2556,7 @@ class TestOps(unittest.TestCase):
       with self.subTest(padding=p):
         helper_test_op([shape],
           lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(5,5), padding=1),
-          lambda x: Tensor.avg_pool2d(x, kernel_size=(5,5), padding=1), rtol=1e-5, forward_only=True)
+          lambda x: Tensor.avg_pool2d(x, kernel_size=(5,5), padding=1), rtol=1e-5)
     self.helper_test_exception([shape], lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(2,2), padding=(1,1,1)),
                                lambda x: Tensor.avg_pool2d(x, kernel_size=(2,2), padding=(1,1,1)), expected=(RuntimeError, ValueError))
 
@@ -2600,7 +2600,7 @@ class TestOps(unittest.TestCase):
   def test_global_avg_pool2d(self):
     helper_test_op([(32,2,111,28)],
       lambda x: torch.nn.functional.avg_pool2d(x, kernel_size=(111,28)),
-      lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5, forward_only=True)
+      lambda x: Tensor.avg_pool2d(x, kernel_size=(111,28)), rtol=1e-5)
 
   def test_avg_pool3d_failure(self):
     with Context(NOOPT=0):


### PR DESCRIPTION
Two issues found simply removing alternative implementation. 

The first issue was that `test/test_ops.py::TestOps::test_unfold` failed because `_pool` was not properly handling the edge cases when `kernel = 0` or `stride > input shape`. Fixed this by handling these. 

The second issue is that the backward pass for the pooling kernel taking too long with python backend. The forward pass kernel looks identical from the alternative implementation, but the backward pass kernel doesn't. Especially slow for these tests:
- `PYTHON=1 python -m pytest test/test_ops.py::TestOps::test_global_avg_pool2d` (1.28s vs [almost never ends])
- `PYTHON=1 python -m pytest test/test_ops.py::TestOps::test_avg_pool2d_asymmetric_padding` (2.43s vs 149.98s)

`DEBUG=4 python -m pytest test/test_ops.py::TestOps::test_global_avg_pool2d -rP` on master vs this branch:
<img width="1265" height="652" alt="Screenshot 2025-10-17 at 6 01 42 PM" src="https://github.com/user-attachments/assets/7617b150-9cdf-4c66-879f-2a3146523d29" />

```
$ git checkout master
$ DEBUG=5 python -m pytest test/test_ops.py::TestOps::test_global_avg_pool2d -rP > cmp
$ git checkout usatie:remove-tensor-pool-alternative
$ DEBUG=5 python -m pytest test/test_ops.py::TestOps::test_global_avg_pool2d -rP > out
$ diff cmp out
```
<img width="1261" height="696" alt="Screenshot 2025-10-20 at 2 51 36 PM" src="https://github.com/user-attachments/assets/f5a11445-3656-452f-9c3d-aebf23ffd3ba" />
