### PR TITLE
Replace scheduler with linearizer [pr]

### DIFF
--- a/tinygrad/codegen/late/linearizer.py
+++ b/tinygrad/codegen/late/linearizer.py
@@ -1,88 +1,93 @@
 import heapq
-from typing import Any
 from collections import defaultdict
 from tinygrad.uop.ops import PatternMatcher, UOp, Ops, UPat, multirange_str
 from tinygrad.helpers import prod, getenv, TUPLE_ORDER
 
-def linearize(sink:UOp) -> list[UOp]:
-  # this is a toposort with priority
+def linearize(sink:UOp, for_scheduling:bool=False) -> list[UOp]:
   lst = list(sink.toposort())
-  consumers: defaultdict[UOp, list[UOp]] = defaultdict(list)
+  consumers:defaultdict[UOp, list[UOp]] = defaultdict(list)
   in_degree:dict[UOp, int] = {}
-  out_degree:dict[UOp, int] = {}
-  priorities:dict[UOp, tuple[int, int, Any]] = {}
+  priorities:dict[UOp, tuple] = {}
 
-  # get consumers and assign priorities
-  # NOTE: this requires the lst be locally toposorted
   for u in reversed(lst):
     for s in u.src: consumers[s].append(u)
     in_degree[u] = len(u.src)
-    out_degree[u] = len(consumers[u])
 
-    # we place UOps with higher run_counts later
+  if for_scheduling:
+    topo_idx = {u:i for i,u in enumerate(lst)}
+    depth:dict[UOp, int] = {}
+    for u in lst: depth[u] = max((depth.get(s, 0) for s in u.src), default=0) + 1 if u.src else 0
+    for u in lst:
+      if u.op is Ops.KERNEL:
+        radj = 1000 if any(s.op is Ops.BIND and len(s.src) > 1 and s.src[1].op is Ops.RANGE for s in u.src) else 0
+      elif u.op is Ops.RANGE: radj = 500
+      elif u.op is Ops.END: radj = 2000
+      elif u.op is Ops.AFTER:
+        w = u.src[1]
+        if w.op is Ops.KERNEL: radj = 1000 if any(s.op is Ops.BIND and len(s.src) > 1 and s.src[1].op is Ops.RANGE for s in w.src) else 0
+        elif w.op is Ops.END: radj = 2000
+        elif w.op is Ops.RANGE: radj = 500
+        else: radj = 0
+      else: radj = 0
+      priorities[u] = (radj, depth[u], topo_idx[u])
+    in_deg = dict(in_degree)
+    heapq.heapify(heap:=[(priorities[u], topo_idx[u], u) for u in lst if in_deg[u] == 0])
+    out:list[UOp] = []
+    while heap:
+      out.append(u:=heapq.heappop(heap)[2])
+      for v in consumers[u]:
+        in_deg[v] -= 1
+        if in_deg[v] == 0: heapq.heappush(heap, (priorities[v], topo_idx[v], v))
+    return out
+
+  # codegen path
+  out_degree:dict[UOp, int] = {}
+  for u in reversed(lst): out_degree[u] = len(consumers[u])
+  for u in reversed(lst):
     run_count = prod([int(r.vmax)+1 for r in u.ranges])
-
-    # simple priority override. this is all bottom up now, smaller numbers will be closer to the top
     extra = None
     match u.op:
-      # the order and placement of these defines is important
       case Ops.DEFINE_GLOBAL: priority, extra = -20, u.arg
       case Ops.DEFINE_VAR: priority, extra = -19, u.arg
       case Ops.DEFINE_LOCAL: priority = -18
       case Ops.DEFINE_REG: priority = -17
-      case Ops.CONST: priority = -10  # early consts
-      case Ops.LOAD: priority = -1    # place loads early
-      case Ops.STORE: priority = 1    # place stores late
-      case Ops.RANGE: priority = 5    # placing RANGE is good
-      case Ops.END: priority = -5     # placing END is bad
-      case _: priority = 0            # everything else has priority 0
+      case Ops.CONST: priority = -10
+      case Ops.LOAD: priority = -1
+      case Ops.STORE: priority = 1
+      case Ops.RANGE: priority = 5
+      case Ops.END: priority = -5
+      case _: priority = 0
     priorities[u] = (run_count, priority, extra)
-
-  # number the uops in "ideal" order
   nkey = {u:i for i,u in enumerate(sorted(lst, key=lambda x: priorities[x]+(x.tuplize if TUPLE_ORDER else ())))}
-
-  # then force them to be toposorted in as close to the ideal order as possible
-  heap = [(-nkey[sink], sink)]
-  newlst = []
-  while heap:
-    newlst.append(u:=heapq.heappop(heap)[1])
+  cg_heap:list[tuple[int, UOp]] = [(-nkey[sink], sink)]
+  newlst:list[UOp] = []
+  while cg_heap:
+    newlst.append(u:=heapq.heappop(cg_heap)[1])
     for v in u.src:
       out_degree[v] -= 1
-      if out_degree[v] == 0: heapq.heappush(heap, (-nkey[v],v))
+      if out_degree[v] == 0: heapq.heappush(cg_heap, (-nkey[v], v))
   newlst = newlst[::-1]
-
   if getenv("DEBUG_LINEARIZE"):
-    for i,u in enumerate(newlst):
-      print(f"{i:4d} {str(u.op):20s} {multirange_str(u.ranges, color=True, pad=10)} {priorities[u]}")
+    for i,u in enumerate(newlst): print(f"{i:4d} {str(u.op):20s} {multirange_str(u.ranges, color=True, pad=10)} {priorities[u]}")
   return newlst
 
 class CFGContext:
   def __init__(self, sink:UOp):
-    # there are 3 relationships between ranges:
-    # nested, meaning endrange y is a dependency of endrange x and range x is a dependency of endrange y
-    # dependent, meaning endrange y is a dependency of endrange x and range x is not a dependency of endrange y
-    # independent, endrange y is not a dependency of endrange x
-    # everything is nested inside the sink
-    deps: dict[UOp, dict[UOp, None]] = {}
-    nesting: dict[UOp, UOp] = {}
+    deps:dict[UOp, dict[UOp, None]] = {}
+    nesting:dict[UOp, UOp] = {}
     for u in sink.toposort():
-      # get the deps from the src
       deps[u] = {}
       for s in u.src: deps[u] |= deps[s]
-
       if u.op in (Ops.END, Ops.SINK):
         nesting |= {x:u for x in deps[u] if x.op is Ops.END and (u.op is Ops.SINK or u.src[1] in deps[x]) and x not in nesting}
       if u.op in (Ops.RANGE, Ops.END): deps[u][u] = None
-
-    self.edges: dict[UOp, UOp] = {}
-    siblings: dict[UOp, list[UOp]] = {}
+    self.edges:dict[UOp, UOp] = {}
+    siblings:dict[UOp, list[UOp]] = {}
     for k,vv in nesting.items(): siblings.setdefault(vv, []).append(k)
     for k,v in siblings.items():
-      # ranges that have dependencies on other siblings need to be scheduled after them
       order = sorted(v, key=lambda x: len([u for u in v if u in deps[x]]))
       zipped = zip(order, order[1:]) if k.op is Ops.SINK else zip([k.src[1]] + order, order)
       for x,y in zipped:
-        # TODO: this can happen! it causes infinite loop in shufflenet
         assert y.src[1] not in x.backward_slice_with_self
         self.edges[y.src[1]] = x
 
@@ -96,6 +101,5 @@ def do_split_ends(e:UOp):
   return ret
 
 pm_split_ends = PatternMatcher([
-  # split the ends
   (UPat(Ops.END, name="e"), do_split_ends),
 ])

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
 import time
 from typing import cast
-from collections import deque
 from tinygrad.uop.ops import UOp, Ops, buffers, UOpMetaClass, track_rewrites
 from tinygrad.uop.ops import PatternMatcher, UPat, graph_rewrite, graph_rewrite_map
 from tinygrad.uop.spec import type_verify, tensor_spec
@@ -9,64 +7,39 @@ from tinygrad.device import Buffer, MultiBuffer
 from tinygrad.helpers import DEBUG, cpu_profile, TracingKey, SPEC, flatten, pluralize
 from tinygrad.engine.realize import ExecItem
 
-# **** schedule linearizer
-
-def create_schedule(sched_sink:UOp) -> tuple[list[ExecItem], UOp]:
-  with cpu_profile(TracingKey("toposort sched_sink")):
-    # construct the KERNEL children graph based on assigns
-    children: dict[UOp, list[UOp]] = {}
-    in_degree: dict[UOp, int] = {}
-    for u in sched_sink.toposort():
-      if u.op is Ops.RANGE:
-        in_degree.setdefault(u, 0)
-        continue
-      if u.op is not Ops.AFTER or u.src[1].op is Ops.RANGE: continue
-      k = u.src[1]
-      in_degree.setdefault(k, 0)
-      for s in k.src[0].src if k.op is Ops.END else k.src:
-        if s.op is Ops.AFTER:
-          children.setdefault(s.src[1], []).append(k)
-          in_degree[k] += 1
-        elif s.op in {Ops.MSELECT, Ops.MSTACK}:
-          for ss in s.src:
-            if ss.op is Ops.MSELECT: ss = ss.src[0]
-            if ss.op is not Ops.BUFFER:
-              assert ss.op is Ops.AFTER, f"ss.op is not AFTER, it's {ss.op}"
-              children.setdefault(ss.src[1], []).append(k)
-              in_degree[k] += 1
-        elif s.op in {Ops.BUFFER, Ops.BIND}:
-          pass  # a BUFFER is already realized, BINDs are handled in complete_create_schedule_with_vars
-        else:
-          raise RuntimeError(f"input to kernel must be AFTER or BUFFER, not {s.op}")
-
-  with cpu_profile(TracingKey("linearize schedule")):
-    queue: deque[UOp] = deque()
-    for k,v in in_degree.items():
-      if v == 0: queue.append(k)
-
-    schedule: list[tuple|UOp] = []
-    while len(queue):
-      k = rk = queue.popleft()
-      if k.op is Ops.END: k = k.src[0]
-      if k.op is Ops.RANGE: schedule.append(k)
-      elif k.op is Ops.KERNEL:
-        ast = k.arg.ast
-        buf_uops = tuple(s.buf_uop for s in k.src if s.op is not Ops.BIND)
-        bound_ranges = tuple(s for s in k.src if s.op is Ops.BIND and len(s.src) > 1 and s.src[1].op is Ops.RANGE)
-        schedule.append((ast, buf_uops, k.arg.metadata, {}, bound_ranges))
-        if rk.op is Ops.END: schedule.append(rk)
-      else:
-        raise RuntimeError(f"can't schedule {k.op}")
-      for x in children.get(rk, []):
-        in_degree[x] -= 1
-        if in_degree[x] == 0: queue.append(x)
-
+def create_schedule(sched_sink:UOp) -> list[ExecItem]:
+  from tinygrad.codegen.late.linearizer import linearize
+  with cpu_profile(TracingKey("linearize sched_sink")): ordered = linearize(sched_sink, for_scheduling=True)
+  with cpu_profile(TracingKey("linearize to schedule")):
+    # internal: (ast, bufs, metadata, fixedvars, bound_ranges) or UOp for RANGE/END
+    schedule:list[tuple|UOp] = []
+    seen_kernels:set[UOp] = set()
+    for u in ordered:
+      if u.op is Ops.RANGE: schedule.append(u)
+      elif u.op is Ops.AFTER and u.src[1].op is not Ops.RANGE:
+        rk = k = u.src[1]
+        if k.op is Ops.END: k = k.src[0]
+        if k.op is Ops.KERNEL and k not in seen_kernels:
+          seen_kernels.add(k)
+          ast = k.arg.ast
+          if ast.op is Ops.BUFFER_VIEW:
+            base = k.src[1].buf_uop.buffer
+            assert isinstance(base, Buffer), "base can't be MultiBuffer"
+            buffers[k.src[0].buf_uop] = base.view(k.src[0].buf_uop.arg, ast.dtype, ast.arg[1]*base.dtype.itemsize)
+          ubufs = [s.buf_uop.buffer for s in k.src if s.op is not Ops.BIND]
+          bound_ranges = tuple(s for s in k.src if s.op is Ops.BIND and len(s.src) > 1 and s.src[1].op is Ops.RANGE)
+          if any(isinstance(x, MultiBuffer) for x in ubufs):
+            assert all(isinstance(x, MultiBuffer) for x in ubufs), "kernel must all be multibuffer"
+            dnums = [x for x in ast.variables() if x.arg[0] == '_device_num']
+            for i,bufs in enumerate(zip(*[x.bufs for x in cast(list[MultiBuffer], ubufs)])):
+              schedule.append((ast, list(bufs), k.arg.metadata, {dnums[0].expr:i} if len(dnums) else {}, bound_ranges))
+          else: schedule.append((ast, ubufs, k.arg.metadata, {}, bound_ranges))
+          if rk.op is Ops.END: schedule.append(rk)
   with cpu_profile(TracingKey("expand ranges")):
-    pre_schedule: list[ExecItem] = []
-    buf_uops_list: list[UOp] = []
+    real_schedule:list[ExecItem] = []
     sched_ptr = 0
-    in_ranges: dict[UOp, int] = {}
-    range_ptrs: dict[UOp, int] = {}
+    in_ranges:dict[UOp, int] = {}
+    range_ptrs:dict[UOp, int] = {}
     while sched_ptr < len(schedule):
       si = schedule[sched_ptr]
       if isinstance(si, UOp):
@@ -79,12 +52,11 @@ def create_schedule(sched_sink:UOp) -> tuple[list[ExecItem], UOp]:
             sched_ptr = range_ptrs[si.src[1]]
             continue
       else:
-        ast, buf_uops, metadata, fixedvars, bound_ranges = si
+        ast, bufs, metadata, fixedvars, bound_ranges = si
         fixedvars = fixedvars | {s.src[0].arg[0]:in_ranges[s.src[1]] for s in bound_ranges}
-        pre_schedule.append(ExecItem(ast, [], metadata, fixedvars))
-        buf_uops_list.append(UOp.sink(*buf_uops))
+        real_schedule.append(ExecItem(ast, bufs, metadata, fixedvars))
       sched_ptr += 1
-  return pre_schedule, UOp.sink(*buf_uops_list)
+  return real_schedule
 
 from tinygrad.engine.memory import memory_planner
 from tinygrad.schedule.rangeify import get_rangeify_map
@@ -92,114 +64,66 @@ from tinygrad.schedule.multi import get_multi_map
 
 def replace_input_buffer(ctx:dict[UOp, UOp], b:UOp):
   if (ret:=ctx.get(b, None)) is None:
-    if b.op is Ops.BUFFER:
-      ctx[b] = ret = b.replace(src=(UOp(Ops.LUNIQUE, arg=len(ctx)), b.src[1]))
+    if b.op is Ops.BUFFER: ctx[b] = ret = b.replace(src=(UOp(Ops.LUNIQUE, arg=len(ctx)), b.src[1]))
     else:
-      # TODO: flip args in CONST
       assert b.op is Ops.CONST
       ctx[b] = ret = b.replace(src=(b.src[0], UOp(Ops.LUNIQUE, arg=len(ctx))))
   return ret
 
 pm_pre_sched_cache = PatternMatcher([
-  # replace input buffers
   (UPat(Ops.BUFFER, src=(UPat(Ops.UNIQUE), UPat(Ops.DEVICE)), name="b"), replace_input_buffer),
-  # remove unique consts
   (UPat(Ops.CONST, src=(UPat(Ops.DEVICE), UPat(Ops.UNIQUE)), name="b"), replace_input_buffer),
-  # strip value from BIND for cache key normalization, so different values hit same cache
   (UPat(Ops.BIND, src=(UPat(Ops.DEFINE_VAR), UPat(Ops.CONST)), name="b"), lambda ctx,b: ctx.setdefault(b, b.replace(src=(b.src[0],)))),
 ])
 
 def replace_input_buffer_back(ctx:dict[UOp, UOp], b:UOp):
   if (ret:=ctx.get(b, None)) is None:
     assert b.op is Ops.BUFFER
-    # if it's not in the cache, create a new buffer
     ctx[b] = ret = UOp.new_buffer(b.device, b.arg, b.dtype)
   return ret
 
 pm_post_sched_cache = PatternMatcher([
   (UPat(Ops.BUFFER, src=(UPat(Ops.LUNIQUE), UPat(Ops.DEVICE)), name="b"), replace_input_buffer_back),
   (UPat(Ops.CONST, src=(UPat(Ops.DEVICE), UPat(Ops.LUNIQUE)), name="b"), replace_input_buffer_back),
-  # restore BIND value stripped in pm_pre_sched_cache
   (UPat(Ops.BIND, src=(UPat(Ops.DEFINE_VAR),), name="b"), lambda ctx,b: ctx.get(b)),
 ])
 
-schedule_cache: dict[bytes, tuple[list[ExecItem], UOp]] = {}
+schedule_cache:dict[bytes, tuple[UOp, UOp]] = {}
 @track_rewrites(lambda _,ret: f"Schedule {pluralize('Kernel', len(ret[1]))}")
 def complete_create_schedule_with_vars(big_sink:UOp) -> tuple[dict[UOp, UOp], list[ExecItem], dict[str, int]]:
-  # big_sink srcs are all the Tensors
   st = time.perf_counter()
-
-  # replace all UNIQUE buffers with LUNIQUE, strip BIND values for cache key
-  input_buffers: dict[UOp, UOp] = {}
+  input_buffers:dict[UOp, UOp] = {}
   big_sink_cache = graph_rewrite(big_sink, pm_pre_sched_cache, ctx=input_buffers, name="rewrite for sched cache")
   sched_cache_key = big_sink_cache.key
-
   if (sc_ret:=schedule_cache.get(sched_cache_key, None)) is None:
-    # verify Tensors match the spec (on big_sink, we only need to do this if cache misses)
     if SPEC: type_verify(big_sink, tensor_spec)
-
-    # hack to preserve metadata
     graph_rewrite_map(big_sink, pm_pre_sched_cache, ctx={}, name="preserve metadata")
-
-    # tensor map is what we return
-    tensor_map: dict[UOp, UOp] = {}
-
+    tensor_map:dict[UOp, UOp] = {}
     if any(isinstance(x._device, tuple) for x in big_sink_cache.toposort()):
       tensor_map |= get_multi_map(big_sink_cache)
       big_sink_cache = big_sink_cache.substitute(tensor_map, name="Apply Multi Map")
       big_sink_cache = UOp.sink(*flatten([x.src if x.op is Ops.MULTI else [x] for x in big_sink_cache.src]))
-
     tensor_map |= get_rangeify_map(big_sink_cache)
     big_sink = big_sink_cache.substitute(tensor_map, name="Apply Kernelize Map")
-
-    pre_schedule, buf_uops_sink = create_schedule(big_sink)
-
-    # save in schedule cache (include AFTERs in tensor_map so we don't need big_sink)
-    after_map = [(u, u.buf_uop) for u in big_sink.toposort() if u.op is Ops.AFTER]
-    tensor_map_sink = UOp.sink(*flatten([(k,v) for k,v in tensor_map.items()]), *flatten(after_map))
-    combined_sink = UOp.sink(tensor_map_sink, buf_uops_sink)
-    schedule_cache[sched_cache_key] = (pre_schedule, combined_sink)
+    tensor_map_sink = UOp.sink(*flatten([(k,v) for k,v in tensor_map.items()]))
+    schedule_cache[sched_cache_key] = (big_sink, tensor_map_sink)
   else:
-    # schedule cache hit
     del big_sink_cache
-    pre_schedule, combined_sink = sc_ret
-
-  # replace all the LUNIQUEs with UNIQUEs (single graph_rewrite for everything)
+    big_sink, tensor_map_sink = sc_ret
   input_buffers_reverse = {v:k for k,v in input_buffers.items()}
-  combined = graph_rewrite(combined_sink, pm_post_sched_cache, ctx=input_buffers_reverse, name="unrewrite combined")
-  tensor_map_sink, buf_uops_sink = combined.src
-  tm_src = tensor_map_sink.src
+  big_sink = graph_rewrite(big_sink, pm_post_sched_cache, ctx=input_buffers_reverse, name="unrewrite for sched cache")
+  tm_src = graph_rewrite(tensor_map_sink, pm_post_sched_cache, ctx=input_buffers_reverse, name="unrewrite for tensor map").src
   tensor_map = {tm_src[i]:tm_src[i+1] for i in range(0, len(tm_src), 2)}
-
-  # add bufs to pre_schedule
-  schedule: list[ExecItem] = []
-  for i, si in enumerate(pre_schedule):
-    buf_uops = buf_uops_sink.src[i].src
-    # create subbuffers if needed
-    if si.ast.op is Ops.BUFFER_VIEW:
-      base = buf_uops[1].buffer
-      assert isinstance(base, Buffer), "base can't be MultiBuffer"
-      buffers[buf_uops[0]] = base.view(buf_uops[0].arg, si.ast.dtype, si.ast.arg[1]*base.dtype.itemsize)
-    ubufs = tuple(b.buffer for b in buf_uops)
-    if any(isinstance(x, MultiBuffer) for x in ubufs):
-      assert all(isinstance(x, MultiBuffer) for x in ubufs), "kernel must all be multibuffer"
-      dnums = [x for x in si.ast.variables() if x.arg[0] == '_device_num']
-      for j, bufs in enumerate(zip(*[x.bufs for x in cast(tuple[MultiBuffer, ...], ubufs)])):
-        schedule.append(ExecItem(si.ast, list(bufs), si.metadata, si.fixedvars | ({dnums[0].expr:j} if len(dnums) else {})))
-    else:
-      # ONE -> ONE
-      schedule.append(ExecItem(si.ast, list(ubufs), si.metadata, si.fixedvars))
+  schedule = create_schedule(big_sink)
   with cpu_profile(TracingKey("memory planner")): schedule = memory_planner(schedule)
-
-  # extract var_vals from BINDs that were stripped (only if there are kernels)
-  var_vals: dict[str, int] = {}
+  var_vals:dict[str, int] = {}
   if schedule:
     for u in input_buffers:
       if u.op is Ops.BIND:
         var, val = u.unbind()
         assert var.expr not in var_vals or var_vals[var.expr] == val, f"bind mismatch on {var}, {var_vals[var.expr]} != {val}"
         var_vals[var.expr] = val
-
+  tensor_map |= {u:u.buf_uop for u in big_sink.toposort() if u.op is Ops.AFTER}
   if (DEBUG >= 1 and len(schedule) > 1) or DEBUG >= 3:
     print(f"scheduled {len(schedule):4d} kernels in {(time.perf_counter()-st)*1000:8.2f} ms"+\
           f" | {' cache hit' if sc_ret is not None else 'CACHE MISS'} {sched_cache_key.hex()[:8]}"+\


### PR DESCRIPTION
Unifies schedule creation to use `linearize()` instead of separate graph-building code. Adds `for_scheduling` mode to linearize with scheduling-specific priorities.