### PR TITLE
fix: handle readonly memoryviews in from_mv

### DIFF
--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -230,6 +230,11 @@ class TestMemoryview(unittest.TestCase):
     mv[0] = 2
     assert base[0] == 2
 
+  def test_from_mv_readonly(self):
+    base = memoryview(b"\x11\x22\x33")
+    ct = from_mv(base)
+    self.assertEqual(bytes(ct), b"\x11\x22\x33")
+
   @unittest.skip("allocates tons of memory")
   def test_to_mv(self):
     sizes = [

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -435,8 +435,8 @@ def wait_cond(cb, *args, value=True, timeout_ms=10000, msg="") -> bool:
 
 # *** ctypes helpers
 
-# TODO: make this work with read only memoryviews (if possible)
 def from_mv(mv:memoryview, to_type:type[ctypes._SimpleCData]=ctypes.c_char) -> ctypes.Array:
+  if mv.readonly: return (to_type * len(mv)).from_buffer_copy(mv)
   return ctypes.cast(ctypes.addressof(to_type.from_buffer(mv)), ctypes.POINTER(to_type * len(mv))).contents
 def to_mv(ptr:int, sz:int) -> memoryview: return memoryview((ctypes.c_uint8 * sz).from_address(ptr)).cast("B")
 def mv_address(mv): return ctypes.addressof(ctypes.c_char.from_buffer(mv))


### PR DESCRIPTION
### What
Handle readonly `memoryview` inputs in `from_mv` using `from_buffer_copy`. Also added a regression test.

### Why
`ctypes.from_buffer` requires writable buffers and can return incorrect bytes for read-only views.

### Tests:
`python3 -m pytest test/unit/test_helpers.py -k memoryview`

<img width="1039" height="131" alt="Screenshot 2026-01-21 at 09 19 43" src="https://github.com/user-attachments/assets/72337d5c-c182-4593-aca3-f0f2deab5c5c" />
