### PR TITLE
added cache to fix n^2

### DIFF
--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -45,6 +45,7 @@ class BufferizeOpts:
 class IndexingContext:
   realize_map: dict[UOp, None|list[int]] = field(default_factory=dict)
   range_map: dict[UOp, tuple[tuple[UOp, ...], tuple[UOp, ...]]] = field(default_factory=dict)
+  buf_cache: dict[UOp,set[UOp]] = field(default_factory=dict)
 
   # create ranges
   range_idx: Iterator[int] = field(default_factory=itertools.count)

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -271,7 +271,6 @@ def limit_bufs(ctx:IndexingContext, root:UOp):
   device = device if isinstance(device, str) else device[0].split(":")[0]
   if not (MAX_BUFS:=getenv("MAX_KERNEL_BUFFERS", DEVICE_MAX_BUFS.get(device, 0))): return None
 
-  if not hasattr(ctx,"buf_cache"): ctx.buf_cache:dict[UOp,set[UOp]] = {}
   def get_bufs(u:UOp) -> set[UOp]:
     if u in ctx.buf_cache: return ctx.buf_cache[u]
     if u.op in {Ops.BUFFERIZE, Ops.AFTER, Ops.BUFFER, Ops.MSELECT, Ops.MSTACK, Ops.DEFINE_VAR}: ret = {u}


### PR DESCRIPTION
the previous implementation of limit_bufs triggered a full toposort traversal for every node. this PR replaces that with caching. 