### PR TITLE
viz: fix wave sort, show message if sqtt trace is empty

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -284,13 +284,8 @@ def sqtt_timeline(e) -> list[ProfileEvent]:
   ret:list[ProfileEvent] = []
   rows:dict[str, None] = {}
   def add(name:str, p:PacketType, idx=0, width=1) -> None:
-    if hasattr(p, "wave"):
-      for w in [p.wave, p.wave+10]:
-        rows.setdefault(r:=(f"WAVE:{w}" if hasattr(p, "wave") else f"{p.__class__.__name__}:0 {name}"))
-        ret.append(ProfileRangeEvent(r, f"{name} OP:{idx}", Decimal(p._time), Decimal(p._time+width)))
-    else:
-      rows.setdefault(r:=(f"WAVE:{w}" if hasattr(p, "wave") else f"{p.__class__.__name__}:0 {name}"))
-      ret.append(ProfileRangeEvent(r, f"{name} OP:{idx}", Decimal(p._time), Decimal(p._time+width)))
+    rows.setdefault(r:=(f"WAVE:{p.wave}" if hasattr(p, "wave") else f"{p.__class__.__name__}:0 {name}"))
+    ret.append(ProfileRangeEvent(r, f"{name} OP:{idx}", Decimal(p._time), Decimal(p._time+width)))
   for p in decode(e.blob):
     if len(ret) > 50_000: break
     if isinstance(p, INST):


### PR DESCRIPTION
happens in SE:0 trace of smaller kernels, where only SE:1 captures the instruction trace.