### PR TITLE
skip lvp process replay in CI [pr]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -759,6 +759,7 @@ jobs:
       - name: Run TRANSCENDENTAL math
         run: TRANSCENDENTAL=2 python -m pytest -n=auto test/test_ops.py::TestOps::test_sin test/test_ops.py::TestOps::test_cos test/test_ops.py::TestOps::test_tan test/test_ops.py::TestOps::test_exp test/test_ops.py::TestOps::test_log --durations=20
       - name: Run process replay tests
+        if: matrix.backend != 'lvp'
         uses: ./.github/actions/process-replay
 
 # ****** OSX Tests ******
@@ -888,6 +889,7 @@ jobs:
       - name: Run pytest (${{ matrix.backend }})
         run: python3 -m pytest -n=auto test/ --ignore=test/models --ignore=test/unit --durations=20
       - name: Run process replay tests
+        if: matrix.backend != 'lvp'
         uses: ./.github/actions/process-replay
       - name: Run macOS-specific unit test
         if: matrix.backend == 'cpu'


### PR DESCRIPTION
After https://github.com/tinygrad/tinygrad/commit/0cb024a5bb85b1ccc4db50c6e846aea5aa3b5f96 LVP render output became non deterministic.

Simple standalone repro:
Passes with CPU=1 CPU_LVP=1 on 255e0573b, fails on 0cb024a5b.
```
from tinygrad import Tensor, Device
from tinygrad.uop.ops import KernelInfo
from tinygrad.engine.realize import get_program

renderer = Device[Device.DEFAULT].renderer

def custom_kernel(C):
  return C[0].store(1).sink(arg=KernelInfo(name="custom_name"))
a = Tensor.empty(4)
a = Tensor.custom_kernel(a, fxn=custom_kernel)[0]
ast = a.schedule()[0].ast

p1 = get_program(ast, renderer)
p2 = get_program(ast, renderer)
assert p1.src == p2.src
```


If you wanna integration test with process replay:
```
test/external/process_replay/reset.py
CAPTURE_PROCESS_REPLAY=1 CPU=1 CPU_LVP=1 python test/test_tiny.py TestTiny.test_plus
test/external/process_replay/process_replay.py
```