### PR TITLE
viz: improve the program run tooltip

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -159,6 +159,7 @@ def timeline_layout(dev_events:list[tuple[int, int, float, DevEvent]], start_ts:
         fmt = [f"{flops*1e-9:.0f} GFLOPS" if flops < 1e14 else f"{flops*1e-12:.0f} TFLOPS",
                f"{membw*1e-9:.0f}|{ldsbw*1e-9:.0f} GB/s" if membw < 1e13 and ldsbw < 1e15 else f"{membw*1e-12:.0f}|{ldsbw*1e-12:.0f} TB/s"]
         if (metadata_str:=",".join([str(m) for m in (ei.arg['metadata'] or ())])): fmt.append(metadata_str)
+        if isinstance(e, ProfileGraphEntry): fmt.append("(batched)")
         key = ei.key
     elif isinstance(e.name, TracingKey):
       name = e.name.display_name


### PR DESCRIPTION
It'll show if the kernel run was graphed:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/acb712e9-f2ce-472c-9a03-1803f489280f" />
also adding the TFLOPS similar to DEBUG=2.
