### PR TITLE
fix: library loading on fedora systems by prioritizing lib64 paths

### DIFF
--- a/tinygrad/runtime/support/c.py
+++ b/tinygrad/runtime/support/c.py
@@ -43,7 +43,7 @@ class DLL(ctypes.CDLL):
     if nm == 'libc' and OSX: return '/usr/lib/libc.dylib'
     if pathlib.Path(path:=getenv(nm.replace('-', '_').upper()+"_PATH", '')).is_file(): return path
     for p in paths:
-      libpaths = {"posix": ["/usr/lib", "/usr/local/lib"], "nt": os.environ['PATH'].split(os.pathsep),
+      libpaths = {"posix": ["/usr/lib64", "/usr/lib", "/usr/local/lib"], "nt": os.environ['PATH'].split(os.pathsep),
                   "darwin": ["/opt/homebrew/lib", f"/System/Library/Frameworks/{p}.framework"],
                   'linux': ['/lib', '/lib64', f"/lib/{sysconfig.get_config_var('MULTIARCH')}", "/usr/lib/wsl/lib/"]}
       if (pth:=pathlib.Path(p)).is_absolute():


### PR DESCRIPTION
On Fedora 43, tinygrad fails to load libraries with "wrong ELF class: ELFCLASS32" errors when running 64-bit Python.

## Root Cause

On multilib systems:
- `/usr/lib/` contains 32-bit libraries
- `/usr/lib64/` contains 64-bit libraries


##  Fedora
before:

```bash
DEBUG=3 uv run --no-sync test_r.py
loading libc from /usr/lib/libc.so.6
loading libc failed: /usr/lib/libc.so.6: wrong ELF class: ELFCLASS32
loading hsa from /usr/lib/libhsa-runtime64.so
loading libusb from /usr/lib/libusb-1.0.so.0
loading libusb failed: /usr/lib/libusb-1.0.so.0: wrong ELF class: ELFCLASS32
loading nvrtc failed: not found on system
loading nvjitlink failed: not found on system
loading mesa failed: not found on system
loading cuda failed: not found on system
loading opencl from /lib64/libOpenCL.so.1
CLDevice: got 1 platforms and 0 devices
loading llvm from /usr/lib/libLLVM-21.so
loading llvm failed: /usr/lib/libLLVM-21.so: wrong ELF class: ELFCLASS32
opened device CPU from pid:37657
scheduled    1 kernels in     3.42 ms | CACHE MISS 36ec5ca9 | 115 uops in cache
(Opt(op=OptOps.UPCAST, axis=1, arg=4), Opt(op=OptOps.UPCAST, axis=0, arg=4), Opt(op=OptOps.UNROLL, axis=0, arg=4), Opt(op=OptOps.THREAD, axis=0, arg=2))
*** CPU        1 r_253_506_2_4_4_506_4                          arg  3 mem   0.05 GB tm    319.54ms/   319.54ms (     52 GFLOPS    0|52     GB/s) ['__mul__', 'sum']
```
### AMD=1
```bash
AMD=1 DEBUG=3 uv run --no-sync test_r.py
scheduled    1 kernels in     3.42 ms | CACHE MISS d67823c1 | 115 uops in cache
loading libc from /usr/lib/libc.so.6
loading libc failed: /usr/lib/libc.so.6: wrong ELF class: ELFCLASS32
loading hsa from /usr/lib/libhsa-runtime64.so
loading libusb from /usr/lib/libusb-1.0.so.0
loading libusb failed: /usr/lib/libusb-1.0.so.0: wrong ELF class: ELFCLASS32
error lowering Ops.SINK
tensor operations:
( Metadata(name='__mul__', caller='', backward=False),
  Metadata(name='sum', caller='', backward=False))
  + Exception Group Traceback (most recent call last):
  |   File "/home/billy/projects/tinygrad/test_r.py", line 6, in <module>
  |     (a.reshape(N, 1, N) * b.T.reshape(1, N, N)).sum(axis=2).realize()
  |   File "/home/billy/projects/tinygrad/tinygrad/tensor.py", line 4018, in _wrapper
  |     ret = fn(*args, **kwargs)
  |           ^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 81, in inner
  |     return func(*args, **kwds)
  |            ^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/tensor.py", line 263, in realize
  |     run_schedule(*Tensor.schedule_with_vars(*to_realize), do_update_stats=do_update_stats)
  |   File "/home/billy/projects/tinygrad/tinygrad/engine/realize.py", line 195, in run_schedule
  |     ei = schedule.pop(0).lower()
  |          ^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/engine/realize.py", line 153, in lower
  |     raise e
  |   File "/home/billy/projects/tinygrad/tinygrad/engine/realize.py", line 147, in lower
  |     try: self.prg = cast(Runner, si_lowerer.rewrite(self.ast, self.bufs))
  |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/uop/ops.py", line 1058, in rewrite
  |     if (ret:=match(uop, ctx)) is not None and ret is not uop: return ret
  |              ^^^^^^^^^^^^^^^
  |   File "<string>", line 3, in compiled_match
  |   File "/home/billy/projects/tinygrad/tinygrad/engine/realize.py", line 128, in <lambda>
  |     (UPat((Ops.SINK, Ops.PROGRAM), name="sink"), lambda ctx,sink: get_runner(ctx[0].device, sink)),
  |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/engine/realize.py", line 114, in get_runner
  |     ckey = (device, type(Device[device].compiler), ast.key, context, False)
  |                          ~~~~~~^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/device.py", line 23, in __getitem__
  |     def __getitem__(self, ix:str) -> Compiled: return self.__get_canonicalized_item(self.canonicalize(ix))
  |                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/device.py", line 29, in __get_canonicalized_item
  |     ret = [cls for cname, cls in inspect.getmembers(importlib.import_module(f'{base}.runtime.ops_{x}')) \
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/runtime/ops_amd.py", line 898, in __init__
  |     self.iface = self._select_iface(KFDIface, PCIIface, USBIface)
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/hcq.py", line 449, in _select_iface
  |     return select_first_inited([functools.partial(cast(Callable, iface), self, self.device_id) for iface in ifaces],
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/billy/projects/tinygrad/tinygrad/helpers.py", line 125, in select_first_inited
  |     raise ExceptionGroup(err_msg, excs)
  | ExceptionGroup: No interface for AMD:0 is available (3 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/billy/projects/tinygrad/tinygrad/helpers.py", line 121, in select_first_inited
    |     x = tuple([cast(Callable, t)() if t is not None else None for t in typ]) if isinstance(typ, Sequence) else cast(Callable, typ)()
    |                                                                                                                ^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/ops_amd.py", line 696, in __init__
    |     KFDIface.event_page = self.alloc(0x8000, uncached=True)
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/ops_amd.py", line 723, in alloc
    |     else: buf, addr = 0, FileIOInterface.anon_mmap(0, size, 0, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS | MAP_NORESERVE, 0)
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/hcq.py", line 47, in anon_mmap
    |     def anon_mmap(start, sz, prot, flags, offset): return FileIOInterface._mmap(start, sz, prot, flags, -1, offset)
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/hcq.py", line 43, in _mmap
    |     x = libc.mmap(start, sz, prot, flags, fd, offset)
    |         ^^^^^^^^^
    | AttributeError: module 'tinygrad.runtime.autogen.libc' has no attribute 'mmap'
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "/home/billy/projects/tinygrad/tinygrad/helpers.py", line 121, in select_first_inited
    |     x = tuple([cast(Callable, t)() if t is not None else None for t in typ]) if isinstance(typ, Sequence) else cast(Callable, typ)()
    |                                                                                                                ^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/ops_amd.py", line 809, in __init__
    |     super().__init__(dev, dev_id, vendor=0x1002, devices=[(0xffff, [0x74a1, 0x744c, 0x7480, 0x7550, 0x7590, 0x75a0])], bars=[0, 2, 5], vram_bar=0,
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/system.py", line 256, in __init__
    |     FileIOInterface.anon_mmap(va_start, va_size, 0, mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS | MAP_NORESERVE | MAP_FIXED, 0)
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/hcq.py", line 47, in anon_mmap
    |     def anon_mmap(start, sz, prot, flags, offset): return FileIOInterface._mmap(start, sz, prot, flags, -1, offset)
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/hcq.py", line 43, in _mmap
    |     x = libc.mmap(start, sz, prot, flags, fd, offset)
    |         ^^^^^^^^^
    | AttributeError: module 'tinygrad.runtime.autogen.libc' has no attribute 'mmap'
    +---------------- 3 ----------------
    | Traceback (most recent call last):
    |   File "/home/billy/projects/tinygrad/tinygrad/helpers.py", line 121, in select_first_inited
    |     x = tuple([cast(Callable, t)() if t is not None else None for t in typ]) if isinstance(typ, Sequence) else cast(Callable, typ)()
    |                                                                                                                ^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/ops_amd.py", line 864, in __init__
    |     self.dev, self.pci_dev = dev, USBPCIDevice(dev.__class__.__name__[:2], f"usb:{dev_id}", bars=[0, 2, 5])
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/system.py", line 235, in __init__
    |     self.usb = ASM24Controller()
    |                ^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/usb.py", line 117, in __init__
    |     self.usb = USB3(0xADD1, 0x0001, 0x81, 0x83, 0x02, 0x04)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/billy/projects/tinygrad/tinygrad/runtime/support/usb.py", line 14, in __init__
    |     if libusb.libusb_init(ctypes.byref(self.ctx)): raise RuntimeError("libusb_init failed")
    |        ^^^^^^^^^^^^^^^^^^
    | AttributeError: module 'tinygrad.runtime.autogen.libusb' has no attribute 'libusb_init'
    +------------------------------------
```
after:
```bash
DEBUG=3 uv run --no-sync test_r.py
loading libc from /usr/lib64/libc.so.6
loading hsa from /usr/lib64/libhsa-runtime64.so.1
loading libusb from /usr/lib64/libusb-1.0.so.0
AMDDevice: opening 0 with target (11, 0, 0) arch gfx1100
opened device AMD from pid:37582
scheduled    1 kernels in     3.49 ms | CACHE MISS d67823c1 | 115 uops in cache
loading comgr from /usr/lib64/libamd_comgr.so.3
loading comgr_3 from /usr/lib64/libamd_comgr.so.3
loading llvm from /usr/lib64/libLLVM-21.so
(Opt(op=OptOps.UPCAST, axis=1, arg=4), Opt(op=OptOps.UPCAST, axis=0, arg=4), Opt(op=OptOps.UNROLL, axis=0, arg=4), Opt(op=OptOps.LOCAL, axis=0, arg=2), Opt(op=OptOps.LOCAL, axis=1, arg=2))
*** AMD        1 r_253_253_2_2_4_4_506_4                        arg  3 mem   0.05 GB tm     13.73ms/    13.73ms (   1208 GFLOPS    4|1209   GB/s) ['__mul__', 'sum']
```
### AMD=1
```bash
AMD=1 DEBUG=3 uv run --no-sync test_r.py
scheduled    1 kernels in     3.47 ms | CACHE MISS d67823c1 | 115 uops in cache
loading libc from /usr/lib64/libc.so.6
loading hsa from /usr/lib64/libhsa-runtime64.so.1
loading libusb from /usr/lib64/libusb-1.0.so.0
AMDDevice: opening 0 with target (11, 0, 0) arch gfx1100
opened device AMD from pid:38594
loading comgr from /usr/lib64/libamd_comgr.so.3
loading comgr_3 from /usr/lib64/libamd_comgr.so.3
loading llvm from /usr/lib64/libLLVM-21.so
(Opt(op=OptOps.UPCAST, axis=1, arg=4), Opt(op=OptOps.UPCAST, axis=0, arg=4), Opt(op=OptOps.UNROLL, axis=0, arg=4), Opt(op=OptOps.LOCAL, axis=0, arg=2), Opt(op=OptOps.LOCAL, axis=1, arg=2))
*** AMD        1 r_253_253_2_2_4_4_506_4                        arg  3 mem   0.05 GB tm     15.96ms/    15.96ms (   1039 GFLOPS    3|1040   GB/s) ['__mul__', 'sum']
```

## Arch Linux
before:
```bash
DEBUG=3 uv run --no-sync test_r.py
loading libc from /usr/lib/libc.so.6
loading hsa failed: not found on system
loading libusb from /usr/lib/libusb-1.0.so
loading nvrtc failed: not found on system
loading nvjitlink failed: not found on system
loading mesa failed: not found on system
loading cuda failed: not found on system
loading opencl from /usr/lib/libOpenCL.so
CLDevice: got 2 platforms and 1 devices
...
```
after:
```bash
DEBUG=3 uv run --no-sync test_r.py
loading libc from /usr/lib64/libc.so.6
loading hsa failed: not found on system
loading libusb from /usr/lib64/libusb-1.0.so
loading nvrtc failed: not found on system
loading nvjitlink failed: not found on system
loading mesa failed: not found on system
loading cuda failed: not found on system
loading opencl from /usr/lib64/libOpenCL.so
CLDevice: got 2 platforms and 1 devices
...
```