### PR TITLE
test: enable cummax scalar IndexError test

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1074,8 +1074,7 @@ class TestOps(unittest.TestCase):
   @slow_test
   def test_cummax(self):
     helper_test_op([()], lambda x: torch.cummax(x, dim=0).values, lambda x: Tensor.cummax(x, axis=0))
-    # TODO: torch allows this?
-    # self.helper_test_exception([()], lambda x: torch.cummax(x, dim=1).values, lambda x: Tensor.cummax(x, axis=1), expected=IndexError)
+    self.helper_test_exception([()], lambda x: torch.cummax(x, dim=1).values, lambda x: Tensor.cummax(x, axis=1), expected=IndexError)
     helper_test_op([(20,)], lambda x: torch.cummax(x, dim=0).values, lambda x: Tensor.cummax(x, axis=0))
     self.helper_test_exception([(20,)], lambda x: torch.cummax(x, dim=1).values, lambda x: Tensor.cummax(x, axis=1), expected=IndexError)
     self.helper_test_exception([(20,)], lambda x: torch.cummax(x, dim=-2).values, lambda x: Tensor.cummax(x, axis=-2), expected=IndexError)


### PR DESCRIPTION
- Uncommented test for cummax with invalid axis on scalar tensor
- Both torch and tinygrad correctly raise IndexError for invalid dim on scalar


The original bug report here: https://github.com/pytorch/pytorch/issues/71477
The fix in pytorch: https://github.com/pytorch/pytorch/pull/143920