### PR TITLE
remove dtypes.index_like and dtypes.fields [pr]

### DIFF
--- a/test/test_const_folding.py
+++ b/test/test_const_folding.py
@@ -1,6 +1,6 @@
 import unittest, itertools, math
 from tinygrad import Tensor, Device, dtypes, Context
-from tinygrad.dtype import DType, ConstType
+from tinygrad.dtype import DType, ConstType, DTYPES_DICT
 from tinygrad.uop.ops import Ops, UOp
 from tinygrad.codegen import full_rewrite_to_sink
 from tinygrad.device import is_dtype_supported
@@ -237,7 +237,7 @@ class TestReduceOpsConstFolding(unittest.TestCase):
 
   def test_sum_output_dtype(self):
     # sum output dtype can be different from input
-    for dt in dtypes.fields().values():
+    for dt in DTYPES_DICT.values():
       if is_dtype_supported(dt):
         t = Tensor.ones(16, dtype=dt).reshape(4, 4)
         assert t.sum().dtype == t.contiguous().sum().dtype

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -102,13 +102,12 @@ class TestDType(unittest.TestCase):
     _test_to_np(Tensor(v, dtype=self.DTYPE)+2, _to_np_dtype(self.DTYPE), np.array(v, dtype=_to_np_dtype(self.DTYPE))+2)
     _test_to_np(Tensor(v, dtype=self.DTYPE)*2, _to_np_dtype(self.DTYPE), np.array(v, dtype=_to_np_dtype(self.DTYPE))*2)
 
-  def test_dtypes_fields(self):
-    fields = dtypes.fields()
-    self.assertIn("float", fields)
-    self.assertIn("float32", fields)
-    self.assertEqual(len(fields), 26)
-    self.assertTrue(all(isinstance(value, DType) for value in fields.values()))
-    self.assertTrue(all(issubclass(_to_np_dtype(value), np.generic) for value in fields.values() if _to_np_dtype(value) is not None))
+  def test_dtypes_DTYPES_DICT(self):
+    self.assertIn("float", DTYPES_DICT)
+    self.assertIn("float32", DTYPES_DICT)
+    self.assertEqual(len(DTYPES_DICT), 26)
+    self.assertTrue(all(isinstance(value, DType) for value in DTYPES_DICT.values()))
+    self.assertTrue(all(issubclass(_to_np_dtype(value), np.generic) for value in DTYPES_DICT.values() if _to_np_dtype(value) is not None))
 
   def test_resulting_and_init_dtypes_match(self):
     dtypes = list(map(np.dtype, ["bool", "uint8", "int8", "int16", "int32", "int64", "float32", "float64"]))

--- a/test/test_tensor.py
+++ b/test/test_tensor.py
@@ -11,7 +11,7 @@ from tinygrad.uop.ops import Ops, UOp
 from tinygrad.renderer.ptx import PTXRenderer
 from tinygrad.renderer.nir import NIRRenderer
 from tinygrad.engine.realize import get_program
-from tinygrad.dtype import DType
+from tinygrad.dtype import DType, DTYPES_DICT
 
 settings.register_profile("my_profile", max_examples=200, deadline=None, derandomize=getenv("DERANDOMIZE_CI", False))
 settings.load_profile("my_profile")
@@ -353,7 +353,7 @@ class TestTinygrad(unittest.TestCase):
       assert Tensor(arr).tolist() == torch.tensor(arr).tolist() == arr
 
   def test_element_size(self):
-    for _, dtype in dtypes.fields().items():
+    for _, dtype in DTYPES_DICT.items():
       assert dtype.itemsize == Tensor.randn(3, dtype=dtype).element_size(), f"Tensor.element_size() not matching Tensor.dtype.itemsize for {dtype}"
 
   def test_deepwalk_ctx_check(self):

--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -2,7 +2,7 @@ import os, pathlib, tempfile, unittest
 import numpy as np
 from tinygrad import Tensor, Device, dtypes
 from tinygrad.device import is_dtype_supported
-from tinygrad.dtype import DType
+from tinygrad.dtype import DType, DTYPES_DICT
 from tinygrad.nn.state import safe_load, safe_save, get_state_dict, torch_load
 from tinygrad.helpers import Timing, fetch, temp, OSX
 from test.helpers import slow
@@ -164,7 +164,7 @@ class TestSafetensors(unittest.TestCase):
     assert json.loads(dat[8:8+sz])['__metadata__']['hello'] == 'world'
 
   def test_save_all_dtypes(self):
-    for dtype in dtypes.fields().values():
+    for dtype in DTYPES_DICT.values():
       if dtype in [dtypes.bfloat16]: continue # not supported in numpy
       if not is_dtype_supported(dtype): continue
       path = temp(f"ones.{dtype}.safetensors")

--- a/tinygrad/dtype.py
+++ b/tinygrad/dtype.py
@@ -119,7 +119,7 @@ class dtypes:
   def is_float(x: DType) -> bool: return x.scalar() in dtypes.floats or isinstance(x, ImageDType)
   @staticmethod # static methods on top, or bool in the type info will refer to dtypes.bool
   @functools.cache
-  def is_int(x: DType) -> bool: return x.scalar() in dtypes.index_like
+  def is_int(x: DType) -> bool: return x.scalar() in (dtypes.ints + (dtypes.index,))
   @staticmethod
   @functools.cache
   def is_unsigned(x: DType) -> bool: return x.scalar() in dtypes.uints
@@ -158,8 +158,6 @@ class dtypes:
     if not dtypes.is_float(dtype): raise ValueError(f"{dtype} is not a floating point type")
     return {dtypes.float16: (5, 10), dtypes.bfloat16: (8, 7), dtypes.float32: (8, 23), dtypes.float64: (11, 52),
             dtypes.fp8e5m2: (5, 2), dtypes.fp8e4m3: (4, 3)}[dtype]
-  @staticmethod
-  def fields() -> dict[str, DType]: return DTYPES_DICT
   void: Final[DType] = DType.new(-1, 0, "void", None)
   index: Final[DType] = DType.new(-1, 800, "index", None)
   bool: Final[DType] = DType.new(0, 1, "bool", '?')
@@ -198,7 +196,6 @@ class dtypes:
   uints = (uint8, uint16, uint32, uint64)
   sints = (int8, int16, int32, int64)
   ints = uints + sints
-  index_like = ints + (index,)
   all = floats + ints + (bool, index) # noqa: A003
 
 if (env_default_float := getenv("DEFAULT_FLOAT", "")):
@@ -343,7 +340,7 @@ def _to_np_dtype(dtype:DType) -> type|None:
   return np.dtype(dtype.fmt).type if dtype.fmt is not None else None
 def _from_np_dtype(npdtype:'np.dtype') -> DType: # type: ignore [name-defined] # noqa: F821
   import numpy as np
-  return dtypes.fields()[np.dtype(npdtype).name]
+  return DTYPES_DICT[np.dtype(npdtype).name]
 
 @functools.cache
 def _to_torch_dtype(dtype:DType) -> 'torch.dtype'|None:  # type: ignore [name-defined] # noqa: F821

--- a/tinygrad/nn/onnx.py
+++ b/tinygrad/nn/onnx.py
@@ -5,7 +5,7 @@ from io import BufferedReader
 from tinygrad.nn.state import TensorIO
 from tinygrad.tensor import Tensor, _broadcast_shape, ReductionStr
 from tinygrad.helpers import getenv, DEBUG, all_same, prod, flatten, make_tuple, argsort, is_numpy_ndarray, get_single_element, polyN
-from tinygrad.dtype import DType, ConstType, dtypes, _from_np_dtype, truncate, least_upper_dtype
+from tinygrad.dtype import DType, ConstType, dtypes, _from_np_dtype, truncate, least_upper_dtype, DTYPES_DICT
 from tinygrad.device import is_dtype_supported, Device
 
 # ***** protobuf definitions ******
@@ -33,7 +33,7 @@ class OnnxDataType(enum.IntEnum):
   FLOAT = 1; UINT8 = 2; INT8 = 3; UINT16 = 4; INT16 = 5; INT32 = 6; INT64 = 7; BOOL = 9; FLOAT16 = 10; DOUBLE = 11; UINT32 = 12 # noqa: E702
   UINT64 = 13; BFLOAT16 = 16 # noqa: E702
 
-  def to_dtype(self) -> DType: return dtypes.fields()[self.name.lower()]
+  def to_dtype(self) -> DType: return DTYPES_DICT[self.name.lower()]
 
 def dtype_fallback(dtype: DType, fallback_context: str) -> DType:
   if is_dtype_supported(dtype): return dtype


### PR DESCRIPTION
barely used, so just use inline and DTYPES_DICT