### PR TITLE
Update openpilot warp and add failing self-test

### DIFF
--- a/test/external/external_openpilot_image_warp.py
+++ b/test/external/external_openpilot_image_warp.py
@@ -80,8 +80,6 @@ def update_both_imgs_tinygrad(calib_img_buffer, new_img, M_inv,
   calib_big_img_buffer, calib_big_img_pair = update_img_input_tinygrad(calib_big_img_buffer, new_big_img, M_inv_big)
   return calib_img_buffer, calib_img_pair, calib_big_img_buffer, calib_big_img_pair
 
-import numpy as np
-
 def warp_perspective_numpy(src, M_inv, dst_shape):
   w_dst, h_dst = dst_shape
   h_src, w_src = src.shape[:2]


### PR DESCRIPTION
Had to add all of the additional code that happens in openpilot, for it fail in the same way.

Currently it fails the self-test as follows (only happens when jitting, tinygrad without jit works fine):
```
batman@workstation-harald:~/xx/openpilot/tinygrad_repo$ python test/external/external_openpilot_image_warp.py
enqueue 1357.24 ms -- total run 1357.25 ms
enqueue 817.33 ms -- total run 817.34 ms
enqueue   5.60 ms -- total run   5.81 ms
enqueue   0.47 ms -- total run   0.68 ms
Traceback (most recent call last):
  File "/home/batman/xx/openpilot/tinygrad_repo/test/external/external_openpilot_image_warp.py", line 177, in <module>
    assert mismatch_percent < mismatch_percent_tol, f"input mismatch percent {mismatch_percent} exceeds tolerance {mismatch_percent_tol}"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: input mismatch percent 50.000762939453125 exceeds tolerance 0.01
```

All of the issues seem to come from editing the big buffer and passing it back in. If I add .clone() on line 73, the self-tests pass, but it's not clear to me why this is needed. That buffer should not need to be copied? If anything the other output buffer should be copied, but doing that doesn't fix it.
