### PR TITLE
Fix SVD rank‑1 Jacobi rotation when tau == 0

### DIFF
--- a/test/unit/test_linalg.py
+++ b/test/unit/test_linalg.py
@@ -83,6 +83,12 @@ class TestLinAlg(unittest.TestCase):
       s_diag = (S.unsqueeze(-2) * Tensor.eye(2))
       reconstruction_helper([U, s_diag, V], a)
 
+  def test_svd_rank1(self):
+    a = Tensor([[1.0, 1.0], [2.0, 2.0]]).realize()
+    U, S, V = a.svd()
+    np.testing.assert_allclose(S.numpy(), [np.sqrt(10), 0.0], atol=1e-4, rtol=1e-4)
+    reconstruction_helper([U, S.unsqueeze(-2) * Tensor.eye(2), V], a)
+
   def test_newton_schulz(self):
     coefficients = [(2, -1.5, 0.5), (2.0, -1.4, 0.2, 0.2)]#these params map to the sign function
     sizes = [(2,2), (3,2), (2,3), (2,2,2)]

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3672,7 +3672,7 @@ class Tensor(OpMixin):
       alpha, beta = U_permuted.square().sum(-2).unsqueeze(-2).split(num//2, -1)
       rot = gamma != 0
       tau = (beta - alpha) / (2 * rot.where(gamma, 1))
-      t = tau.sign() / (tau.abs() + (1 + tau.square()).sqrt())
+      t = (tau != 0).where(tau.sign(), 1) / (tau.abs() + (1 + tau.square()).sqrt())
       t = rot.where(t, 0)
       c = 1 / (1 + t.square()).sqrt()
       s = c * t


### PR DESCRIPTION
This fixes a rank‑1 SVD bug where Jacobi rotations skipped when tau == 0, leaving AᵀA undiagonalized and producing duplicate singular values (e.g., [[1,1],[2,2]] → sqrt(5), sqrt(5) instead of sqrt(10), 0). The change treats tau == 0 as a 45° rotation, which matches torch/jax.

```python
import numpy as np
import torch
import jax.numpy as jnp
from tinygrad import Tensor

A = np.array([[1.0, 1.0], [2.0, 2.0]], dtype=np.float32)

print("tinygrad S", Tensor(A).svd()[1].numpy())
print("torch S", torch.linalg.svd(torch.tensor(A))[1].numpy())
print("jax S", np.array(jnp.linalg.svd(jnp.array(A), full_matrices=True)[1]))
```

before
```
tinygrad S 
[2.2360682 2.2360682]
torch S 
[3.1622775e+00 3.8302623e-09]
jax S 
[3.1622775e+00 3.8302623e-09]
```

after
```
tinygrad S 
[3.162278e+00 5.683209e-17]
torch S 
[3.1622775e+00 3.8302623e-09]
jax S 
[3.1622775e+00 3.8302623e-09]
```