### PR TITLE
assembly/amd: use Tensor.custom_kernel to run assembly

### DIFF
--- a/extra/gemm/amd_asm_matmul.py
+++ b/extra/gemm/amd_asm_matmul.py
@@ -591,7 +591,6 @@ def test_matmul():
     print(f"Loaded stock kernel from {stock_path}")
   else:
     asm = build_kernel(dev.arch)
-  if getenv("PRINT_ASM", 0): print(asm)
 
   binary = dev.compiler.compile(asm)
   print(f"Compiled! Binary size: {len(binary)} bytes")


### PR DESCRIPTION
This enables showing the CFG and source code in VIZ
<img width="3024" height="1732" alt="image" src="https://github.com/user-attachments/assets/cfe2297a-8959-48f6-a46e-1c4f7ca1d061" />

Also, you no longer need PRINT_ASM since DEBUG=4 works.