### PR TITLE
list buffer args to kernel in profiler

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -176,7 +176,7 @@ function tabulate(rows) {
 var data, focusedDevice, focusedShape, canvasZoom, zoomLevel = d3.zoomIdentity, shapeMetadata = new Map();
 function focusShape(shape) {
   saveToHistory({ shape:focusedShape });
-  focusedShape = shape.key; d3.select("#timeline").call(canvasZoom.transform, zoomLevel);
+  focusedShape = shape?.key; d3.select("#timeline").call(canvasZoom.transform, zoomLevel);
   return document.querySelector(".metadata").replaceChildren(shapeMetadata.get(focusedShape) ?? "");
 }
 


### PR DESCRIPTION
Also the buffers are clickable, eg in here if I click on data3 it'll highlight it: 
<img width="3840" height="1678" alt="image" src="https://github.com/user-attachments/assets/bdf6648b-f027-49f4-8711-2b657b486499" />
<img width="3840" height="1678" alt="image" src="https://github.com/user-attachments/assets/434eebb0-2b6c-4604-ac31-d952401317ac" />

ordering is based on the buffer number
back button switches focus to the old one.