### PR TITLE
viz: bring back flops and mem in sidebar

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -202,8 +202,10 @@ function getMetadata(shape) {
   const e = track.shapes[idx];
   const html = d3.create("div").classed("info", true);
   if (track.eventType === EventTypes.EXEC) {
-    html.append(() => tabulate([["Name", d3.create("p").html(e.arg.tooltipText.split("\n")[0]).node()],
-                                ["Duration", formatTime(e.width)], ["Start Time", formatTime(e.x)]]).node());
+    const [n, _, ...rest] = e.arg.tooltipText.split("\n");
+    html.append(() => tabulate([["Name", d3.create("p").html(n).node()], ["Duration", formatTime(e.width)], ["Start Time", formatTime(e.x)]]).node());
+    const group = html.append("div").classed("args", true);
+    for (const r of rest) group.append("p").text(r);
     if (e.arg.ctx != null) {
       const i = e.arg.ctx; s = e.arg.step;
       html.append("a").text(ctxs[i+1].steps[s].name).on("click", () => switchCtx(i, s));


### PR DESCRIPTION
missed it in the #13455 sidebar refactor, back now and matches DEBUG=2

<img width="3024" height="752" alt="image" src="https://github.com/user-attachments/assets/64075b66-ad55-426c-8087-e5f162c40f20" />
<img width="3024" height="36" alt="image" src="https://github.com/user-attachments/assets/4ab3af71-5fc6-472c-b14b-fcc06d08e93a" />
