### PR TITLE
viz: draw markers on top

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -706,7 +706,7 @@ async function main() {
         if (subrewrites.length > 0) { l.appendChild(d3.create("span").text(` (${subrewrites.length})`).node()); l.parentElement.classList.add("has-children"); }
       }
     }
-    return setState({ currentCtx:0 });
+    return setState({ currentCtx:-1 });
   }
   // ** center graph
   const { currentCtx, currentStep, currentRewrite, expandSteps } = state;


### PR DESCRIPTION
The markers go on top of x axis.
Text clipping shares infrastructure with the shape labels. It'll reveal the full text when there's enough space.
<img width="3024" height="980" alt="image" src="https://github.com/user-attachments/assets/21199f1b-b6f4-47f3-9d66-587b00abd157" />
