### PR TITLE
support _rebuild_tensor method interception

### DIFF
--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -194,6 +194,10 @@ def torch_load(t:Tensor) -> dict[str, Tensor]:
   """
   offsets: dict[str|int, int] = {}
   lens: dict[str|int, int] = {}
+
+  def _rebuild_tensor(storage, storage_offset, size, stride):
+    return _rebuild_tensor_v2(storage, storage_offset, size, stride)
+
   def _rebuild_tensor_v2(storage, storage_offset, size, stride, requires_grad=None, backward_hooks=None, metadata=None):
     #print(storage, storage_offset, size, stride, requires_grad, backward_hooks, metadata)
     lens[storage[2]] = storage[4] * storage[1].itemsize
@@ -220,7 +224,8 @@ def torch_load(t:Tensor) -> dict[str, Tensor]:
   deserialized_objects: dict[str, Any] = {}
   intercept = {"HalfStorage": dtypes.float16, "FloatStorage": dtypes.float32, "BFloat16Storage": dtypes.bfloat16,
                "IntStorage": dtypes.int32, "BoolStorage": dtypes.bool,
-               "LongStorage": dtypes.int64, "_rebuild_tensor_v2": _rebuild_tensor_v2, "FloatTensor": None, "Parameter": Parameter}
+               "LongStorage": dtypes.int64, "_rebuild_tensor": _rebuild_tensor, "_rebuild_tensor_v2": _rebuild_tensor_v2,
+               "FloatTensor": None, "Parameter": Parameter}
   whitelist = {"torch", "collections", "numpy", "_codecs"}  # NOTE: this is not for security, only speed
   class Dummy: pass
   class TorchPickle(pickle.Unpickler):


### PR DESCRIPTION
https://github.com/pytorch/vision/blob/acccf86477759b2d3500f1ae1be065f7b1e409ec/torchvision/models/vgg.py#L248

While loading this particular variant of VGG16 I get the following error:
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[17], line 1
----> 1 state_dict = nn.state.torch_load(fetch("/Users/fzngagan/.cache/torch/hub/checkpoints/vgg16-397923af.pth"))

File ~/deeplearning/tinygrad/tinygrad/nn/state.py:39, in accept_filename.<locals>.wrapper(fn)
     38 @functools.wraps(func)
---> 39 def wrapper(fn: Tensor|str|pathlib.Path) -> T: return func(Tensor(pathlib.Path(fn)) if not isinstance(fn, Tensor) else fn)

File ~/deeplearning/tinygrad/tinygrad/nn/state.py:271, in torch_load(t)
    269 else:
    270   pkl = TorchPickle(fobj)
--> 271   _, _, _, rwd, _, ids, base_offset = pkl.load(), pkl.load(), pkl.load(), fobj.tell(), pkl.load(), pkl.load(), fobj.tell()
    272   for i in ids:
    273     offsets[i] = base_offset + 8

File ~/deeplearning/tinygrad/tinygrad/nn/state.py:232, in torch_load.<locals>.TorchPickle.find_class(self, module, name)
    230   if DEBUG >= 2: print(f"WARNING: returning Dummy for {module} {name}")
    231   return Dummy
--> 232 return intercept[name] if module_root == "torch" else super().find_class(module, name)

KeyError: '_rebuild_tensor'
```

Turns out, some models do look for this method. This PR simply adds a shim to call the `_rebuild_tensor_v2` method. Works perfectly fine.