### PR TITLE
llama: contig backward for wk / wv matmul backward

### DIFF
--- a/extra/models/llama.py
+++ b/extra/models/llama.py
@@ -55,7 +55,7 @@ class Attention:
       xqkv = x @ self.wqkv.T
       xq, xk, xv = xqkv.split([self.wq.weight.shape[0], self.wk.weight.shape[0], self.wv.weight.shape[0]], dim=2)
     else:
-      xq, xk, xv = self.wq(x), self.wk(x), self.wv(x)
+      xq, xk, xv = self.wq(x), self.wk(x.contiguous_backward()), self.wv(x)
 
     if self.q_norm is not None and self.k_norm is not None:
       xq = self.q_norm(xq)


### PR DESCRIPTION
wk has a float gradient and fusing the backwards creates an extremely slow multiple precision matmul and does not trigger asm gemm / tensor cores. This was the slowest kernel in llama train 
```
AMD
| name                         | total     |   count | pct    |
|------------------------------|-----------|---------|--------|
| r_256_64_8_16_4_4_256_4      | 329.77s   |   12448 | 19.92% |
| fa_custom_backward_kv        | 199.77s   |   12448 | 12.06% |
| r_64_56_64_4_2_2_4_4_256_2   | 61.14s    |   24896 | 3.69%  |
```

especially with bfloat16 emulation, it's 4x slower than the already non TC half kernel:
```
from tinygrad.uop.ops import UOp, Ops, KernelInfo, AxisType
from tinygrad import Tensor, dtypes


for dtype in {dtypes.half, dtypes.bfloat16}:
  out = Tensor.empty(33554432, dtype=dtype)
  a = Tensor.empty(4194304, dtype=dtype)
  b = Tensor.empty(8388608, dtype=dtype)
  c = Tensor.empty(4194304, dtype=dtype)
  d = Tensor.empty(8388608, dtype=dtype)
  e = Tensor.empty(33554432, dtype=dtype)

  def fn(out, a, b, c, d, e):
    c2 = UOp.range(8192, 1, AxisType.LOOP)
    c5 = UOp.range(4096, 2, AxisType.LOOP)
    c6 = c2*UOp.const(dtypes.index, 4096)+c5
    c10 = UOp.range(1024, 0, AxisType.REDUCE)
    c12 = c10*UOp.const(dtypes.index, 4096)+c5
    c16 = c2*UOp.const(dtypes.index, 1024)+c10
    c26 = (a.index(c12)*b.index(c16).cast(dtype)+c.index(c12)*d.index(c16)).cast(dtypes.float)
    c31 = c26.reduce(c10, arg=Ops.ADD).cast(dtype)+e.index(c6)
    c33 = out.index(c6, ptr=True).store(c31).end(c2, c5)
    return c33.sink(arg=KernelInfo(name='kernel', axis_types=(), dont_use_locals=False, applied_opts=(), opts_to_apply=None, estimates=None))

  out = Tensor.custom_kernel(out, a, b, c, d, e, fxn=fn)[0]
  out.realize()
  ```