### PR TITLE
torch backend: no aten.detach for torch 2.10 compat

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -76,6 +76,9 @@ view_ops = {
   "aten.alias": lambda self: self,
   }
 
+# torch 2.10 handles this natively
+if tuple(map(int, torch.__version__.split('.')[:2])) < (2, 10): view_ops.update({"aten.detach": Tensor.detach})
+
 for k,v in view_ops.items(): torch.library.impl(k.replace("aten.", "aten::"), "privateuseone")(wrap_view_op(v))
 
 def _get_view_ops(view): return getattr(view, "_view_ops", [])


### PR DESCRIPTION
This should work for both torch 2.9 and 2.10.

Tested locally for OSX, Python 3.13 and Pytorch 2.10.0.dev20251120 (https://download.pytorch.org/whl/nightly/cpu/torch-2.10.0.dev20251120-cp313-none-macosx_11_0_arm64.whl).