### PR TITLE
add tensor-tensor shift support and ONNX BitShift op

### DIFF
--- a/test/external/external_test_onnx_backend.py
+++ b/test/external/external_test_onnx_backend.py
@@ -115,9 +115,6 @@ backend_test.exclude('test_dequantizelinear_float4e2m1_cpu')
 backend_test.exclude('test_pow_types_int32_int32_cpu')
 backend_test.exclude('test_pow_types_int64_int64_cpu')
 
-# no boolean ops (2d, 3d, 4d)
-backend_test.exclude('test_bitshift_*')
-
 # no string ops
 backend_test.exclude('string')
 backend_test.exclude('test_strnorm_*')

--- a/tinygrad/nn/onnx.py
+++ b/tinygrad/nn/onnx.py
@@ -642,6 +642,7 @@ def get_onnx_ops() -> dict[str, types.FunctionType|dict[OpSetId, types.FunctionT
   def BitwiseOr(x:Tensor,y:Tensor): return x | y
   def BitwiseXor(x:Tensor,y:Tensor): return x ^ y
   def BitwiseNot(x:Tensor): return ~x
+  def BitShift(X: Tensor, Y:Tensor, direction:str): return X << Y if direction == "LEFT" else X >> Y
   def Mod(x:Tensor,y:Tensor,fmod=0): return x - x.div(y, rounding_mode="trunc") * y if fmod else x % y
 
   # ***** Casting Ops *****

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -3276,8 +3276,11 @@ class Tensor(OpMixin):
     print(Tensor([1, 3, 31], dtype=dtypes.uint8).lshift(2).numpy())
     ```
     """
-    assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0 and not reverse, f"not supported {self.dtype=} {x=}"
-    return self.mul(2 ** x, reverse)
+    assert dtypes.is_unsigned(self.dtype), f"lshift not supported for {self.dtype=}"
+    if isinstance(x, int):
+      assert x >= 0 and not reverse, f"not supported {x=} {reverse=}"
+      return self.mul(2 ** x)
+    return self._binop(Ops.SHL, x, reverse)
 
   def rshift(self, x:Tensor|int, reverse=False) -> Tensor:
     """
@@ -3288,8 +3291,11 @@ class Tensor(OpMixin):
     print(Tensor([4, 13, 125], dtype=dtypes.uint8).rshift(2).numpy())
     ```
     """
-    assert dtypes.is_unsigned(self.dtype) and isinstance(x, int) and x >= 0 and not reverse, f"not supported {self.dtype=} {x=}"
-    return self.idiv(2 ** x, reverse)
+    assert dtypes.is_unsigned(self.dtype), f"rshift not supported for {self.dtype=}"
+    if isinstance(x, int):
+      assert x >= 0 and not reverse, f"not supported {x=} {reverse=}"
+      return self.idiv(2 ** x)
+    return self._binop(Ops.SHR, x, reverse)
 
   def pow(self, x:Tensor|ConstType, reverse=False) -> Tensor:
     """


### PR DESCRIPTION
- Adds support for `Tensor << Tensor` and `Tensor >> Tensor` using `Ops.SHL`/`Ops.SHR`
- Adds ONNX BitShift op
- Enables 8 previously excluded ONNX backend tests

Let me know if you would like something else done. 