### PR TITLE
add new remu instructions from #13533

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -2729,9 +2729,6 @@ class TestOps(unittest.TestCase):
 
   def test_clip(self):
     helper_test_op([(45,65)], lambda x: x.clip(-2.3, 1.2))
-    # NOTE: torch set backward to 1 at the boundaries
-    # https://github.com/pytorch/pytorch/blob/7a41b66367c38d0af3e8a90f7be48d6b281e7bca/tools/autograd/derivatives.yaml#L421
-    helper_test_op(None, lambda x: x.clip(-2.5, 1.5), vals=[[-3.0, -2.5, 0, 1.5, 2]])
     helper_test_op([(45,65)], lambda x: x.clip(0, 0))
     helper_test_op([(45,65)], lambda x: x.clip(10, 100))
     helper_test_op([(45,65)], lambda x: x.clip(0, 0.1))

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3020,8 +3020,8 @@ class Tensor(OpMixin):
     ```
     """
     if min_ is None and max_ is None: raise RuntimeError("at least one of 'min_' or 'max_' must not be None")
-    ret = (self < min_).where(min_, self) if min_ is not None else self
-    return (ret > max_).where(max_, ret) if max_ is not None else ret
+    ret = self.maximum(min_) if min_ is not None else self
+    return ret.minimum(max_) if max_ is not None else ret
 
   def clip(self, min_=None, max_=None) -> Tensor:
     """


### PR DESCRIPTION
From the failing tests in https://github.com/tinygrad/tinygrad/actions/runs/19873879400/job/56956336924?pr=13533

- `TestOps.test_hardtanh` used the new v_med3_f32 instruction https://github.com/tinygrad/tinygrad/pull/13539/commits/51d7ab73ed772185fe92ca0dba3fc2a4abeda1fa
- The rest of the tests (test_pow, test_permute, etc) used the v_maxmin_f32 instruction
- `TestOps.test_binary_crossentropy` used clamp modifier on a VOP3, remu didn't really support output clamping before this (and still does not for integer output). I implemented the trait for floats, will look into ints. 
