### PR TITLE
validate workitem idx for metal renderer

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -322,7 +322,7 @@ class MetalRenderer(CStyleLanguage):
   arg_int_prefix = "constant int&"
   barrier = "threadgroup_barrier(mem_flags::mem_threadgroup);"
   float4 = "float4"
-  code_for_workitem = {"g": lambda x: f"gid.{chr(120+int(x))}", "l": lambda x: f"lid.{chr(120+int(x))}"}
+  code_for_workitem = {"g": lambda x: workitem("gid",x), "l": lambda x: workitem("lid",x)}
   # uint3 used for gid/lid - TODO: this should probably be `ushort3 lid [[thread_position_in_threadgroup]]`
   extra_args = ['uint3 gid [[threadgroup_position_in_grid]]', 'uint3 lid [[thread_position_in_threadgroup]]']
   type_map = {dtypes.bfloat16: "bfloat"}
@@ -351,6 +351,12 @@ class MetalRenderer(CStyleLanguage):
   mat_a.thread_elements()[1] = a[1]; mat_b.thread_elements()[1] = b[1]; mat_c.thread_elements()[1] = c[1];
   simdgroup_multiply_accumulate(mat_c, mat_a, mat_b, mat_c);\n  return {dstr_out}(mat_c.thread_elements()[0], mat_c.thread_elements()[1]);\n}}""")
     return super().render_kernel(function_name, kernel, bufs, uops, prefix)
+
+def workitem(prefix: str, x: str) -> str:
+  idx = int(x)
+  assert 0 <= idx <= 2, f"Invalid Metal coordinate index {idx}, must be in range [0,2] for x/y/z position components"
+  return f"{prefix}.{chr(120+idx)}"
+
 
 _nms = "xyzwabcdefghijkl"
 


### PR DESCRIPTION
fix for #12689

tested with invalid input

Before Fix:
```
➜   ✗ python3 test_metal.py
#include <metal_stdlib>
using namespace metal;
kernel void test(uint3 gid [[threadgroup_position_in_grid]], uint3 lid [[thread_position_in_threadgroup]]) {
  int gidx4 = gid.|; /* 16 */
}
```

After Fix:
```
➜   ✗ python3 test_metal.py
Traceback (most recent call last):
  File "/Users/shiwamjaiswal/ml/tinygrad/test_metal.py", line 13, in <module>
    rendered = metal_renderer.render(uops)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/renderer/cstyle.py", line 207, in render
    def render(self, uops:list[UOp]) -> str: return self.render_kernel(*self._render(uops), uops)
                                                                        ^^^^^^^^^^^^^^^^^^
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/renderer/cstyle.py", line 188, in _render
    l = cast(str, self.string_rewrite.rewrite(u, ctx=self))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/uop/ops.py", line 1012, in rewrite
    if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
             ^^^^^^^^^^^^^^^
  File "<string>", line 3, in compiled_match
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/renderer/cstyle.py", line 29, in <lambda>
    (UPat(Ops.SPECIAL, name="x"), lambda ctx,x: f"{ctx.code_for_workitem[x.arg[0]](x.arg[-1])}; /* {(x.src[0]).render()} */"),
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/renderer/cstyle.py", line 325, in <lambda>
    code_for_workitem = {"g": lambda x: validate_workitem_index("gid",x), "l": lambda x: validate_workitem_index("lid",x)}
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shiwamjaiswal/ml/tinygrad/tinygrad/renderer/cstyle.py", line 357, in validate_workitem_index
    assert 0 <= idx <= 2, f"Invalid Metal coordinate index {idx}, must be in range [0,2] for x/y/z position components"
           ^^^^^^^^^^^^^
AssertionError: Invalid Metal coordinate index 4, must be in range [0,2] for x/y/z position components
```