### PR TITLE
add static amd program info to viz

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -366,7 +366,7 @@ def amd_readelf(lib:bytes) -> list[dict]:
   namesz, descsz, typ = struct.unpack_from(hdr:="<III", data, 0)
   offset = (struct.calcsize(hdr)+namesz+3) & -4
   notes = msgpack.unpackb(data[offset:offset+descsz])
-  keys = {".sgpr_count":"SGPRs", ".vgpr_count":"VGPRs", ".max_flat_workgroup_size":"WGP size",
+  keys = {".sgpr_count":"SGPRs", ".vgpr_count":"VGPRs", ".max_flat_workgroup_size":"Max WGP size",
           ".group_segment_fixed_size":"LDS size", ".private_segment_fixed_size":"Scratch size"}
   return [{"label":label, "value":v} for k,label in keys.items() if (v:=notes["amdhsa.kernels"][0][k]) > 0]
 


### PR DESCRIPTION
It uses the existing ELF loader to read the `.notes` section.
AMD's assembler populates this using MessagePack, it currently requires `pip install msgpack` to read the blob.
<img width="2560" height="1270" alt="image" src="https://github.com/user-attachments/assets/3b342368-5bcb-4647-a986-e99ec94408fa" />

Other option was to use `system("llvm-readelf")`, I think the dump is kind of verbose:
<img width="2560" height="1270" alt="image" src="https://github.com/user-attachments/assets/7d1c0a33-edca-4836-9dc7-203d5bd82d7a" />

