### PR TITLE
failed test case for shrink overlap assigns

### DIFF
--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -415,6 +415,8 @@ class TestAssign(unittest.TestCase):
 
   # TODO: is there a way to sneak in a permute such that it returns the wrong answer?
 
+  # NOTE: overlapping shrink assign tests are WIP, behavior depends on backend/thread ordering
+  @unittest.skip("WIP: not a stable test, relies on undefined behavior")
   def test_overlapping_shrink_assignment_forward(self):
     # Forward shift: read index > write index in overlap - works by thread ordering luck
     N = 100000
@@ -425,6 +427,7 @@ class TestAssign(unittest.TestCase):
     with Context(NOOPT=1): a[0:N-shift].assign(a[shift:N]).realize()
     np.testing.assert_allclose(a.numpy(), expected)
 
+  @unittest.skip("WIP: not a stable test, relies on undefined behavior")
   @unittest.expectedFailure
   def test_overlapping_shrink_assignment_reverse(self):
     # Reverse shift: write index > read index in overlap - race condition!
@@ -437,6 +440,7 @@ class TestAssign(unittest.TestCase):
     with Context(NOOPT=1): a[shift:N].assign(a[0:N-shift]).realize()
     np.testing.assert_allclose(a.numpy(), expected)
 
+  @unittest.skip("WIP: not a stable test, relies on undefined behavior")
   def test_overlapping_shrink_assignment_reverse_with_contiguous(self):
     # Adding .contiguous() forces a copy, fixing the race
     N = 100000


### PR DESCRIPTION
current logic can create a race resulted in wrong output