### PR TITLE
fix: CPU_COUNT respects ContextVar in ClangRenderer

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -224,7 +224,9 @@ class ClangRenderer(CStyleLanguage):
   gep_arr_threshold = 0
   has_local = False
   has_threads = bool(getenv("THREADS", 1))
-  global_max = (CPU_COUNT.value, 0, 0)
+  # global_max is a property to respect ContextVar changes at runtime
+  @property
+  def global_max(self) -> tuple[int, int, int]: return (CPU_COUNT.value, 0, 0)
   infinity = "__builtin_inff()"
   nan = '__builtin_nanf("")'
   code_for_workitem = {"g": lambda _: "core_id"}


### PR DESCRIPTION
## Summary
- Fixed #13534: `CPU_COUNT` ContextVar was not respected in ClangRenderer's `global_max`
- Changed `global_max` from a class attribute to a `@property` that evaluates at runtime

## Test
```python
with Context(CPU_COUNT=4):
    # kernel now correctly shows: core_id; /* 4 */
    
with Context(CPU_COUNT=2):
    # kernel now correctly shows: core_id; /* 2 */
```