### PR TITLE
[TYPED=1] fix mathmixin typecheck

### DIFF
--- a/tinygrad/codegen/late/devectorizer.py
+++ b/tinygrad/codegen/late/devectorizer.py
@@ -274,7 +274,7 @@ pm_render = PatternMatcher([
     lambda x: x.replace(src=(x.src[0], x.const_like(0))+x.src[1:])
       if len(x.src) == 1 or x.src[1].op in (Ops.CUSTOM, Ops.STORE, Ops.BARRIER) else None),
   # Where after gated load becomes alt value
-  (UPat.var("c").where(UPat(Ops.LOAD, src=(UPat().index(UPat.var("idx"), UPat.var("c")).or_casted(),), allow_any_len=True, name="l").or_casted(),
+  (UPat.var("c").where(UPat(Ops.LOAD, src=(UPat().index(UPat.var("idx"), UPat.var("c")).or_casted(),), allow_any_len=True, name="l").or_casted().to_upat(),
     UPat.var("a")), lambda c,idx,l,a: l.replace(src=(l.src[0], a.cast(l.dtype))+l.src[2:]).cast(a.dtype)),
   (UPat.var("c").where(UPat.var("a"), UPat(Ops.LOAD, src=(UPat().index(UPat.var("idx"), UPat.var("c").logical_not()).or_casted(),),
     allow_any_len=True, name="l").or_casted()), lambda c,idx,l,a: l.replace(src=(l.src[0], a.cast(l.dtype))+l.src[2:]).cast(a.dtype)),

--- a/tinygrad/codegen/simplify.py
+++ b/tinygrad/codegen/simplify.py
@@ -86,7 +86,7 @@ pm_reduce_unparented = PatternMatcher([
 
 pm_reduce_collapse = pm_reduce_unparented + PatternMatcher([
   # lift x+y out of reduce on lt
-  ((UPat.var("x")+UPat.var("y")).or_casted() < UPat.var("c"), lambda x,y,c: (x < (c.cast(y.dtype)-y)) if no_range(y) and no_range(c) else None),
+  ((UPat.var("x")+UPat.var("y")).or_casted().to_upat() < UPat.var("c"), lambda x,y,c: (x < (c.cast(y.dtype)-y)) if no_range(y) and no_range(c) else None),
   # lift x*y out of reduce
   ((UPat.var("x")*UPat.var("y")) < UPat.var("c"),
    lambda x,y,c: (x < ((c+y-1) // y)) if no_range(y) and no_range(c) and dtypes.is_int(y.dtype) and y.vmin > 0 else None),
@@ -113,9 +113,9 @@ pm_reduce_collapse = pm_reduce_unparented + PatternMatcher([
 
 pm_reduce_load_collapse = pm_reduce_collapse + PatternMatcher([
   # lift x+y out of reduce on ne
-  ((UPat.var("x")+UPat.var("y")).or_casted() != UPat.var("c"), lambda x,y,c: (x != (c.cast(y.dtype)-y)) if no_range(y) and no_range(c) else None),
+  ((UPat.var("x")+UPat.var("y")).or_casted().to_upat() != UPat.var("c"), lambda x,y,c: (x != (c.cast(y.dtype)-y)) if no_range(y) and no_range(c) else None),
   # reduce on gated load becomes can substitute the range and remove the reduce
-  ((UPat.var("idx")!=(UPat(Ops.RANGE, name="r").or_casted())).where(0, UPat.var("expr")).reduce(UPat.var("r"), arg=Ops.ADD),
+  ((UPat.var("idx")!=(UPat(Ops.RANGE, name="r").or_casted().to_upat())).where(0, UPat.var("expr")).reduce(UPat.var("r"), arg=Ops.ADD),
    lambda r,idx,expr: (v:=(idx.cast(r.dtype) >= 0) & (idx.cast(r.dtype) < r.src[0])).where(expr.substitute({r:idx.cast(r.dtype).valid(v)}),0)),
 ])
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -998,6 +998,16 @@ class UPatAny(UPat):
     matches = [x.match(uop, store.copy()) for x in self.src[0]]
     return flatten([x for x in matches if x is not None])
 
+  def to_upat(self:UPat) -> UPat:
+    return UPat(op=self.op,
+                dtype=self.dtype,
+                src=self._in_src,
+                arg=self.arg,
+                name=self.name,
+                allow_any_len=not self.strict_length, 
+                custom_early_reject= self.custom_early_reject, 
+                location=self.location)
+
 def deconstruct_function(fxn:Callable) -> tuple:
   new_globals = {k:v for k,v in fxn.__globals__.items() if k in fxn.__code__.co_names}
   for co in fxn.__code__.co_consts:


### PR DESCRIPTION
This is a change that solves a single typing error and moves the
codebase towards the goal of being able to run tinygrad normally with option
TYPED=1 (open issue https://github.com/tinygrad/tinygrad/issues/7889).

The type error being solved (full trace below):
```
typeguard.TypeCheckError: argument "x" (tinygrad.uop.ops.UPat) did not match any element in the union:
  Self: is not an instance of the self type (tinygrad.uop.ops.UPatAny)
  float: is neither float or int
  int: is not an instance of int
  bool: is not an instance of bool
```

Produced by running
```
python3 -c "import os; os.environ['TYPED'] = '1'; import tinygrad"
```
on windows (system data below).


# Data of system that error was produced on
- Python version: Python 3.13.1
- typeguard version: 4.4.4
- OS: Microsoft Windows [Version 10.0.19045.6216]

# Full error trace
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import os; os.environ['TYPED'] = '1'; import tinygrad
                                          ^^^^^^^^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\__init__.py", line 5, in <module>
    from tinygrad.tensor import Tensor                                    # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\tensor.py", line 15, in <module>
    from tinygrad.engine.schedule import ScheduleItem, complete_create_schedule_with_vars
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\engine\schedule.py", line 6, in <module>
    from tinygrad.uop.spec import type_verify, tensor_spec
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\uop\spec.py", line 271, in <module>
    from tinygrad.codegen.opt import Opt, OptOps
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\codegen\__init__.py", line 14, in <module>
    from tinygrad.codegen.late.expander import expander, pm_pre_expander, pm_group_for_reduce
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\codegen\late\expander.py", line 6, in <module>
    from tinygrad.schedule.rangeify import BufferizeOpts
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\schedule\rangeify.py", line 9, in <module>
    from tinygrad.codegen.simplify import pm_flatten_range, pm_reduce_simplify
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_importhook.py", line 98, in exec_module
    super().exec_module(module)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\codegen\simplify.py", line 89, in <module>
    ((UPat.var("x")+UPat.var("y")).or_casted() < UPat.var("c"), lambda x,y,c: (x < (c.cast(y.dtype)-y)) if no_range(y) and no_range(c) else None),
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\KarlMogensen\source\repos\contributor\tinygrad\tinygrad\mixin\math.py", line 200, in __lt__
    def __lt__(self, x: Self | ConstType):
      return self.alu(Ops.CMPLT, self.ufix(x))
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_functions.py", line 137, in check_argument_types
    check_type_internal(value, annotation, memo)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_checkers.py", line 960, in check_type_internal
    checker(value, origin_type, args, memo)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\KarlMogensen\AppData\Local\Programs\Python\Python313\Lib\site-packages\typeguard\_checkers.py", line 427, in check_union
    raise TypeCheckError(f"did not match any element in the union:\n{formatted_errors}")
typeguard.TypeCheckError: argument "x" (tinygrad.uop.ops.UPat) did not match any element in the union:
  Self: is not an instance of the self type (tinygrad.uop.ops.UPatAny)
  float: is neither float or int
  int: is not an instance of int
  bool: is not an instance of bool
```
