### PR TITLE
sqtt test_timing work

### DIFF
--- a/extra/sqtt/test_timing.py
+++ b/extra/sqtt/test_timing.py
@@ -86,7 +86,8 @@ class TestTiming(unittest.TestCase):
     with save_sqtt() as sqtt:
       for tc in dev.renderer.get_tensor_cores(dev.arch):
         M, K, N = tc.dims
-        a = Tensor.empty(M, K, dtype=tc.dtype_in)@Tensor.empty(K, N, dtype=tc.dtype_in)
+        s = 32
+        a = Tensor.empty(M*s, K*s, dtype=tc.dtype_in)@Tensor.empty(K*s, N*s, dtype=tc.dtype_in)
         a.realize()
         print(a)
     for p,waves in sqtt.items():


### PR DESCRIPTION
`PYTHONPATH=. python extra/sqtt/test_timing.py TestTiming.test_wmma` launches matmuls for all wmmas in the arch. I do not believe this number:
<img width="2560" height="1276" alt="image" src="https://github.com/user-attachments/assets/1a70594c-e6a4-4494-b664-d4c077faa40b" />
RGP says 9 cycles:
<img width="2560" height="1276" alt="image" src="https://github.com/user-attachments/assets/6fb4dff4-8b09-4fee-8e12-706995308fa9" />
Traced on tinyr9: https://github.com/qazalin/tinygrad/commit/2f3ceaea1c7236f1444b909c2b1c70fc27b8d0ee
