### PR TITLE
also skip test_overlapping_shrink_assignment_reverse

### DIFF
--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -426,6 +426,7 @@ class TestAssign(unittest.TestCase):
     with Context(NOOPT=1): a[0:N-shift].assign(a[shift:N]).realize()
     np.testing.assert_allclose(a.numpy(), expected)
 
+  @unittest.skip("this test is crashing!")
   def test_overlapping_shrink_assignment_reverse(self):
     # Reverse shift: write index > read index in overlap
     N = 100000


### PR DESCRIPTION
crashing