### PR TITLE
perf: faster simplify_valid (via uop_given_valid) [pr]

### DIFF
--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -310,10 +310,10 @@ def uop_given_valid(valid:UOp, uop:UOp, try_simplex=True) -> UOp:
         if not any(X in uop_topo for X,_ in candidate): continue
         newuops = [substitute_simplify(uop, {X:newX}) for X,newX in candidate]
         if any(u is uop for u in newuops): continue
-        if all_same(newuops): uop = newuops[0]
+        if all_same(newuops): uop, uop_topo = newuops[0], None
         elif uop.op is Ops.VECTORIZE and len(uop.src) == 2:
-          if all_same([uops.src[0] for uops in newuops]): uop = uop.replace(src=(newuops[0].src[0], uop.src[1]))
-          if all_same([uops.src[1] for uops in newuops]): uop = uop.replace(src=(uop.src[0], newuops[0].src[1]))
+          if all_same([uops.src[0] for uops in newuops]): uop, uop_topo = uop.replace(src=(newuops[0].src[0], uop.src[1])), None
+          if all_same([uops.src[1] for uops in newuops]): uop, uop_topo = uop.replace(src=(uop.src[0], newuops[0].src[1])), None
 
   # try all the valids together (but only the whole expressions)
   if try_simplex and uop_topo is None: uop_topo = uop.toposort()


### PR DESCRIPTION
early exits for `substitute(a).simplify().substitute(inv_a)`

main
```
***** model tensor in     61.69 ms
***** model schedule in  413.22 ms
***** model rewrite in   1519.84 ms
***** model linearize in 130.62 ms
***** model verify in     39.17 ms
28381
all 2166.22 ms
```


```
***** model tensor in     60.62 ms
***** model schedule in  383.93 ms
***** model rewrite in   1380.06 ms
***** model linearize in 135.63 ms
***** model verify in     39.22 ms
28381
all 2001.04 ms
```

main:

 ```
    15 /      90 --     22.57 /    152.69 ms -- simplify.py:40       (UPat((Ops.END, Ops.REDUCE), name="u"), simplify_merge_adjacent),
     7 /     333 --     96.55 /    208.97 ms -- symbolic.py:367      (UPat(Ops.AND, name="valid"), simplify_valid),
     6 /     139 --     51.13 /    225.74 ms -- devectorizer.py:50   (UPat(Ops.INDEX, src=(UPat.var("buf"), invalid_gate)), lambda buf,x,i,cond: simplify_valid_load(buf, x, cond)),
  1547 /    7899 --     87.59 /    334.13 ms -- divandmod.py:107     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),
 99048 / 1259921 --    649.70 /   1956.52 ms -- TOTAL
 ```
 
 branch
```
   189 /   58676 --      2.04 /     63.01 ms -- symbolic.py:210      (UPat(GroupOp.ALU|{Ops.DEFINE_VAR, Ops.SPECIAL}, name="x"), lambda x: x.const_like(x.vmin) if x.vmin == x.vmax else None),
     6 /     139 --     32.15 /     88.81 ms -- devectorizer.py:50   (UPat(Ops.INDEX, src=(UPat.var("buf"), invalid_gate)), lambda buf,x,i,cond: simplify_valid_load(buf, x, cond)),
     7 /     333 --     50.80 /    106.19 ms -- symbolic.py:380      (UPat(Ops.AND, name="valid"), simplify_valid),
    15 /      90 --     22.77 /    151.35 ms -- simplify.py:40       (UPat((Ops.END, Ops.REDUCE), name="u"), simplify_merge_adjacent),
  1647 /    5250 --     91.12 /    289.48 ms -- divandmod.py:107     (UPat((Ops.IDIV, Ops.MOD), dtypes.index, name="d"), lambda d: fold_divmod_general(d, bool(CORRECT_DIVMOD_FOLDING))),
 97298 / 1063428 --    587.69 /   1590.70 ms -- TOTAL
 ```
 


