### PR TITLE
NULL_VRAM_SIZE

### DIFF
--- a/test/device/test_null.py
+++ b/test/device/test_null.py
@@ -1,6 +1,8 @@
 import unittest
 from tinygrad import dtypes, Device
 from tinygrad.device import is_dtype_supported
+from tinygrad.helpers import Context
+from tinygrad.runtime.ops_null import NullDevice
 
 @unittest.skipUnless(Device.DEFAULT=="NULL", "Don't run when testing non-NULL backends")
 class TestNULLSupportsDTypes(unittest.TestCase):
@@ -8,6 +10,31 @@ class TestNULLSupportsDTypes(unittest.TestCase):
     dts = dtypes.ints + dtypes.floats + (dtypes.bool,)
     not_supported = [dt for dt in dts if not is_dtype_supported(dt, "NULL")]
     self.assertFalse(not_supported, msg=f"expected these dtypes to be supported by NULL: {not_supported}")
+
+class TestNULLVRAM(unittest.TestCase):
+  @Context(NULL_VRAM_SIZE=1 << 20) # 1 MB VRAM limit
+  def test_oom(self):
+    allocator = NullDevice("NULL").allocator
+    buf1 = allocator.alloc(512 << 10)  # 512 KB
+    self.assertIsNotNone(buf1)
+    with self.assertRaises(MemoryError):
+      allocator.alloc(1 << 20)  # 1 MB
+
+  @Context(NULL_VRAM_SIZE=1 << 20) # 1 MB VRAM limit
+  def test_allow_realloc(self):
+    allocator = NullDevice("NULL").allocator
+    buf1 = allocator.alloc(900 << 10)  # 900 KB
+    self.assertIsNotNone(buf1)
+    allocator.free(buf1, 900 << 10)
+    buf2 = allocator.alloc(900 << 10)  # 900 KB
+    self.assertIsNotNone(buf2)
+
+  # by default null device has infinite memory
+  @Context(NULL_VRAM_SIZE=-1)
+  def test_unlimited_default(self):
+    allocator = NullDevice("NULL").allocator
+    buf = allocator.alloc(1 << 30)  # 1 GB
+    self.assertIsNone(buf) # null alloc returns nothing
 
 if __name__ == "__main__":
   unittest.main()

--- a/tinygrad/helpers.py
+++ b/tinygrad/helpers.py
@@ -180,7 +180,7 @@ CACHELEVEL, IGNORE_BEAM_CACHE, DEVECTORIZE = ContextVar("CACHELEVEL", 2), Contex
 VALIDATE_WITH_CPU, DISABLE_FAST_IDIV = ContextVar("VALIDATE_WITH_CPU", 0), ContextVar("DISABLE_FAST_IDIV", 0)
 CORRECT_DIVMOD_FOLDING, FUSE_OPTIM = ContextVar("CORRECT_DIVMOD_FOLDING", 0), ContextVar("FUSE_OPTIM", 0)
 ALLOW_DEVICE_USAGE, MAX_BUFFER_SIZE = ContextVar("ALLOW_DEVICE_USAGE", 1), ContextVar("MAX_BUFFER_SIZE", 0)
-EMULATE, EMULATED_DTYPES = ContextVar("EMULATE", ""), ContextVar("EMULATED_DTYPES", "")
+EMULATE, EMULATED_DTYPES, NULL_VRAM_SIZE = ContextVar("EMULATE", ""), ContextVar("EMULATED_DTYPES", ""), ContextVar("NULL_VRAM_SIZE", -1)
 CPU_COUNT = ContextVar("CPU_COUNT", max(1, len(os.sched_getaffinity(0)) if hasattr(os, "sched_getaffinity") else (os.cpu_count() or 1)))
 # Compilers
 CPU_LLVM, CPU_LVP, AMD_LLVM = ContextVar("CPU_LLVM", 0), ContextVar("CPU_LVP", 0), ContextVar("AMD_LLVM", 0)


### PR DESCRIPTION
allows reproducing the ASM_GEMM issue on the null device:
`NULL_VRAM_SIZE=$((260 << 30)) ASM_GEMM=1 FAKEDATA=1 SEQLEN=8192 DEV=NULL EMULATE=AMD_CDNA4 JITBEAM=0 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/dev_run.sh`
https://wandb.ai/wozeparrot/MLPerf-LLaMA3/runs/irsuj6ax/logs?nw=nwuserwozeparrot

`ASM_GEMM=0` works fine.