### PR TITLE
viz: visible horizontal scrollbar in long texts

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -284,11 +284,14 @@
     height: fit-content;
   }
   .raw-text {
-    padding: 0 8px;
+    padding-left: 15px;
     width: 100%;
     height: 100%;
     max-height: 100vh;
     overflow-x: auto;
+  }
+  .raw-text > pre {
+    display: inline-block;
   }
   .raw-text code {
     max-height: none !important;


### PR DESCRIPTION
It was only accessible in the end of the long text, now it's always at the bottom of the screen:
<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/37369e4b-cd0f-45f4-a6f0-1e4b6b009107" />
