### PR TITLE
mmapeak: fix compiler import

### DIFF
--- a/extra/mmapeak/mmapeak.py
+++ b/extra/mmapeak/mmapeak.py
@@ -4,7 +4,8 @@ import os, pathlib
 os.environ["AMD_AQL"] = "1"
 
 from tinygrad.device import Device
-from tinygrad.runtime.ops_amd import AMDProgram, HIPCompiler
+from tinygrad.runtime.support.compiler_amd import HIPCompiler
+from tinygrad.runtime.ops_amd import AMDProgram
 
 NUM_WORKGROUPS = 96
 WAVE_SIZE = 32


### PR DESCRIPTION
Started giving ImportError after the deviceless AMD compiler refactor https://github.com/tinygrad/tinygrad/commit/f1111ac7de423a1aa646025c70d7b9e4d64c0a9c