### PR TITLE
cuda compilers disassemble properly

### DIFF
--- a/tinygrad/runtime/support/compiler_cuda.py
+++ b/tinygrad/runtime/support/compiler_cuda.py
@@ -38,7 +38,7 @@ def cuda_disassemble(lib:bytes, arch:str, ptx=False):
   try:
     fn = (pathlib.Path(tempfile.gettempdir()) / f"tinycuda_{hashlib.md5(lib).hexdigest()}").as_posix()
     with open(fn, "wb") as f: f.write(lib.rstrip(b'\x00') if ptx else lib)
-    if ptx: subprocess.run(["ptxas", f"-arch={arch}", "-o", fn, fn], check=False, stderr=subprocess.DEVNULL) # optional ptx -> sass step for CUDA=1
+    if ptx: system(f"ptxas -arch={arch} -o {fn} {fn}")
     print(system(f'nvdisasm {fn}'))
   except Exception as e: print("Failed to generate SASS", str(e), "Make sure your PATH contains ptxas/nvdisasm binary of compatible version.")
 


### PR DESCRIPTION
`DEBUG=7 NV=1 python3 test/test_ops.py TestOps.test_add` gives:

```
nvdisasm fatal   : File /tmp/tinycuda_545dba5d319ccb27f198f9ed96fc8837 is an invalid ELF file
Failed to generate SASS Command '['nvdisasm', '/tmp/tinycuda_545dba5d319ccb27f198f9ed96fc8837']' returned non-zero exit status 1. Make sure your PATH contains ptxas/nvdisasm binary of compatible version.
```

Because of rstrip.