### PR TITLE
explicitly check advanced setitem

### DIFF
--- a/test/unit/test_disk_tensor.py
+++ b/test/unit/test_disk_tensor.py
@@ -301,6 +301,11 @@ class TestDiskTensor(TempDirTestCase):
     # self.assertEqual(dt.tolist(), [10, 2, 20, 4, 30, 6])
     self.assertEqual(dt.tolist(), [10, 20, 30, 4, 5, 6])  # wrong!
 
+  def test_advanced_setitem_not_supported(self):
+    dt = Tensor.arange(12).reshape(3, 4).to(f"disk:{self.tmp('dt_advanced_setitem')}")
+    with self.assertRaises(RuntimeError, msg="advanced setitem is not supported for DISK tensors"):
+      dt[Tensor([0, 2]), Tensor([1, 3])] = 99
+
   def test_assign_const_to_disk(self):
     # assign from CONST (Tensor.full) to disk - source has no buffer, needs contiguous first
     dt = Tensor.empty(4, device=f"disk:{self.tmp('dt_assign_const')}", dtype=dtypes.int32)

--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -1280,19 +1280,19 @@ class Tensor(OpMixin):
 
   def __setitem__(self, indices, v:Tensor|PyConst|list|tuple) -> None:
     if isinstance(v, Tensor) and v.dtype != self.dtype: raise RuntimeError(f"setitem dtype mismatch: {self.dtype=} != {v.dtype=}")
+    idx = [indices] if (isinstance(indices, list) and all_int(indices)) or not isinstance(indices, (tuple, list)) else list(indices)
+    is_advanced = any(isinstance(i, (Tensor, list, tuple)) for i in idx)
     if isinstance(self.device, str) and self.device.startswith("DISK"):
+      if is_advanced: raise RuntimeError("advanced setitem is not supported for DISK tensors")
       self.realize()._getitem(indices).assign(v)
       return
     if not isinstance(v, Tensor): v = Tensor(v, device=self.device, dtype=self.dtype)
     if self.requires_grad or v.requires_grad: raise NotImplementedError("setitem with requires_grad is not supported")
-    res = self._getitem(indices, v)
-    # if shapes match and data is not shared, it's advanced indexing, res is the assigned output
-    if res.shape == self.shape and res.uop is not self.uop:
-      self.assign(res).realize()
+    if is_advanced: self.assign(self._getitem(indices, v)).realize()
     else: # basic setitem
       self.realize()
       if not self.uop.is_writable_view(): raise RuntimeError("setitem target must be a writable view backed by a buffer")
-      res.assign(v).realize()
+      self[indices].assign(v).realize()
 
   def __delitem__(self, indices) -> None:
     raise TypeError("Tensor does not support deleting items")


### PR DESCRIPTION
advanced setitem DISK would failed in rangeify with bad error, now it's checked directly in setitem. eventully DISK can use regular setitem path