### PR TITLE
viz: add kernel buffers back to the sidebar

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -201,7 +201,7 @@ function selectShape(key) {
   return { eventType:track?.eventType, e:track?.shapes[idx] };
 }
 
-const Modes = {0:'read', 1:'write', 2:'read+write'};
+const Modes = {0:'read', 1:'write', 2:'write+read'};
 
 function getMetadata(key) {
   const { eventType, e } = selectShape(key);


### PR DESCRIPTION
Turns out with some refactoring this is a ~lightweight feature, the original first version of this was partly causing the UI OOM in the 405B profiler.
Most of new lines come from markup stuff, the data mapping is much simpler than https://github.com/tinygrad/tinygrad/pull/12826/files