### PR TITLE
roc: propagate decoder errors to main thread

### DIFF
--- a/extra/sqtt/roc.py
+++ b/extra/sqtt/roc.py
@@ -117,8 +117,9 @@ def decode(sqtt_evs:list[ProfileSQTTEvent], disasms:dict[str, dict[int, tuple[st
   def worker():
     nonlocal exc
     try: rocprof.rocprof_trace_decoder_parse_data(copy_cb, trace_cb, isa_cb, None)
-    except AttributeError:
+    except AttributeError as e:
       exc = RuntimeError("Failed to find rocprof-trace-decoder. Run sudo ./extra/sqtt/install_sqtt_decoder.py to install")
+      exc.__cause__ = e
   (t:=threading.Thread(target=worker, daemon=True)).start()
   t.join()
   if exc is not None:


### PR DESCRIPTION
enables VIZ to show an error message in the UI if decoder isn't installed:
<img width="3024" height="528" alt="image" src="https://github.com/user-attachments/assets/29098bc4-6007-4a3b-9816-93511e31dc34" />
