### PR TITLE
correct var_vals schedule filter

### DIFF
--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2184,6 +2184,14 @@ class TestBufferUOp(unittest.TestCase):
     run_schedule(check_schedule(a, 0))
     self.assertIsNone(a.uop.base.realized)
 
+  def test_unused_var_not_in_var_vals(self):
+    # unused variable should not appear in var_vals even when there's other work
+    a = Tensor(UOp.variable("unused", 0, 10).bind(1))
+    b = Tensor.empty(3) + 1
+    _, var_vals = Tensor.schedule_with_vars(a, b)
+    self.assertEqual(var_vals, {})
+    self.assertIsNone(a.uop.base.realized)
+
   def test_view_does_not_realize(self):
     a = Tensor.randn(1, 4).expand(4, 4)
     a.realize()

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -173,8 +173,8 @@ def complete_create_schedule_with_vars(big_sink:UOp) -> tuple[dict[UOp, UOp], li
     pre_schedule, combined_sink = sc_ret
 
   # replace all the LUNIQUEs with UNIQUEs (single graph_rewrite for everything)
-  input_buffers_reverse = {v:k for k,v in input_buffers.items()}
-  combined = graph_rewrite(combined_sink, pm_post_sched_cache, ctx=input_buffers_reverse, name="unrewrite combined")
+  input_buffers_inverse = {v:k for k,v in input_buffers.items()}
+  combined = graph_rewrite(combined_sink, pm_post_sched_cache, ctx=input_buffers_inverse, name="unrewrite combined")
   tensor_map_sink, buf_uops_sink = combined.src
   tm_src = tensor_map_sink.src
   tensor_map = {tm_src[i]:tm_src[i+1] for i in range(0, len(tm_src), 2)}
@@ -203,4 +203,6 @@ def complete_create_schedule_with_vars(big_sink:UOp) -> tuple[dict[UOp, UOp], li
     print(f"scheduled {len(schedule):4d} kernels in {(time.perf_counter()-st)*1000:8.2f} ms"+\
           f" | {' cache hit' if SCACHE and sc_ret is not None else 'CACHE MISS'} {sched_cache_key.hex()[:8]}"+\
           f" | {len(UOpMetaClass.ucache)} uops in cache")
-  return tensor_map, schedule, var_vals if schedule else {}
+
+  used_vars = set().union(*[{v.arg[0] for v in si.ast.variables()} for si in schedule])
+  return tensor_map, schedule, {k:v for k,v in var_vals.items() if k in used_vars}


### PR DESCRIPTION
complete_create_schedule_with_vars returns var_vals that's used in schedule