### PR TITLE
Add torch.compile backend with TinyJit caching

### DIFF
--- a/extra/torch_backend/test_compile.py
+++ b/extra/torch_backend/test_compile.py
@@ -1,36 +1,63 @@
 # https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html
+import unittest
 import torch
 import torch._dynamo
-from extra.torch_backend.backend import unwrap, wrap
+import extra.torch_backend.backend  # noqa: F401 # registers the "tiny" backend
 
-from torch._dynamo.backends.registry import register_backend
-from torch._functorch.aot_autograd import aot_module_simplified
+class TestTorchCompile(unittest.TestCase):
+  def test_torch_compile_basic(self):
+    """Test that torch.compile with the tiny backend works."""
+    def foo(x, y):
+      a = torch.sin(x)
+      b = torch.cos(y)
+      return a + b
 
-from tinygrad import Tensor, TinyJit
+    opt_foo = torch.compile(foo, backend="tiny")
+    # run multiple times to test caching
+    for _ in range(5):
+      out = opt_foo(torch.randn(10, 10), torch.randn(10, 10))
+      # outputs are on CPU when inputs are CPU (for backward compatibility)
+      self.assertEqual(str(out.device), "cpu")
 
-@register_backend
-def tiny(gm:torch.fx.GraphModule, sample_inputs):
-  def my_compiler(gm:torch.fx.GraphModule, sample_inputs):
-    # TODO: the jit should capture the graph directly, not need three runs. this is a planned tinygrad refactor after becomes_map
-    @TinyJit
-    def tiny_function(*args:Tensor):
-      outs = gm(*[wrap(x) for x in args])
-      for x in outs: unwrap(x).realize()
-      return outs
-    # TODO: this should be able to pass in .tiny() Tensors, not need to convert them. it tries to access Storage if you pass in.
-    def torch_function(*args:torch.Tensor): return tiny_function(*[unwrap(x.tiny()) for x in args])
-    return torch_function
-  return aot_module_simplified(gm, sample_inputs, decompositions={}, fw_compiler=my_compiler)
+  def test_torch_compile_backward(self):
+    """Test that backward pass works with torch.compile tiny backend."""
+    @torch.compile(backend="tiny")
+    def matmul(x, w):
+      return x @ w
+
+    x = torch.randn(4, 8, requires_grad=True)
+    w = torch.randn(8, 4, requires_grad=True)
+
+    out = matmul(x, w)
+    loss = out.sum()
+    loss.backward()
+
+    self.assertEqual(x.grad.shape, x.shape)
+    self.assertEqual(w.grad.shape, w.shape)
+
+  def test_torch_compile_model(self):
+    """Test that a compiled model can train."""
+    class SimpleModel(torch.nn.Module):
+      def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(16, 10)
+      def forward(self, x):
+        return self.fc(x)
+
+    model = torch.compile(SimpleModel(), backend="tiny")
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    loss_fn = torch.nn.CrossEntropyLoss()
+
+    # training step
+    x = torch.randn(4, 16)
+    y = torch.randint(0, 10, (4,))
+    out = model(x)
+    loss = loss_fn(out, y)
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+
+    self.assertIsInstance(loss.item(), float)
 
 if __name__ == "__main__":
-  def foo(x, y):
-    a = torch.sin(x)
-    b = torch.cos(y)
-    return a + b
-
-  print("calling compile")
-  opt_foo1 = torch.compile(foo, backend="tiny")
-  print("compiled")
-  for i in range(5):
-    out = opt_foo1(torch.randn(10, 10), torch.randn(10, 10))
-    print(out.device)
+  unittest.main()


### PR DESCRIPTION
## Summary
- Registers a `tiny` backend for `torch.compile` that routes graph operations through tinygrad with TinyJit caching
- Adds `TORCH_COMPILE=1` flag to `beautiful_mnist_torch.py` for opt-in torch.compile mode
- Adds batch norm decomposition for training support

This addresses the $300 bounty: "beautiful_mnist_torch uses torch.compile TinyJIT working with TINY_BACKEND=1"

## Test plan
- [x] `python -m pytest extra/torch_backend/test_compile.py -xvs` passes
- [x] `TINY_BACKEND=1 TORCH_COMPILE=1 python examples/other_mnist/beautiful_mnist_torch.py` trains successfully
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)