### PR TITLE
viz: extend main code block to full height

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -241,6 +241,9 @@
     max-height: 30vh;
     padding: 8px;
   }
+  pre.full-height code.hljs {
+    max-height: none;
+  }
   #progress-message {
     position: absolute;
     z-index: 2;

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -731,8 +731,8 @@ async function main() {
   if (ret.length === 0) return;
   renderDag(ret[currentRewrite].graph, ret[currentRewrite].changed_nodes ?? [], currentRewrite === 0);
   // ** right sidebar code blocks
-  metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }),
-                           codeBlock(ret[currentRewrite].uop, "python", { wrap:false }));
+  const codeElement = codeBlock(ret[currentRewrite].uop, "python", { wrap:false });
+  metadata.replaceChildren(codeBlock(step.code_line, "python", { loc:step.loc, wrap:true }), codeElement);
   // ** rewrite steps
   if (step.match_count >= 1) {
     const rewriteList = metadata.appendChild(document.createElement("div"));
@@ -755,7 +755,7 @@ async function main() {
         diffCode.className = "wrap";
       }
     }
-  }
+  } else codeElement.classList.add("full-height");
 }
 
 // **** collapse/expand


### PR DESCRIPTION
new view kernel graph:
<img width="3840" height="1988" alt="image" src="https://github.com/user-attachments/assets/e76fca05-0242-4d8d-a5a7-2f6fdf123d56" />
things that have rewrites below them stay with the height limit:
<img width="3840" height="1988" alt="image" src="https://github.com/user-attachments/assets/5e3b9649-6967-46a2-9c17-63a636c74e2f" />
