### PR TITLE
fix: add test_sum_int and remove outdated TODO

### DIFF
--- a/test/test_custom_kernel.py
+++ b/test/test_custom_kernel.py
@@ -155,9 +155,14 @@ class TestCustomKernel(unittest.TestCase):
     self.assertTrue((b_p1 == 3).all().item())
 
   def test_sum(self):
-    # TODO: this only works for float, and silently fails with int
     a = Tensor([1.0, 2, 3, 4, 5])
     tst = Tensor.empty(1)
+    b = Tensor.custom_kernel(tst, a, fxn=custom_sum)[0]
+    self.assertEqual(b.item(), 15)
+
+  def test_sum_int(self):
+    a = Tensor([1, 2, 3, 4, 5])
+    tst = Tensor.empty(1, dtype=a.dtype)
     b = Tensor.custom_kernel(tst, a, fxn=custom_sum)[0]
     self.assertEqual(b.item(), 15)
 


### PR DESCRIPTION
## Summary
- Added `test_sum_int` to verify custom_sum kernel works with integer dtypes
- Removed outdated TODO comment (the issue appears to be fixed)

## Test plan
- [x] Ran `python3 test/test_custom_kernel.py` - all 14 tests pass