### PR TITLE
[pr] fix: CPU_COUNT respects ContextVar in ClangRenderer

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -224,7 +224,9 @@ class ClangRenderer(CStyleLanguage):
   gep_arr_threshold = 0
   has_local = False
   has_threads = bool(getenv("THREADS", 1))
-  global_max = (CPU_COUNT.value, 0, 0)
+  # global_max is a property to respect ContextVar changes at runtime
+  @property
+  def global_max(self) -> tuple[int, int, int]: return (CPU_COUNT.value, 0, 0)
   infinity = "__builtin_inff()"
   nan = '__builtin_nanf("")'
   code_for_workitem = {"g": lambda _: "core_id"}


### PR DESCRIPTION
## Summary
- Fixed #13534: `CPU_COUNT` ContextVar was not respected in ClangRenderer's `global_max` attribute
- Changed `global_max` from a class attribute to a `@property` that evaluates `CPU_COUNT.value` at runtime

## Before this fix
```python
with Context(CPU_COUNT=4):
    # kernel generated with: core_id; /* 11 */ (original value)
    
with Context(CPU_COUNT=2):
    # kernel generated with: core_id; /* 11 */ (original value)
```

## After this fix
```python
with Context(CPU_COUNT=4):
    # kernel generated with: core_id; /* 4 */
    
with Context(CPU_COUNT=2):
    # kernel generated with: core_id; /* 2 */
```

## Test plan
- [x] Reproduced the issue from #13534
- [x] Verified fix with DEBUG=4 output showing correct core counts
- [x] Tested that `global_max[0]` access still works (used in test skip conditions)