### PR TITLE
hotfix: correct viz rewrite step counter reset

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -639,7 +639,7 @@ async function main() {
           e.stopPropagation();
           const subrewrites = getSubrewrites(e.currentTarget.parentElement);
           if (subrewrites.length) { e.currentTarget.parentElement.classList.toggle("expanded"); }
-          setState({ currentStep:j, currentCtx:i });
+          setState({ currentStep:j, currentCtx:i, currentRewrite:0 });
         }
         stack.push(u);
       }


### PR DESCRIPTION
simple repro:
1. click on sub rewrite
2. go to nth rewrite
3. click on another subrewrite with rewrite count less than n
4. complains:
<img width="3840" height="2050" alt="image" src="https://github.com/user-attachments/assets/87803a38-00bf-4087-ade5-90c4fb2a851d" />
