### PR TITLE
CUDA GEMM FP16 with FP32 accum in UOps

### DIFF
--- a/extra/gemm/nv_uop_matmul.py
+++ b/extra/gemm/nv_uop_matmul.py
@@ -12,9 +12,9 @@ run_count = getenv("CNT", 5)
 
 WARP_SIZE = 32
 
-BLOCK_N = 128   # columns of C per block
+BLOCK_N = 256   # columns of C per block
 BLOCK_M = 128   # rows of C per block
-BLOCK_K = 32    # K-slice per block iteration
+BLOCK_K = 64    # K-slice per block iteration
 
 TN = 4  # columns per thread
 TM = 4  # rows per thread


### PR DESCRIPTION
For bounty _165+ TFLOP GEMM (match torch) with kernel on 4090, FP16 with FP32 acc. amd_uop_matmul style_

This is currently FMA only which is what `amd_uop_matmul` does. However it only has 36 TFLOPS on 4090. 
It seems that only WMMA can achieve 165 TFLOPs but the memory mappings are pretty complicated to hand spec without ldmatrix. Is that really what we want?

Any tips are appreciated. Thanks!

```bash
((.venv) ) ➜  tinygrad git:(master) ✗ python extra/gemm/nv_uop_matmul.py
*** NV         3 E_16_32_256_128_32_64_4_4_2_4_4_4_2_4_4_4_2_4_64_64 arg  3 mem   0.10 GB tm   3790.24us/     3.79ms (  36261 GFLOPS   27|7658   GB/s)
*** NV         4 E_16_32_256_128_32_64_4_4_2_4_4_4_2_4_4_4_2_4_64_64 arg  3 mem   0.10 GB tm   3785.70us/     7.58ms (  36305 GFLOPS   27|7667   GB/s)
*** NV         5 E_16_32_256_128_32_64_4_4_2_4_4_4_2_4_4_4_2_4_64_64 arg  3 mem   0.10 GB tm   3786.34us/    11.36ms (  36299 GFLOPS   27|7666   GB/s)
*** NV         6 E_16_32_256_128_32_64_4_4_2_4_4_4_2_4_4_4_2_4_64_64 arg  3 mem   0.10 GB tm   3786.78us/    15.15ms (  36294 GFLOPS   27|7665   GB/s)
*** NV         7 E_16_32_256_128_32_64_4_4_2_4_4_4_2_4_4_4_2_4_64_64 arg  3 mem   0.10 GB tm   3784.67us/    18.93ms (  36315 GFLOPS   27|7669   GB/s)
REAL TFLOPS 36.31
*** NV         1 r_128_64_8_16_4_4_1024_4                       arg  3 mem   0.17 GB tm   7501.89us/     7.50ms (  18321 GFLOPS   18|9169   GB/s) ['cast', '__matmul__']
mean squared error 1.2220243661431596e-06
```