### PR TITLE
fix: add __delitem__ to Tensor with proper TypeError

### DIFF
--- a/test/unit/test_indexing.py
+++ b/test/unit/test_indexing.py
@@ -176,9 +176,8 @@ class TestIndexing(unittest.TestCase):
     self.assertRaises(IndexError, lambda: reference[0.0, ..., 0.0:2.0])
     self.assertRaises(IndexError, lambda: reference[0.0, :, 0.0])
 
-    # TODO: delitem
-    # def delitem(): del reference[0]
-    # self.assertRaises(TypeError, delitem)
+    def delitem(): del reference[0]
+    self.assertRaises(TypeError, delitem)
 
   # TODO setitem backward
   '''

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1257,6 +1257,9 @@ class Tensor(OpMixin):
       v = v.cast(res.dtype)._broadcast_to(_broadcast_shape(res.shape, v.shape)).contiguous()
       res.assign(v).realize()
 
+  def __delitem__(self, indices) -> None:
+    raise TypeError("Tensor does not support deleting items")
+
   def gather(self:Tensor, dim:int, index:Tensor) -> Tensor:
     """
     Gathers values along an axis specified by `dim`.


### PR DESCRIPTION
## Summary
- Added `__delitem__` method to Tensor class that raises `TypeError`
- Matches PyTorch behavior: `TypeError: Tensor does not support deleting items`
- Previously raised confusing `AttributeError: __delitem__`
- Uncommented existing test in `test_indexing.py`

## Test plan
- [x] `python3 -m unittest test.unit.test_indexing.TestIndexing.test_invalid_index -v` passes
- [x] Full `test.unit.test_indexing` suite passes (59 tests)