### PR TITLE
viz: add linearized UOp list view

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -253,7 +253,7 @@ def get_stdout(f:Callable) -> str:
 
 def get_render(ctx:list[str], fmt:list[str]):
   if not isinstance(prg:=trace.keys[int(ctx[0])].ret, ProgramSpec): return
-  if fmt[0] == "uops": return json.dumps({"src":get_stdout(lambda: print_uops(prg.uops or [])), "lang":"cpp"}).encode()
+  if fmt[0] == "uops": return json.dumps({"src":get_stdout(lambda: print_uops(prg.uops or [])), "lang":"python"}).encode()
   if fmt[0] == "src": return json.dumps({"src":prg.src, "lang":"cpp"}).encode()
   lib = (compiler:=Device[prg.device].compiler).compile(prg.src)
   disasm_str = get_stdout(lambda: compiler.disassemble(lib))


### PR DESCRIPTION
It's like DEBUG>=6:
<img width="3840" height="1988" alt="image" src="https://github.com/user-attachments/assets/27a91043-893b-4546-a4e3-d5897508dba3" />


in the case of a linearizer failure, the option will not exist in the list:
<img width="3840" height="1204" alt="image" src="https://github.com/user-attachments/assets/b3092282-0a56-480b-9a5d-2cf32eb83a58" />