### PR TITLE
fix viz endstream

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -817,7 +817,7 @@ async function main() {
     const eventSource = new EventSource(ckey);
     evtSources.push(eventSource);
     eventSource.onmessage = (e) => {
-      if (e.data === "END") return eventSource.close();
+      if (e.data === "[DONE]") return eventSource.close();
       const chunk = JSON.parse(e.data);
       ret.push(chunk);
       // if it's the first one render this new rgaph


### PR DESCRIPTION
https://github.com/tinygrad/tinygrad/pull/13648/changes#diff-55db3dd96de229d7898600c350db55b2747e065ca91cacae55ba7a7d437f63ecL477 updated SSE to Open AI style sentinel tokens, the VIZ UI should've updated as well. Started seeing these in the chrome console:
<img width="3024" height="676" alt="image" src="https://github.com/user-attachments/assets/677c3405-646c-4d76-9a27-4fb4dbcda196" />
