### PR TITLE
assembly/amd: handwritten wmma failing test

### DIFF
--- a/extra/assembly/amd/test/test_handwritten.py
+++ b/extra/assembly/amd/test/test_handwritten.py
@@ -21,6 +21,9 @@ class TestIntegration(unittest.TestCase):
     self.assertEqual(repr(self.inst), repr(reasm))
     print(desc)
 
+  def test_wmma(self):
+    self.inst = v_wmma_f32_16x16x16_f16(v[0:7], v[189:192], v[140:143], v[0:7])
+
   def test_load_b128(self):
     self.inst = s_load_b128(s[4:7], s[0:1], NULL, 0)
 


### PR DESCRIPTION
per the LLVM tests, op_sel_hi isn't a valid operand for v_wmma https://github.com/llvm/llvm-project/blob/fdc393f9ee12c4069f9f04374e62f5c36a617298/llvm/test/MC/AMDGPU/gfx12_asm_wmma_w64.s#L10

The document says:
> OPSEL[0] and [1] are unused for WMMA ops, and OPSEL[2] is used only with WMMA ops with 16-bit
output to control whether the C matrix is read from upper or lower bits in the VGPR, and whether
the D matrix is stored into upper or lower bits