### PR TITLE
assembly/amd: add dsl tests to mac ci

### DIFF
--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -292,7 +292,9 @@ runs:
     - name: Install LLVM (macOS)
       if: inputs.llvm == 'true' && runner.os == 'macOS'
       shell: bash
-      run: brew install llvm@20
+      run: |
+        brew install llvm@20
+        echo "$(brew --prefix llvm@20)/bin" >> "$GITHUB_PATH"
 
     # **** mesa ****
     - name: Install mesa (linux)

--- a/extra/assembly/amd/test/helpers.py
+++ b/extra/assembly/amd/test/helpers.py
@@ -14,7 +14,7 @@ class KernelInfo:
 # LLVM tool detection (shared across test files)
 def get_llvm_mc():
   """Find llvm-mc executable, preferring newer versions."""
-  for p in ['/opt/homebrew/bin/llvm-mc', 'llvm-mc', 'llvm-mc-21', 'llvm-mc-20']:
+  for p in ['llvm-mc', 'llvm-mc-21', 'llvm-mc-20']:
     if shutil.which(p): return p
   raise FileNotFoundError("llvm-mc not found")
 


### PR DESCRIPTION
The failure in `PYTHONPATH=. python extra/assembly/amd/test/hw/test_vop2.py TestSpecialFloatValues.test_denormal_f32_mul_ftz` is a real issue. Linux python3.12 is right, Mac python3.12 is wrong