### PR TITLE
viz: check overlay width after layout

### DIFF
--- a/tinygrad/viz/js/worker.js
+++ b/tinygrad/viz/js/worker.js
@@ -29,10 +29,10 @@ onmessage = (e) => {
       const node = g.node(n);
       if (node.label.includes("dtypes.index")) g.removeNode(n);
     }
-    // After all layout changes are complete, remove the overlay node if it's empty
-    if (!g.node("addition")?.width) g.removeNode("addition");
   }
   dagre.layout(g);
+  // remove additions overlay if it's empty
+  if (!g.node("addition")?.width) g.removeNode("addition");
   postMessage(dagre.graphlib.json.write(g));
   self.close();
 }


### PR DESCRIPTION
This way viz still highlights changed nodes in "hide indexing" mode:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/aaf4b442-7d6a-4a4d-a193-ea1f91c0c515" />

If the rewrite only changed indexing ops it doesn't draw the highlight node:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/0f5743ee-bc8a-4a65-b07b-c44b9f20dabd" />
