### PR TITLE
Test Opt immutability

### DIFF
--- a/test/test_opts.py
+++ b/test/test_opts.py
@@ -16,7 +16,7 @@ class TestOpts(unittest.TestCase):
     if Device.DEFAULT in {"CPU", "CL", "METAL"} and not CPU_LLVM and not CPU_LVP:
       prg = get_program(s[-1].ast, renderer=Device[Device.DEFAULT].renderer)
       self.assertIn('float4', prg.src)
-  
+
   def test_opt_immutability(self):
     opt = Opt(OptOps.UPCAST, axis=0, arg=4)
     with self.assertRaises(dataclasses.FrozenInstanceError): opt.op = OptOps.UNROLL


### PR DESCRIPTION
Adding test case for testing Opt instance immutability. This is a prerequisite for https://github.com/tinygrad/tinygrad/pull/13603.