### PR TITLE
remove redundant copy in beam search

### DIFF
--- a/tinygrad/codegen/opt/search.py
+++ b/tinygrad/codegen/opt/search.py
@@ -94,13 +94,12 @@ def _ensure_buffer_alloc(bufs:list[Buffer]) -> list[Buffer]: return [buf.ensure_
 # get dictionary of all possible actions
 def get_kernel_actions(s:Scheduler, include_0=True) -> dict[int, Scheduler]:
   acted, max_up, max_lcl = {0:s} if include_0 else {}, getenv("BEAM_UPCAST_MAX", 256), getenv("BEAM_LOCAL_MAX", 1024)
-  kernel_actions = actions.copy()
 
-  for i,a in enumerate(kernel_actions):
+  for i,a in enumerate(actions):
     if a.axis is not None and a.op is not OptOps.TC:
       try: ax = s.real_axis(a.op, a.axis)
       except KernelOptError: continue
-      if (ax >= s.shape_len) or (s.full_shape[ax] == a.arg and Opt(a.op, a.axis, 0) in kernel_actions): continue
+      if (ax >= s.shape_len) or (s.full_shape[ax] == a.arg and Opt(a.op, a.axis, 0) in actions): continue
     s2 = s.copy()
     try:
       s2.apply_opt(a)


### PR DESCRIPTION
**_actions_** list is copied in beam search on every call of **_get_kernel_actions_** function. 
**_actions_** list is not changed in the function call.
Also, _**actions**_ list is not changed after it is created on import.

Seems, that this copy() is present due to historical reasons. **_get_kernel_actions_**  used to mutate _**actions**_ list:  https://github.com/geohotstan/tinygrad/blob/onnx_parser_uint64_double/tinygrad/opt/search.py#L111 