### PR TITLE
handle empty VECTORIZE in UOp.render()

### DIFF
--- a/test/test_uops.py
+++ b/test/test_uops.py
@@ -544,6 +544,12 @@ class TestUopsObject(unittest.TestCase):
     self.assertEqual(a.device, Device.DEFAULT)
 
 class TestUOpRender(unittest.TestCase):
+  def test_render_vectorize_empty(self):
+    u = UOp(Ops.VECTORIZE, dtype=dtypes.int.vec(0), src=())
+    self.assertEqual(u.render(simplify=False), "{}")
+  def test_render_vectorize_empty_simplified(self):
+    u = UOp(Ops.VECTORIZE, dtype=dtypes.int.vec(0), src=())
+    self.assertEqual(u.render(), "{}")
   def test_render_vectorize_same(self):
     u = UOp(Ops.VECTORIZE, dtype=dtypes.int.vec(3), src=(UOp.const(dtypes.int, 0), UOp.const(dtypes.int, 0), UOp.const(dtypes.int, 0)))
     self.assertEqual(u.render(simplify=False), "{0, ...}")

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -1353,7 +1353,7 @@ renderer = PatternMatcher([
   (UPat(set(syms.keys()), name="x"), lambda ctx,x: strip_binary_parens(x, ctx[x.src[0]], ctx[x.src[1]], lambda a,b: f"({a}{syms[x.op]}{b})")),
   (UPat((Ops.INDEX, Ops.BUFFERIZE), name="x"), lambda x, ctx: ''.join([f"[{strip_parens(ctx[y])}]" for y in x.src[1:]])),
   (UPat(Ops.VECTORIZE, name="x"),
-   lambda ctx,x: f"{{{','.join([ctx[y] for y in x.src])}}}" if not all_same(x.src) else f"{{{ctx[x.src[0]]}, ...}}"),
+   lambda ctx,x: f"{{{','.join([ctx[y] for y in x.src])}}}" if not x.src or not all_same(x.src) else f"{{{ctx[x.src[0]]}, ...}}"),
   (UPat(GroupOp.All, name="x"), lambda x: str(x)),
 ])
 


### PR DESCRIPTION
`UOp.render()` crashed with `IndexError: tuple index out of range` when the UOp graph contained a `VECTORIZE` with empty `src=()`. This occurs when reshaping to scalar shape `()`, *e.g.*, `Tensor.ones(4).sum()`.

The bug was in the renderer's VECTORIZE pattern: `all_same(())` returns `True` (vacuous truth), causing the code to access `x.src[0]` on an empty tuple.

- Fix `IndexError` when calling `UOp.render()` on graphs containing empty `VECTORIZE` nodes.
- Add test for empty `VECTORIZE` rendering.