### PR TITLE
llama 1B faster than torch on CPU in CI [WIP]

### DIFF
--- a/test/speed/external_test_speed_llama1b_v_torch.py
+++ b/test/speed/external_test_speed_llama1b_v_torch.py
@@ -4,7 +4,7 @@ os.environ["NUMEXPR_NUM_THREADS"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["VECLIB_MAXIMUM_THREADS"] = "1"
 import unittest
-import time, math
+import time
 import numpy as np
 import torch
 import torch.nn as nn
@@ -221,7 +221,7 @@ class TestLlamaCorrectness(BaseLlamaTest):
     max_diff = np.abs(torch_out - tiny_out).max()
     mean_diff = np.abs(torch_out - tiny_out).mean()
 
-    print(f"\nCorrectness check:")
+    print("\nCorrectness check:")
     print(f"  max_diff={max_diff:.6e}, mean_diff={mean_diff:.6e}")
 
     self.assertLess(max_diff, 1e-5, "Outputs differ more than tolerance")


### PR DESCRIPTION
This PR adds a CI test to compare LLama 1B execution times on CPU between Tinygrad and PyTorch. The test also includes a correctness check to ensure both frameworks perform the same computation.

Findings from initial runs on AMD EPYC 7502 (32 cores) vast ai instance:
- Tinygrad is consistently faster than Torch with JIT enabled (≈0.72x execution time).
- Using BEAM=2 nearly doubles Tinygrad’s speedup (≈0.43x execution time).
- LLVM backend is slower for this test (≈2.24x slower than Torch).

If the test looks good, I can add it to the `benchmark.yml` file, please let me know if that's the right way to do it.

### Env variables

- CNT: The number of steps to run the models
- TORCHCOMPILE: A boolean, 1 to run torch.compile, 0 to skip

### Results

Tested on a AMD EPYC 7502 32-Core Processor.

```
===> PYTHONPATH=. JIT=1 CPU=1 CNT=50 TORCHCOMPILE=0 python test/speed/external_test_speed_llama1b_v_torch.py

Benchmark results:
  Torch min:    255.55 ms
  Tinygrad min: 184.01 ms
  Ratio (tiny/torch):    0.72x
ok

Correctness check:
  max_diff=6.914139e-06, mean_diff=7.383848e-07
ok

----------------------------------------------------------------------
Ran 2 tests in 75.502s

===> PYTHONPATH=. JIT=1 CPU=1 CNT=50 python test/speed/external_test_speed_llama1b_v_torch.py

Benchmark results:
  Torch min:    251.22 ms
  Tinygrad min: 180.67 ms
  Ratio (tiny/torch):    0.72x
ok

Correctness check:
  max_diff=6.437302e-06, mean_diff=7.260255e-07
ok

----------------------------------------------------------------------
Ran 2 tests in 83.735s

===> PYTHONPATH=. JIT=1 BEAM=2 CPU=1 CNT=50 python test/speed/external_test_speed_llama1b_v_torch.py

Benchmark results:
  Torch min:    254.90 ms
  Tinygrad min: 114.73 ms
  Ratio (tiny/torch):    0.45x
ok

Correctness check:
  max_diff=7.629395e-06, mean_diff=7.299471e-07
ok

----------------------------------------------------------------------
Ran 2 tests in 78.964s

===> PYTHONPATH=. JIT=1 BEAM=2 CPU=1 CNT=50 python test/speed/external_test_speed_llama1b_v_torch.py

Benchmark results:
  Torch min:    252.27 ms
  Tinygrad min: 108.37 ms
  Ratio (tiny/torch):    0.43x
ok

Correctness check:
  max_diff=5.841255e-06, mean_diff=7.332109e-07
ok

----------------------------------------------------------------------
Ran 2 tests in 464.118s

===> PYTHONPATH=. JIT=1 CPU=1 CPU_LLVM=1 CNT=50 python test/speed/external_test_speed_llama1b_v_torch.py

Benchmark results:
  Torch min:    251.85 ms
  Tinygrad min: 564.53 ms
  Ratio (tiny/torch):    2.24x
ok

Correctness check:
  max_diff=6.318092e-06, mean_diff=7.236959e-07
ok

----------------------------------------------------------------------
Ran 2 tests in 104.807s
```
