### PR TITLE
fix docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,7 @@ plugins:
 - mkdocstrings:
     handlers:
       python:
-        import:
+        inventories:
         - https://docs.python.org/3/objects.inv
         paths: [tinygrad]
         options:


### PR DESCRIPTION
Changed in https://github.com/mkdocstrings/mkdocstrings/releases/tag/0.28.0
Became a breaking change in [1.0.0 released 3h ago](https://github.com/mkdocstrings/mkdocstrings/releases/tag/1.0.0).




Found via: https://github.com/mkdocstrings/python/issues/258 (which is otherwise unrelated)

```
 FutureWarning: The 'import' key is renamed 'inventories' for the Python handler
             File
           "/Users/kyle/tmp/async-tiff/python/.venv/lib/python3.12/site-packages/mkdocstrings/handlers/base.py",
           line 682, in get_handler
               self._handlers[name] = module.get_handler(**kwargs)
             File
           "/Users/kyle/tmp/async-tiff/python/.venv/lib/python3.12/site-packages/mkdocstrings_handlers/python/handler.py",
           line 370, in get_handler
               warn("The 'import' key is renamed 'inventories' for the Python handler",
           FutureWarning, stacklevel=1)
 ```