### PR TITLE
AMD: Apply an override for nbio 7.3 to 7.2.0 with gfx1036 iGPU

### DIFF
--- a/tinygrad/runtime/support/amd.py
+++ b/tinygrad/runtime/support/amd.py
@@ -35,7 +35,7 @@ def fixup_ip_version(ip:str, version:tuple[int, ...]) -> list[tuple[int, ...]]:
       if version[:len(ver)] == ver: return ovrd_ver
     return version
 
-  if ip in ['nbio', 'nbif']: version = _apply_ovrd({(3,3): (2,3,0)})
+  if ip in ['nbio', 'nbif']: version = _apply_ovrd({(3,3): (2,3,0), (7,3): (7,2,0)})
   elif ip in ['mp', 'smu']: version = _apply_ovrd({(14,0,3): (14,0,2)})
   elif ip in ['gc']: version = _apply_ovrd({(9,5,0): (9,4,3)})
 


### PR DESCRIPTION
Resolve `ImportError: Failed to load ASIC registers for NBIO 7.3.0` when running on `gfx1036` AMD devices by mapping down to 7.2.0 ASIC header files.

This is seen with an [AMD Ryzen 5 9600X 6-Core Processor](https://www.amd.com/en/products/processors/desktops/ryzen/9000-series/amd-ryzen-5-9600x.html) with an iGPU on Ubuntu 24.04 with `6.14.0-33-generic` HWE kernel.

With the override applied, `ops_tests.py` seems to work except for `TestOpsUint8.test_cast_relu` and `test_gemm_fp16` - I am not sure whether the status of those tests are with AMD devices; but, given the other tests work and it passes other smoke tests, I figured that it makes sense to at least open this PR for review/feedback.

Thanks!

```
$ DEBUG=3 python3 -c "from tinygrad import Tensor;
N = 1024; a, b = Tensor.empty(N, N), Tensor.empty(N, N);
(a.reshape(N, 1, N) * b.T.reshape(1, N, N)).sum(axis=2).realize()"
Using LLVM at 'libLLVM.so.20.1'
AMDDevice: opening 0 with target (10, 3, 6) arch gfx1036
LLVM init for 'gfx1036' with '+cumode'
AMD: using AMDLLVMCompiler
opened device AMD from pid:2451927
scheduled 1 kernels in 4.02 ms
Traceback (most recent call last):
  File "<string>", line 3, in <module>
  File "/home/ubuntu/work/tinygrad/tinygrad/tensor.py", line 4532, in _wrapper
    ret = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/tensor.py", line 273, in realize
    run_schedule(*Tensor.schedule_with_vars(*to_realize), do_update_stats=do_update_stats)
  File "/home/ubuntu/work/tinygrad/tinygrad/engine/realize.py", line 237, in run_schedule
    ei.run(var_vals, do_update_stats=do_update_stats)
  File "/home/ubuntu/work/tinygrad/tinygrad/engine/realize.py", line 172, in run
    et = self.prg(bufs, var_vals, wait=wait or DEBUG >= 2)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/engine/realize.py", line 107, in __call__
    return self._prg(*[x._buf for x in rawbufs], **lra, vals=tuple(var_vals[k.expr] for k in self.p.vars), wait=wait)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/runtime/support/hcq.py", line 334, in __call__
    q = self.dev.hw_compute_queue_t().wait(self.dev.timeline_signal, self.dev.timeline_value - 1).memory_barrier()
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/runtime/ops_amd.py", line 120, in memory_barrier
    self.wait_reg_mem(reg=getattr(self.nbio, f'regBIF_BX_PF{pf}_GPU_HDP_FLUSH_REQ').addr[0],
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/runtime/support/amd.py", line 26, in __getattr__
    if name in self.regs: return self.regs[name]
               ^^^^^^^^^
  File "/usr/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/runtime/support/amd.py", line 23, in regs
    def regs(self): return import_asic_regs(self.name, self.version, cls=functools.partial(AMDReg, bases=self.bases))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/work/tinygrad/tinygrad/runtime/support/amd.py", line 93, in import_asic_regs
    raise ImportError(f"Failed to load ASIC registers for {prefix.upper()} {'.'.join(map(str, version))}")
ImportError: Failed to load ASIC registers for NBIO 7.3.0
```
