### PR TITLE
also look for linux libraries in RHEL-themed paths

### DIFF
--- a/tinygrad/runtime/support/c.py
+++ b/tinygrad/runtime/support/c.py
@@ -45,7 +45,7 @@ class DLL(ctypes.CDLL):
     for p in paths:
       libpaths = {"posix": ["/usr/lib", "/usr/local/lib"], "nt": os.environ['PATH'].split(os.pathsep),
                   "darwin": ["/opt/homebrew/lib", f"/System/Library/Frameworks/{p}.framework"],
-                  'linux': ['/lib', f"/lib/{sysconfig.get_config_var('MULTIARCH')}", "/usr/lib/wsl/lib/"]}
+                  'linux': ['/lib', '/lib64', f"/lib/{sysconfig.get_config_var('MULTIARCH')}", "/usr/lib/wsl/lib/"]}
       if (pth:=pathlib.Path(p)).is_absolute():
         if pth.is_file(): return p
         else: continue


### PR DESCRIPTION
RHEL-style distros (RHEL, Fedora, Alma, Rocky, etc.) do not have `libc.so.6` under `/lib/x86_64-linux-gnu`, but under `/lib64`. Running on such a system will fail to find glibc and then fail upon first access
```
ImportError: cannot import name 'syscall' from 'tinygrad.runtime.autogen.libc'
```
See for example
```
$ sudo docker run -it fedora
[root@ce0eb4746cfc /]# ls /lib | grep libc.so
[root@ce0eb4746cfc /]# ls /lib64 | grep libc.so
libc.so.6
```
To fix, add `/lib64` to the list of `libpaths` being searched.