### PR TITLE
EVAL_BS=0 in llama profile

### DIFF
--- a/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/profile.sh
+++ b/examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/profile.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 export BENCHMARK=5
+export EVAL_BS=0
 export VIZ=${VIZ:--1}
 examples/mlperf/training_submission_v6.0/tinycorp/benchmarks/llama8b/implementations/tinybox_8xMI350X/dev_run.sh
 PYTHONPATH="." extra/viz/cli.py --profile --device "AMD" --top 20


### PR DESCRIPTION
```
  AMD
| name                         | total     |   count | pct    |
|------------------------------|-----------|---------|--------|
| fa_custom_backward_kv        | 886.02ms  |     160 | 8.82%  |
| fa_custom_backward_q         | 777.62ms  |     160 | 7.74%  |
| r_32_32_4_2048_4n1           | 719.66ms  |     165 | 7.17%  |
| r_32_32_4_2048_4             | 684.84ms  |     160 | 6.82%  |
| fa_custom_forward            | 570.73ms  |     160 | 5.68%  |
| r_501_64_64_4_2_2_4_4_256_2  | 413.95ms  |       5 | 4.12%  |
| gemm_1_8192_14336_4096       | 402.46ms  |     480 | 4.01%  |
| gemm_1_8192_4096_14336       | 390.28ms  |     480 | 3.89%  |
| gemm_1_4096_14336_8192       | 286.05ms  |     320 | 2.85%  |
| r_128_501_64_4_2_2_4_4_128_2 | 240.14ms  |       5 | 2.39%  |
| r_64_32_4_1024_4n2           | 208.32ms  |     165 | 2.07%  |
| r_32_64_64_4_2_2_4_4_4008_2  | 197.74ms  |       5 | 1.97%  |
| r_64_32_4_1024_4n1           | 196.40ms  |     160 | 1.96%  |
| r_4_64_64_4_2_2_4_4_256_2    | 191.52ms  |     155 | 1.91%  |
| E_917504_32_4                | 167.91ms  |     320 | 1.67%  |
| E_917504_32_4n2              | 157.56ms  |     640 | 1.57%  |
| gemm_1_8192_4096_4096        | 152.45ms  |     640 | 1.52%  |
| E_917504_32_4n1              | 147.28ms  |     160 | 1.47%  |
| r_4_64_64_4_2_2_4_4_256_2n1  | 145.50ms  |     155 | 1.45%  |
| E_458752_32_4n2              | 133.24ms  |    1088 | 1.33%  |
| Other (225 unique)           | 2972.67ms |   40202 | 29.60% |
```