### PR TITLE
viz: add border colors to pkts timeline

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -482,7 +482,7 @@ async function renderProfiler(path, unit, opts) {
     const paths = [];
     for (const [_, { shapes, eventType, visible, offsetY, valueMap, pcolor, scolor }] of data.tracks) {
       visible.length = 0;
-      const addBorder = scolor != null ? (p,w) => { if (w > 20) { ctx.strokeStyle = scolor; ctx.stroke(p); } } : null;
+      const addBorder = scolor != null ? (p,w) => { if (w > 10) { ctx.strokeStyle = scolor; ctx.stroke(p); } } : null;
       for (const e of shapes) {
         const p = new Path2D();
         if (eventType === EventTypes.BUF) { // generic polygon


### PR DESCRIPTION
Now you can see at a glance how many dispatches happened:
<img width="3024" height="590" alt="image" src="https://github.com/user-attachments/assets/a1f33894-23b8-40be-b55f-9ccdb572c355" />
new lightup color for packets is bright green
<img width="3024" height="590" alt="image" src="https://github.com/user-attachments/assets/a64a0b9a-f8c6-4dd0-9301-c27041ba6fcc" />
