### PR TITLE
whisper: fix oob, explicit dtype

### DIFF
--- a/examples/whisper.py
+++ b/examples/whisper.py
@@ -248,7 +248,7 @@ def transcribe_waveform(model: Whisper, enc, waveforms, truncate=False):
 
   def inferloop(ctx: Union[np.ndarray, List[np.ndarray]], encoded_audio):
     pos, next_tokens = 0, ctx
-    for i in range((nsample-len(start_tokens))*2):
+    for i in range(nsample):
       next_tokens = model.decoder(Tensor(next_tokens, dtype=dtypes.int32), pos, encoded_audio)[:, -1].argmax(axis=-1).numpy().astype(np.int32).reshape(-1, 1)
       next_tokens[ctx[:, -1] == eot] = eot
       ctx = np.concatenate((ctx, next_tokens), axis=1)


### PR DESCRIPTION
First call to decoder has input Tensor with dtype depending on numpy version (v1 int32, v2 int64), corrupts sequence. Pinned it to int32 explicitly.

Fixed variable OOB when EOT is never the top logit in a sequence, which usually happens when decoder is stuck in a repeat loop.

Enforced max decoded tokens limit to match reference openai.