### PR TITLE
use zip_extract and tar_extract in torch load

### DIFF
--- a/tinygrad/nn/state.py
+++ b/tinygrad/nn/state.py
@@ -287,7 +287,7 @@ def torch_load(t:Tensor) -> dict[str, Tensor]:
     _, _, _, rwd, _, ids, base_offset = pkl.load(), pkl.load(), pkl.load(), fobj.tell(), pkl.load(), pkl.load(), fobj.tell()
     # slice source tensor t
     for i in ids:
-      storage_source[str(i)] = t[base_offset + 8:base_offset + 8 + lens[i]]
+      storage_source[i] = t[base_offset + 8:base_offset + 8 + lens[i]]
       base_offset += 8 + lens[i]
     fobj.seek(rwd)
     return TorchPickle(fobj).load()


### PR DESCRIPTION
Completed TODO that asked to use `zip_extract` and `tar_extract` in `torch.load`:

* Made `zip_extract` faster by batch realizing all the header contents (like it was done previously in torch load zip branch).
* `zip_extract`and `tar_extract` return tensor slices, so updated `rebuild_tensor_v2` to work with slices instead of offsets.
* Removed `zipfile` and `tarfile` usage for file operations; instead working with `BufferedReader(TensorIO)` like in `gguf_load`
