### PR TITLE
hotfix SPEC for AFTER(CONTIGUOUS)

### DIFF
--- a/tinygrad/uop/spec.py
+++ b/tinygrad/uop/spec.py
@@ -54,7 +54,7 @@ movement_ops = PatternMatcher([
   (UPat({Ops.ADD, Ops.MUL, Ops.IDIV}, dtype=dtypes.index), lambda: True),
 
   # AFTER on Movement Op
-  (UPat(Ops.AFTER, src=(UPat(GroupOp.Movement.union({Ops.MULTI})),), allow_any_len=True), lambda: True),
+  (UPat(Ops.AFTER, src=(UPat(GroupOp.Movement.union({Ops.MULTI, Ops.CONTIGUOUS})),), allow_any_len=True), lambda: True),
 
   # custom kernels allowed here
   (UPat(Ops.CUSTOM_KERNEL), lambda: True),


### PR DESCRIPTION
fixed spec error in `PYTHONPATH="." REWRITE_STACK_LIMIT=5000000 NULL=1 DEFAULT_FLOAT="HALF" BERT_LAYERS=2 BENCHMARK=10  BS=128 GPUS=1 MODEL=bert python3 examples/mlperf/model_train.py`