### PR TITLE
viz: per cu timeline

### DIFF
--- a/extra/sqtt/roc.py
+++ b/extra/sqtt/roc.py
@@ -48,7 +48,7 @@ class WaveSlot:
   @property
   def simd_loc(self) -> str: return f"{self.cu_loc} SIMD:{self.simd}"
   @property
-  def wave_loc(self) -> str: return f"{self.simd_loc} WAVE:{self.wave_id}"
+  def wave_loc(self) -> str: return f"{self.simd_loc} W:{self.wave_id}"
 
 @dataclasses.dataclass(frozen=True)
 class WaveExec(WaveSlot):

--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -251,7 +251,7 @@ async function renderProfiler(path, unit, opts) {
         const e = {name:strings[u32()], ref:optional(u32()), key:optional(u32()), st:u32(), dur:f32(), info:strings[u32()] || null};
         // find a free level to put the event
         let depth = 0;
-        if (opts.levelKey != null) { depth = opts.levelKey(e); levels[depth] = 0; colorKey = e.name.split(" ")[0]; }
+        if (opts.levelKey != null) { depth = opts.levelKey(e); levels[depth] = 0; }
         else {
           depth = levels.findIndex(levelEt => e.st >= levelEt);
           const et = e.st+Math.trunc(e.dur);
@@ -259,8 +259,8 @@ async function renderProfiler(path, unit, opts) {
             depth = levels.length;
             levels.push(et);
           } else levels[depth] = et;
-          if (depth === 0) colorKey = e.name.split(" ")[0];
         }
+        if (depth === 0) colorKey = e.name.split(" ")[0];
         if (!colorMap.has(colorKey)) {
           const color = colors instanceof Map ? (colors.get(colorKey) || colors.get("DEFAULT")) : cycleColors(colors, colorMap.size);
           colorMap.set(colorKey, d3.rgb(color));
@@ -445,7 +445,6 @@ async function renderProfiler(path, unit, opts) {
           const width = xscale(e.x+e.width)-x;
           p.rect(x, y, width, e.height);
           visible.push({ y0:y, y1:y+e.height, x0:x, x1:x+width, arg:e.arg });
-          console.log(e.fillColor, e.arg);
           ctx.fillStyle = e.fillColor; ctx.fill(p);
           // add label
           drawText(ctx, e.label, x+2, y+e.height/2, width);

--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -230,7 +230,7 @@ def load_sqtt(profile:list[ProfileEvent]) -> None:
   for name,disasm in rctx.disasms.items():
     cu_events:dict[str, list[ProfileEvent]] = {}
     # wave instruction events
-    wave_insts:dict[str, list[str, dict]] = {}
+    wave_insts:dict[str, dict[str, dict]] = {}
     inst_units:dict[str, itertools.count] = {}
     for w in rctx.inst_execs.get(name, []):
       if (u:=w.wave_loc) not in inst_units: inst_units[u] = itertools.count(0)


### PR DESCRIPTION
In the VIZ timeline, every wave slot gets 12 pixels of height space. On the 7900 XTX, we have:
6 SE * 8 WGP * 4 SIMD * 16 WAVE = 3072 wave slots. So the visualizer in master would require a 30K pixels long canvas.

I first tried skipping drawing SIMDs that aren't in view, but the limiting factor is the canvas _height_.
The browser gets very slow drawing _any_ canvas with a large height.

This PR switches the timeline to a per-CU graph + all the INST waves nested:
<img width="2560" height="1270" alt="image" src="https://github.com/user-attachments/assets/0b319720-4942-4da3-ad9f-4bd13b9ac6f5" />
The max height is a more manageable ~800-1K pixels.

If we want to scale to >1K pixels graph, there are two ways to keep a small canvas height for a large visualization:
1. No browser scrollbars, use drag. (maps)
2. Keep scrollbar, Pre allocate a canvas of screen size, hook on the scroll event and translate the canvas (Perfetto)