### PR TITLE
fix const_factor TODO

### DIFF
--- a/test/unit/test_uop_vmin_vmax.py
+++ b/test/unit/test_uop_vmin_vmax.py
@@ -292,6 +292,12 @@ class TestConstFactor(unittest.TestCase):
     uop = UOp.const(dtypes.int32, 42)
     self.assertEqual(uop.const_factor(), 42)
 
+  def test_const_factor_negative(self):
+    self.assertEqual(UOp.const(dtypes.int32, -6).const_factor(), 6)
+    x = UOp.variable('x', 0, 10)
+    self.assertEqual((x * -6).const_factor(), 6)
+    self.assertEqual((UOp.const(dtypes.int32, -6) * x).const_factor(), 6)
+
   def test_const_factor_addition(self):
     # const_factor for an addition of constants
     uop = UOp.const(dtypes.int32, 30) + UOp.const(dtypes.int32, 12)

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -710,11 +710,10 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
     return False  # False if not sure
   def const_factor(self) -> int:
     """largest known int that divides self"""
-    # TODO: for negatives it's not the largest
-    if self.op is Ops.CONST: return self.arg
+    if self.op is Ops.CONST: return abs(self.arg)
     if self.op is Ops.VCONST: return math.gcd(*self.arg)
     if self.op is Ops.ADD: return math.gcd(self.src[0].const_factor(), self.src[1].const_factor())
-    if self.op is Ops.MUL: return self.src[0].arg if self.src[0].op is Ops.CONST else self.src[1].arg if self.src[1].op is Ops.CONST else 1
+    if self.op is Ops.MUL: return abs(self.src[0].arg) if self.src[0].op is Ops.CONST else abs(self.src[1].arg) if self.src[1].op is Ops.CONST else 1
     return 1
   def divides(self, v:int) -> UOp|None:
     if v==1: return self


### PR DESCRIPTION
const_factor finds the largest number that divides an expression. For negative numbers like -6 it was returning -6, which is not the largest divisor. Fixed it by using abs() to always return the positive version of the number and added a test. There are more test cases but thought this one is enough. 