### PR TITLE
add external_benchmark_pyrender

### DIFF
--- a/test/external/external_benchmark_pyrender.py
+++ b/test/external/external_benchmark_pyrender.py
@@ -1,5 +1,5 @@
 # benchmark speed of pyrender for all created UOps saved with TRACK_MATCH_STATS=2
-import functools, pickle, time
+import functools, pickle
 from tinygrad.uop.ops import UOp, Ops
 from tinygrad.helpers import tqdm, temp, time_to_str, cpu_profile
 


### PR DESCRIPTION
This script can benchmark pyrender for all created INDEX/BUFFERIZE UOps in a VIZ capture.
Currently pyrender master is very slow compared to before https://github.com/tinygrad/tinygrad/commit/4c8362128bf978b59e70969875f081d9cc76fbe7.

beautiful_mnist capture:
master: 8 minutes for 6517 UOps
before:  33 seconds for 9217 UOps
<img width="2560" height="1230" alt="image" src="https://github.com/user-attachments/assets/7489cdff-e523-4917-9afa-dc143c0bc82e" />
