### PR TITLE
viz: start work on profiler speed

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -197,11 +197,13 @@ var data, focusedDevice, focusedShape, canvasZoom, formatTime, zoomLevel = d3.zo
 function getMetadata(shape) {
   if (shape == null) return;
   const [t, idx] = shape.split("-");
-  const track = data.tracks.get(t), e = track.shapes[idx];
+  const track = data.tracks.get(t);
+  if (track == null) return;
+  const e = track.shapes[idx];
   const html = d3.create("div").classed("info", true);
   if (track.eventType === EventTypes.EXEC) {
-    html.append(() => tabulate([["Name", colored(e.label)], ["Duration", formatTime(e.width)], ["Start Time", formatTime(e.x)]]).node());
-    html.append("div").classed("args", true);
+    html.append(() => tabulate([["Name", d3.create("p").html(e.arg.tooltipText.split("\n")[0]).node()],
+                                ["Duration", formatTime(e.width)], ["Start Time", formatTime(e.x)]]).node());
     if (e.arg.ctx != null) {
       html.append("a").text("View codegen rewrite").on("click", () => switchCtx(e.arg.ctx, e.arg.step));
       html.append("a").text("View program").on("click", () => switchCtx(e.arg.ctx, ctxs[e.arg.ctx+1].steps.findIndex(s => s.name==="View Program")));


### PR DESCRIPTION
Most of the perf gain is from refactoring sidebar data to generate when you click on the shape.
Creating the markup for a single shape is ~low overhead, master pre created it for all N shapes.

`LLAMA3_SIZE=405B SEQLEN=8192` works after this, at ~2GB total memory usage.

`VIZ=1 PYTHONPATH=. NULL=1 python3 examples/stable_diffusion.py --fakeweights`
<img height="75" alt="image" src="https://github.com/user-attachments/assets/a52e2431-edb7-44b7-851b-c9678b549462" />
<img height="75" alt="image" src="https://github.com/user-attachments/assets/2d9a7313-f21a-435a-a80a-b225e6b09367" />