### PR TITLE
[Bounty] Make TestSpeed.test_sum green 

### DIFF
--- a/test/speed/external_test_speed_v_torch.py
+++ b/test/speed/external_test_speed_v_torch.py
@@ -73,7 +73,7 @@ def helper_test_generic_square(name, N, f1, f2, onearg=False):
   tiny_a = Tensor(torch_a.cpu().numpy())
   tiny_b = Tensor(torch_b.cpu().numpy()) if not onearg else None
 
-  helper_test_generic(f"{name:30s} {N:5d}x{N:5d}", f1, (torch_a, torch_b), TinyJit(f2), (tiny_a, tiny_b))
+  helper_test_generic(f"{name:30s} {N:5d}x{N:5d}", f1, (torch_a, torch_b), f2, (tiny_a, tiny_b))
 
 def helper_test_matvec(name, N, M):
   torch.manual_seed(0)


### PR DESCRIPTION
```
$ BEAM=3 LLVM=1 LLVMOPT=1 python3 test/speed/external_test_speed_v_torch.py TestSpeed.test_sum 
sum                             2048x 2048    0.25 ms (     0.00 GFLOPS    0.00 GB/s) in torch,    0.05 ms (     0.00 GFLOPS    0.00 GB/s) in tinygrad,    0.19x faster       0.00 MOPS     0.00 MB
sum                             4096x 4096    1.00 ms (     0.00 GFLOPS    0.00 GB/s) in torch,    0.05 ms (     0.00 GFLOPS    0.00 GB/s) in tinygrad,    0.05x faster       0.00 MOPS     0.00 MB
sum                             8192x 8192    8.75 ms (     0.00 GFLOPS    0.00 GB/s) in torch,    0.09 ms (     0.00 GFLOPS    0.00 GB/s) in tinygrad,    0.01x faster       0.00 MOPS     0.00 MB
sum                            16384x16384   66.26 ms (     0.00 GFLOPS    0.00 GB/s) in torch,    0.10 ms (     0.00 GFLOPS    0.00 GB/s) in tinygrad,    0.00x faster       0.00 MOPS     0.00 MB
.
----------------------------------------------------------------------
Ran 1 test in 5.711s
```

I have discovered that JIT hurts the performance with small size matrice. With JIT disabled we can make the `TestSpeed.test_sum` test as fast as pytorch. 

I have 2 questions remaining:
1. I don't know whether modifying helper_test_generic_square would impact any other tests.
2.  Should I add a switch for JIT depending on matrix size?

