### PR TITLE
ci: remove unused pydeps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
       uses: ./.github/actions/setup-tinygrad
       with:
         deps: docs
+        pydeps: "capstone torch"
     - name: Build wheel and show size
       run: |
         pip install build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,6 @@ docs = [
   "markdown-exec[ansi]",
   "black",
   "numpy",
-  "capstone",
-  "torch",
 ]
 
 


### PR DESCRIPTION
deduping venvs will require installing more deps than necessary