### PR TITLE
bounty beautiful-mnist-torch with TINY_BACKEND=1 proposed solution

### DIFF
--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -28,6 +28,7 @@ class Model(nn.Module):
 if __name__ == "__main__":
   if getenv("TINY_BACKEND"):
     import tinygrad.nn.torch  # noqa: F401
+    from extra.torch_backend import test_compile # noqa: F401
     device = torch.device("tiny")
   else:
     device = torch.device({"METAL":"mps","NV":"cuda"}.get(Device.DEFAULT, "cpu"))
@@ -43,7 +44,7 @@ if __name__ == "__main__":
   optimizer = optim.Adam(model.parameters(), 1e-3)
 
   loss_fn = nn.CrossEntropyLoss()
-  #@torch.compile
+  @torch.compile(backend="tiny")
   def step(samples):
     X,Y = X_train[samples], Y_train[samples]
     out = model(X)

--- a/extra/torch_backend/test_compile.py
+++ b/extra/torch_backend/test_compile.py
@@ -5,21 +5,42 @@ from extra.torch_backend.backend import unwrap, wrap
 
 from torch._dynamo.backends.registry import register_backend
 from torch._functorch.aot_autograd import aot_module_simplified
+from torch._functorch._aot_autograd.runtime_wrappers import make_boxed_func
 
 from tinygrad import Tensor, TinyJit
+from tinygrad.engine.jit import capturing, JitError
 
 @register_backend
-def tiny(gm:torch.fx.GraphModule, sample_inputs):
-  def my_compiler(gm:torch.fx.GraphModule, sample_inputs):
+def tiny(gm: torch.fx.GraphModule, sample_inputs):
+  def my_compiler(gm: torch.fx.GraphModule, sample_inputs):
     # TODO: the jit should capture the graph directly, not need three runs. this is a planned tinygrad refactor after becomes_map
-    @TinyJit
-    def tiny_function(*args:Tensor):
-      outs = gm(*[wrap(x) for x in args])
-      for x in outs: unwrap(x).realize()
-      return outs
+    def tiny_function(*args: Tensor):
+      torch_outs = gm(*[wrap(x) if x is not None else None for x in args])
+      unwrapped_outs = []
+      for x in torch_outs:
+        if x is not None:
+          t = unwrap(x).realize() 
+          unwrapped_outs.append(t)
+        else:
+          unwrapped_outs.append(None)
+      return unwrapped_outs
+    jit_wrapped = TinyJit(tiny_function)
     # TODO: this should be able to pass in .tiny() Tensors, not need to convert them. it tries to access Storage if you pass in.
-    def torch_function(*args:torch.Tensor): return tiny_function(*[unwrap(x.tiny()) for x in args])
-    return torch_function
+    def torch_function(*args:torch.Tensor):
+      tiny_args = []
+      for x in args:
+          if x is None:
+            tiny_args.append(None)
+          else:
+              t = unwrap(x.tiny()).contiguous()
+              tiny_args.append(t)
+      if len(capturing) > 0: return [wrap(x) for x in tiny_function(*tiny_args)] 
+      try:
+        result = jit_wrapped(*tiny_args)
+      except JitError:
+        result = tiny_function(*tiny_args)
+      return [wrap(x) for x in result]
+    return make_boxed_func(torch_function)
   return aot_module_simplified(gm, sample_inputs, decompositions={}, fw_compiler=my_compiler)
 
 if __name__ == "__main__":

--- a/extra/torch_backend/wrapped_tensor.cpp
+++ b/extra/torch_backend/wrapped_tensor.cpp
@@ -97,6 +97,13 @@ struct TinyOpaqueTensorImpl : public OpaqueTensorImpl<OpaqueHandle> {
       : OpaqueTensorImpl<OpaqueHandle>(key_set, data_type, device, opaque_handle, sizes) {
     this->sizes_and_strides_.set_strides(strides);
     this->storage_offset_ = storage_offset;
+    this->storage_ = c10::Storage(
+        c10::Storage::use_byte_size_t(),
+        0,
+        c10::GetAllocator(c10::DeviceType::CPU),
+        false
+    );
+    this->storage_access_should_throw_ = false;
   }
 };
 }


### PR DESCRIPTION
First execution of this script with an enabled `torch.compile` leads to the following error
```
torch._dynamo.exc.InternalTorchDynamoError: NotImplementedError: Cannot access storage of OpaqueTensorImpl

from user code:
   File "/home/ndou/tinygrad/examples/other_mnist/beautiful_mnist_torch.py", line 48, in step
    X,Y = X_train[samples], Y_train[samples]

```
Solved the above error by creating a dummy storage in the C++ `TinyOpaqueTensorImpl`.

Then, i hit the following error:
```
otImplementedError: Could not run 'aten::_native_batch_norm_legit' with arguments from the 'tiny' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). 
```
And solved by adding the missing operator.

Then, the following error:
```
File "/home/ndou/tinygrad/tinygrad/engine/jit.py", line 259, in _prepare_jit_inputs
    raise JitError("JIT inputs cannot be const, create a buffer with .contiguous()")
tinygrad.engine.jit.JitError: JIT inputs cannot be const, create a buffer with .contiguous()

File "/home/ndou/tinygrad/tinygrad/engine/jit.py", line 262, in _prepare_jit_inputs
    if len(set(input_buffers)) != len(input_buffers): raise JitError("duplicate inputs to JIT")
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tinygrad.engine.jit.JitError: duplicate inputs to JIT

File "/home/ndou/tinygrad/extra/torch_backend/test_compile.py", line 81, in torch_function
    return [wrap(x) for x in result]
            ^^^^^^^
  File "/home/ndou/tinygrad/extra/torch_backend/backend.py", line 37, in wrap
    x._strides = strides_for_shape(x.shape) 
                                   ^^^^^^^
AttributeError: 'NoneType' object has no attribute 'shape'

```
And introduced `.contiguos` and filter out None type objects in `wrap` and `tiny` backend.

And the following was the big one where i had JIT inside another JIT. and had to refactor tiny and apply TinyJit manually. In some cases JIT was an empty graph and i captured those with A JITError - not entirely sure about my fix.

```
  File "/home/ndou/tinygrad/extra/torch_backend/test_compile.py", line 35, in torch_function

    result = tiny_function(*tiny_args)

             ^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ndou/tinygrad/tinygrad/engine/jit.py", line 318, in __call__

    if capturing: raise RuntimeError(f"having TinyJit inside another TinyJit is not supported {len(capturing)=} {capturing=}")

File "/home/ndou/tinygrad/extra/torch_backend/test_compile.py", line 51, in torch_function

    result = compiled_tiny_fn(*tiny_args)

             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/home/ndou/tinygrad/tinygrad/engine/jit.py", line 330, in __call__

    if not len(jit_cache): raise JitError("didn't JIT anything!")

                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tinygrad.engine.jit.JitError: didn't JIT anything!
```

Included the the lines: `[wrap(x) for x in result]` to solve the `test_compile.py` error during testing.

I ran this on `pytorch`:

```
Name: torch
Version: 2.10.0+cpu
Summary: Tensors and Dynamic neural networks in Python with strong GPU acceleration

```

Still feels slow.

```
1 GB tm     34.29us/127019.00ms (     14 GFLOPS   15|15     GB/s) ['__add__', 'argmax', 'eq']
*** CPU     26948 E_2500_4n2                                     arg  2 mem   1.01 GB tm      8.12us/127019.01ms (      0 GFLOPS    2|2      GB/s) 
*** CPU     26949 r_2500_4                                       arg  2 mem   1.01 GB tm      7.53us/127019.02ms (      1 GFLOPS    1|1      GB/s) ['sum', 'cast']
*** CPU     26950 En1                                            arg  2 mem   1.01 GB tm      5.99us/127019.02ms (      0 GFLOPS    0|0      GB/s) 
*** CPU     26951 En2395                                         arg  2 mem   1.01 GB tm      5.04us/127019.03ms (      0 GFLOPS    0|0      GB/s) ['__mul__']
*** CPU     26952 En2396                                         arg  2 mem   1.01 GB tm      6.14us/127019.04ms (      0 GFLOPS    0|0      GB/s) ['div']
*** CPU     26953 En4                                            arg  2 mem   1.01 GB tm      5.76us/127019.04ms (      0 GFLOPS    0|0      GB/s) 
loss:   0.26 test_accuracy: 94.33%: 100%|███████| 70/70 [03:44<00:00,  0.31it/s
```