### PR TITLE
fix recursion error calculating UOp key

### DIFF
--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -134,7 +134,7 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     if (self.op, self.dtype, self.src, self.arg, self.tag) == new_args: return self
     return UOp(*new_args)
   def rtag(self, tag=True): return self.replace(tag=tag)
-  @functools.cached_property
+  @recursive_property
   def key(self) -> bytes:
     return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
   def __repr__(self): return pretty_print(self)


### PR DESCRIPTION
Fixes the following error I'm getting building openpilot on WSL:

```
...
  File "/home/user/.local/share/uv/python/cpython-3.12.0-linux-x86_64-gnu/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/user/openpilot/tinygrad/uop/ops.py", line 139, in key
    return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
                                                                                    ^^^^^
  File "/home/user/.local/share/uv/python/cpython-3.12.0-linux-x86_64-gnu/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/user/openpilot/tinygrad/uop/ops.py", line 139, in key
    return hashlib.sha256(str((self.op, self.dtype, self.arg)).encode() + b"".join([s.key for s in self.src])).digest()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/openpilot/tinygrad/uop/__init__.py", line 8, in __repr__
    def __repr__(x): return str(x)
                            ^^^^^^
RecursionError: maximum recursion depth exceeded
scons: *** [selfdrive/modeld/models/dmonitoring_model_tinygrad.pkl] Error 1
scons: building terminated because of errors.
```