### PR TITLE
tinygpu: fix crash

### DIFF
--- a/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
+++ b/extra/usbgpu/tbgpu/installer/TinyGPUDriverExtension/TinyGPUDriverUserClient.cpp
@@ -82,6 +82,7 @@ kern_return_t TinyGPUDriverUserClient::Stop_Impl(IOService* in_provider)
 		for (size_t i = 0; i < ivars->dmaCount; i++) {
 			auto &d = ivars->dmas[i];
 			if (d.dmaCmd) {
+				d.dmaCmd->CompleteDMA(kIODMACommandCompleteDMANoOptions);
 				d.dmaCmd->release();
 				d.dmaCmd = nullptr;
 			}


### PR DESCRIPTION
the underlying buffer ownership is transferred to the client once it is mapped