### PR TITLE
refactor: remove sign dependency from abs

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -2928,7 +2928,7 @@ class Tensor(OpMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).abs().numpy())
     ```
     """
-    return self * self.sign()
+    return (self<0).where(-self, self) + self*0
 
   def reciprocal(self) -> Tensor:
     """


### PR DESCRIPTION
`self * sign()` is more complex than necessary for `abs()`.

For the code `print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).abs().tolist())`

Current graph using VIZ's "View Base AST":
<img width="1581" height="439" alt="image" src="https://github.com/user-attachments/assets/b5783174-6a05-4a7b-a980-23554bf4bdbf" />


Graph after changes:
<img width="1584" height="542" alt="image" src="https://github.com/user-attachments/assets/85a04fbd-b4f7-4ea6-981c-4915b3db52ac" />


Simplifying the UOp graph allows for simpler PatternMatcher patterns such for [x.abs()\*\*2=x\*\*2](https://github.com/tinygrad/tinygrad/issues/11626).