### PR TITLE
fix hcq_profile for qcom backend

### DIFF
--- a/tinygrad/runtime/support/hcq.py
+++ b/tinygrad/runtime/support/hcq.py
@@ -274,7 +274,8 @@ def hcq_profile(dev:HCQCompiled, enabled, desc, queue_type:Callable[[], HWQueue]
       assert queue_type is not None
       queue_type().wait(dev.timeline_signal, dev.timeline_value - 1).timestamp(en).signal(dev.timeline_signal, dev.next_timeline()).submit(dev)
 
-    if enabled and PROFILE: dev.sig_prof_records.append((cast(HCQSignal, st), cast(HCQSignal, en), desc, queue_type is dev.hw_copy_queue_t))
+    if enabled and PROFILE: dev.sig_prof_records.append((cast(HCQSignal, st), cast(HCQSignal, en), desc,
+                                                         dev.hw_copy_queue_t is not None and queue_type is dev.hw_copy_queue_t))
 
 class HCQArgsState(Generic[ProgramType]):
   def __init__(self, buf:HCQBuffer, prg:ProgramType, bufs:tuple[HCQBuffer, ...], vals:tuple[sint, ...]=()):


### PR DESCRIPTION
This looks like a logic bug that resulted in wrong timestamp diffs in the qcom backend. Simple repro:

`VIZ=1 PYTHONPATH=. DEV=QCOM python test/test_tiny.py TestTiny.test_plus` fails because the timestamp offsets are wrong, compare TINY and QCOM's canonicalized timestamps:
```
ProfileRangeEvent(device='TINY', name='get realize', st=Decimal('2690597294102.063'), en=Decimal('2690597294219.612'), is_copy=False)
ProfileRangeEvent(device='QCOM', name='E_3', st=Decimal('2871.562500000000106269160138'), en=Decimal('2876.822916666666773130501328'), is_copy=True)
```

QCOM only specifies the tdiffs from the compute:
```
ProfileDeviceEvent(device='QCOM', comp_tdiff=Decimal('2692129987831.772458333333024'), copy_tdiff=Decimal('0'))
```
because of `if self.hw_copy_queue_t is None: gpu2cpu_copy_time_diff = decimal.Decimal(0)`
but then `@hcq_profile` records events with is_copy=True because `None is None`. I think it's reasonable to record events with is_copy=False if the device doesn't specify a hw_copy_queue.