### PR TITLE
failing multi ram usage test from llama gemm

### DIFF
--- a/test/test_multitensor.py
+++ b/test/test_multitensor.py
@@ -1251,6 +1251,21 @@ class TestMultiRamUsage(unittest.TestCase):
     _ = Tensor.zeros(self.N, self.N).contiguous().shard(devices_2, axis=0).contiguous().realize()
     self.assertUsed(self.N*self.N*4) # sharding should not increase total ram usage
 
+  def _test_matmul_half(self, devs):
+    N = 32
+    total_mem = {}
+    for dtype in {dtypes.float, dtypes.half}:
+      GlobalCounters.reset()
+      a = Tensor.empty((N, N), dtype=dtype).shard(devs, axis=0)
+      b = Tensor.empty((N, N), dtype=dtype).shard(devs, axis=None)
+      (a @ b).realize()
+      total_mem[dtype] = GlobalCounters.global_mem
+    self.assertEqual(total_mem[dtypes.half], total_mem[dtypes.float] // 2)
+
+  def test_matmul_half(self): self._test_matmul_half(devices_2)
+  @unittest.expectedFailure
+  def test_matmul_half_alt(self): self._test_matmul_half(devices_4)
+
 @unittest.skipIf(not_support_multi_device(), "need multi")
 class TestMultiFromUnrenderable(unittest.TestCase):
   @needs_second_gpu


### PR DESCRIPTION
multi is storing the w (originally bf16) in float in global memory before gemm