### PR TITLE
delete extra cast in decompositions

### DIFF
--- a/tinygrad/uop/decompositions.py
+++ b/tinygrad/uop/decompositions.py
@@ -44,7 +44,7 @@ def ldexp3k(d:UOp, e:UOp) -> UOp:
   dtype = {dtypes.float64: dtypes.int64, dtypes.float32: dtypes.int32, dtypes.float16: dtypes.int16}[d.dtype.scalar()].vec(d.dtype.count)
   m1 = d.bitcast(dtype)
   m2 = shl(e.cast(dtype), mantissa_bits(d.dtype))
-  return (m1 + m2).bitcast(d.dtype).cast(d.dtype)
+  return (m1 + m2).bitcast(d.dtype)
 
 def ldexp2k(d:UOp, e:UOp) -> UOp:
   """d*2^e. much faster than ldexp3k but risky. d > 0 and d is not denormal."""


### PR DESCRIPTION
i believe the extra cast is redundant, bitcast(d.dtype) already returns a float. 