### PR TITLE
torch_backend: torch.compile backend='tiny' via TinyJit

### DIFF
--- a/examples/other_mnist/beautiful_mnist_torch.py
+++ b/examples/other_mnist/beautiful_mnist_torch.py
@@ -43,7 +43,6 @@ if __name__ == "__main__":
   optimizer = optim.Adam(model.parameters(), 1e-3)
 
   loss_fn = nn.CrossEntropyLoss()
-  #@torch.compile
   def step(samples):
     X,Y = X_train[samples], Y_train[samples]
     out = model(X)
@@ -52,6 +51,7 @@ if __name__ == "__main__":
     loss.backward()
     optimizer.step()
     return loss
+  if getenv("TINY_BACKEND"): step = torch.compile(step, backend="tiny")
 
   test_acc = float('nan')
   for i in (t:=trange(getenv("STEPS", 70))):

--- a/extra/torch_backend/compile_backend.py
+++ b/extra/torch_backend/compile_backend.py
@@ -1,0 +1,59 @@
+# https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html
+import torch
+import torch._dynamo
+from torch._dynamo.backends.registry import register_backend
+from torch._functorch.aot_autograd import aot_module_simplified
+from torch._functorch._aot_autograd.graph_compile import make_boxed_func
+
+from tinygrad import Tensor, TinyJit
+from tinygrad.engine.jit import JitError
+from tinygrad.uop.ops import Ops
+
+def register_tiny_backend(wrap, unwrap):
+  if "tiny" in torch._dynamo.list_backends(): return
+
+  @register_backend
+  def tiny(gm:torch.fx.GraphModule, sample_inputs):
+    def my_compiler(gm:torch.fx.GraphModule, sample_inputs):
+      out_node = next(n for n in gm.graph.nodes if n.op == "output")
+      outs = out_node.args[0]
+      if not isinstance(outs, (tuple, list)): outs = (outs,)
+      out_mask = tuple(x is not None for x in outs)
+      tensor_only_outs = True
+      for o in outs:
+        if o is None: continue
+        if not isinstance(o, torch.fx.Node): tensor_only_outs = False; break
+        if not isinstance(o.meta.get("val", None), torch.Tensor): tensor_only_outs = False; break
+      gm_run = torch._dynamo.disable(gm)
+      jit_ok = True
+
+      @TinyJit
+      def tiny_function(*args):
+        outs = gm_run(*[wrap(x) if isinstance(x, Tensor) else x for x in args])
+        if not isinstance(outs, (tuple, list)): outs = (outs,)
+        outs = tuple(unwrap(x).realize() for x in outs if x is not None)
+        return outs
+
+      def torch_function(*args:torch.Tensor):
+        nonlocal jit_ok
+        targs = []
+        for x in args:
+          if not isinstance(x, torch.Tensor):
+            targs.append(x)
+            continue
+          tx = unwrap(x) if x.device.type == "tiny" else unwrap(x.tiny())
+          targs.append(tx.contiguous() if tx.uop.base.op is Ops.CONST else tx)
+        if not tensor_only_outs:
+          return gm_run(*[wrap(x) if isinstance(x, Tensor) else x for x in targs])
+        try:
+          touts = tiny_function(*targs) if jit_ok else tiny_function.fxn(*targs)
+        except JitError:
+          # Some graphs have no kernels (pure views / metadata ops). TinyJit can't capture them safely, so fall back.
+          jit_ok = False
+          touts = tiny_function.fxn(*targs)
+        it = iter(touts)
+        outs = [wrap(next(it)) if m else None for m in out_mask]
+        return outs[0] if len(outs) == 1 else tuple(outs)
+      return make_boxed_func(torch_function)
+
+    return aot_module_simplified(gm, sample_inputs, decompositions={}, fw_compiler=my_compiler)

--- a/extra/torch_backend/test_compile.py
+++ b/extra/torch_backend/test_compile.py
@@ -1,26 +1,9 @@
 # https://pytorch.org/tutorials/intermediate/torch_compile_tutorial.html
 import torch
-import torch._dynamo
 from extra.torch_backend.backend import unwrap, wrap
+from extra.torch_backend.compile_backend import register_tiny_backend
 
-from torch._dynamo.backends.registry import register_backend
-from torch._functorch.aot_autograd import aot_module_simplified
-
-from tinygrad import Tensor, TinyJit
-
-@register_backend
-def tiny(gm:torch.fx.GraphModule, sample_inputs):
-  def my_compiler(gm:torch.fx.GraphModule, sample_inputs):
-    # TODO: the jit should capture the graph directly, not need three runs. this is a planned tinygrad refactor after becomes_map
-    @TinyJit
-    def tiny_function(*args:Tensor):
-      outs = gm(*[wrap(x) for x in args])
-      for x in outs: unwrap(x).realize()
-      return outs
-    # TODO: this should be able to pass in .tiny() Tensors, not need to convert them. it tries to access Storage if you pass in.
-    def torch_function(*args:torch.Tensor): return tiny_function(*[unwrap(x.tiny()) for x in args])
-    return torch_function
-  return aot_module_simplified(gm, sample_inputs, decompositions={}, fw_compiler=my_compiler)
+register_tiny_backend(wrap, unwrap)
 
 if __name__ == "__main__":
   def foo(x, y):


### PR DESCRIPTION
Implements a real torch.compile Dynamo backend for the tiny torch backend (backend='tiny') by running FX graphs through TinyJit.

Also fixes incorrect gradients under torch.compile by replacing native_batch_norm_backward's tinygrad-autograd-based implementation with an analytic formula (tinygrad autograd is broken across realize/JIT in this path).

Tests:
- PYTHONPATH=. python3 -m unittest extra.torch_backend.test -q
- PYTHONPATH=. python3 extra/torch_backend/test_compile.py
- PYTHONPATH=. STEPS=20 CPU=1 TARGET_EVAL_ACC_PCT=90.0 TINY_BACKEND=1 python3 examples/other_mnist/beautiful_mnist_torch.py