### PR TITLE
UOp.is_contiguous -> UOp.has_buffer_identity [pr]

### DIFF
--- a/extra/torch_backend/backend.py
+++ b/extra/torch_backend/backend.py
@@ -344,7 +344,7 @@ def scatter_add(self, dim, index, src, out):
 def _copy_between_devices(src, dest, cast_dtype, to_device, non_blocking=False):
   if src.is_tiny and dest.is_tiny:
     src_t, dest_t = unwrap(src), unwrap(dest)
-    if dest_t.uop.is_contiguous() or dest_t.uop.is_realized: src_t = src_t.contiguous()
+    if dest_t.uop.has_buffer_identity() or dest_t.uop.is_realized: src_t = src_t.contiguous()
     _apply_inplace(dest_t, src_t.cast(cast_dtype).to(to_device))
   elif src.is_tiny and dest.is_cpu:
     dest.resize_(src.numel()).resize_(src.shape)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -175,6 +175,14 @@ class TestSchedule(unittest.TestCase):
     child.realize()
     assert a.uop.is_realized
 
+  def test_realize_view_of_realized_has_empty_schedule(self):
+    # views of realized buffers produce an empty schedule
+    t = Tensor.zeros((3, 3)).contiguous().realize()
+    v = t[1]  # view - is_realized but not has_buffer_identity
+    assert v.uop.is_realized
+    sched, _ = Tensor.schedule_with_vars(v)
+    self.assertEqual(len(sched), 0)
+
   # NOTE: because empty does not have a lowered ExecItem if realize is called on a childless empty, it never gets allocated.
   def test_childless_empty_never_allocates(self):
     a = Tensor.empty(10)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -272,7 +272,7 @@ class Tensor(OpMixin):
   @disable_gc()
   def realize(self, *lst:Tensor, do_update_stats=True) -> Tensor:
     """Triggers the computation needed to create these Tensor(s)."""
-    if len(to_realize:=[x for x in (self,)+lst if not x.uop.is_contiguous()]):
+    if len(to_realize:=[x for x in (self,)+lst if not x.uop.has_buffer_identity()]):
       run_schedule(*Tensor.schedule_with_vars(*to_realize), do_update_stats=do_update_stats)
     return self
 


### PR DESCRIPTION
one more confusing buffer related method, but it's definitely not is_contiguous