### PR TITLE
Whisper less flaky tests

### DIFF
--- a/test/models/test_whisper.py
+++ b/test/models/test_whisper.py
@@ -106,7 +106,7 @@ class TestWhisper(unittest.TestCase):
 
     trancriptions = transcribe_waveform(self.model, self.enc, waveforms)
     self.assertEqual(2, len(trancriptions))
-    self.assertWER(trancriptions[0], TRANSCRIPTION_3, 0.1)
+    self.assertWER(trancriptions[0], TRANSCRIPTION_3, 0.085)
     self.assertEqual(TRANSCRIPTION_1, trancriptions[1])
 
   def test_wer_same(self):


### PR DESCRIPTION
This is a second PR in my planned PRs for whisper, its purpose is to make longer tests more useful to find whisper regressions with git bisect (most of them are skipped in CI).

Long transcription tests are way too brittle - case and punctuation changes (',' --> '.') from different whisper models or audio resampling algorithms fail the tests.

Identical transcription to reference isn't possible anyway, even if we normalize and do away with any $, digits, dates, currencies etc, whisper can still output an otherwise perfect transcript and it will fail on some technicality.

The point of these whisper tests isn't to fail on punctuation, but to catch significant transcription quality degradation.

Reference whisper tests quality using Word Error Rate, there is an implementation in `external_test_whisper_librispeech.py` but it depends on jiwer and openai's whisper and IMO overkill for our simple goal.

I'm using a simplified WER calculation from `examples.mlperf.metrics` on lowercased strings stripped of punctuation, so a few subtle differences in transcripts pass the test, but we still catch bigger changes, like empty or a few words in result transcript, or half of it missing (with tests that check different thresholds).