### PR TITLE
perf: sequential disk+dequant realize is way faster than `Tensor.realize(*abc)`, 1.5x-2x for llama tok/s

### DIFF
--- a/tinygrad/apps/llm.py
+++ b/tinygrad/apps/llm.py
@@ -208,10 +208,7 @@ class Transformer:
                         rope_theta=kv[f'{arch}.rope.freq_base'], max_context=max_context,
                         qk_norm=int(state_dict['blk.0.attn_q_norm.weight'].shape[0]) if 'blk.0.attn_q_norm.weight' in state_dict else 0,
                         num_experts=kv.get(f'{arch}.expert_count', 0), num_experts_per_tok=kv.get(f'{arch}.expert_used_count', 0))
-    nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=False)  # NOTE: rope_freqs.weight (32,) is unused
-    # NOTE: without this contiguous, it unpacks the weights from the model every time. we shouldn't need this, but for now it's faster
-    for s in (params:=nn.state.get_parameters(model)): s.replace(s.contiguous())
-    if realize: Tensor.realize(*params)
+    nn.state.load_state_dict(model, state_dict, verbose=False, consume=True, realize=realize)  # NOTE: rope_freqs.weight (32,) is unused
     return model, kv
 
   def generate(self, tokens:list[int], start_pos=0):


### PR DESCRIPTION
**Not for merge, more a curious finding.**

While working on `llm.py`, I noticed that `Tensor.realize(*params)` is way slower than realizing the individual weights by themselves in the `load_state_dict` loop, *both for the realization and for later inference*.

This gives a tok/s speedup for 1.5x-2x for llama models and faster warmup.

I've isolated the behaviour to dequant on top of the disk.

Disk + dequant: sequential is much faster
Disk only: batched is faster



<details>
<summary> Example snippet </summary>

```
#!/usr/bin/env python3
import tempfile, pathlib, time
from tinygrad import Tensor, dtypes

with tempfile.NamedTemporaryFile(delete=False) as f:
  fn = f.name
  for i in range(100): f.write(bytes((i % 256,)) * 65536)

disk_t = Tensor(pathlib.Path(fn))

# Realize together
slices = [disk_t[i*65536:(i+1)*65536].to(None).bitcast(dtypes.float32).cast(dtypes.float16) for i in range(100)]
t1 = time.perf_counter()
for i in range(0, 100, 50): Tensor.realize(*slices[i:i+50])
batch = (time.perf_counter() - t1) * 1000

# Realize one-by-one
t2 = time.perf_counter()
for i in range(100): disk_t[i*65536:(i+1)*65536].to(None).bitcast(dtypes.float32).cast(dtypes.float16).realize()
seq = (time.perf_counter() - t2) * 1000

print(f"Batched: {batch:.0f}ms, Sequential: {seq:.0f}ms, Ratio: {batch/seq:.2f}x")

import os
os.unlink(fn)
```


</details>

<details>
<summary> Llama timings before/after</summary>

```
before
(.venv) ➜  tinygrad git:(master) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.2:1b" --benchmark 10 
1475.66 ms,   0.68 tok/s,    3.16 GB/s, param    2.03 GB/s
1604.26 ms,   0.62 tok/s,    2.76 GB/s, param    1.87 GB/s
744.51 ms,   1.34 tok/s,    5.24 GB/s, param    4.03 GB/s
138.60 ms,   7.21 tok/s,   28.18 GB/s, param   21.62 GB/s
 33.05 ms,  30.26 tok/s,  118.22 GB/s, param   90.68 GB/s
 33.27 ms,  30.05 tok/s,  117.47 GB/s, param   90.07 GB/s
 32.48 ms,  30.79 tok/s,  120.38 GB/s, param   92.27 GB/s
 32.92 ms,  30.38 tok/s,  118.84 GB/s, param   91.05 GB/s
 32.72 ms,  30.56 tok/s,  119.59 GB/s, param   91.59 GB/s
 32.56 ms,  30.71 tok/s,  120.21 GB/s, param   92.03 GB/s

after
(.venv) ➜  tinygrad git:(lazy_gguf) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.2:1b" --benchmark 10
1270.64 ms,   0.79 tok/s,    2.38 GB/s, param    2.36 GB/s
1196.99 ms,   0.84 tok/s,    2.52 GB/s, param    2.50 GB/s
738.55 ms,   1.35 tok/s,    3.37 GB/s, param    4.06 GB/s
 93.66 ms,  10.68 tok/s,   26.59 GB/s, param   32.00 GB/s
 20.56 ms,  48.64 tok/s,  121.20 GB/s, param  145.78 GB/s
 20.98 ms,  47.66 tok/s,  118.79 GB/s, param  142.83 GB/s
 20.69 ms,  48.32 tok/s,  120.48 GB/s, param  144.82 GB/s
 21.17 ms,  47.24 tok/s,  117.82 GB/s, param  141.57 GB/s
 21.50 ms,  46.51 tok/s,  116.05 GB/s, param  139.40 GB/s
 21.29 ms,  46.96 tok/s,  117.21 GB/s, param  140.75 GB/s


before
(.venv) ➜  tinygrad git:(master) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.2:3b" --benchmark 10
3467.15 ms,   0.29 tok/s,    3.35 GB/s, param    2.08 GB/s
3835.01 ms,   0.26 tok/s,    3.08 GB/s, param    1.88 GB/s
2577.23 ms,   0.39 tok/s,    4.27 GB/s, param    2.80 GB/s
215.99 ms,   4.63 tok/s,   50.99 GB/s, param   33.40 GB/s
 89.26 ms,  11.20 tok/s,  123.43 GB/s, param   80.81 GB/s
 89.30 ms,  11.20 tok/s,  123.42 GB/s, param   80.78 GB/s
 90.37 ms,  11.07 tok/s,  122.01 GB/s, param   79.82 GB/s
102.68 ms,   9.74 tok/s,  107.42 GB/s, param   70.25 GB/s
 90.31 ms,  11.07 tok/s,  122.19 GB/s, param   79.88 GB/s
 91.20 ms,  10.96 tok/s,  121.03 GB/s, param   79.09 GB/s

 after
(.venv) ➜  tinygrad git:(lazy_gguf) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.2:3b" --benchmark 10
3357.89 ms,   0.30 tok/s,    2.42 GB/s, param    2.15 GB/s
3438.47 ms,   0.29 tok/s,    2.39 GB/s, param    2.10 GB/s
2645.87 ms,   0.38 tok/s,    2.80 GB/s, param    2.73 GB/s
160.06 ms,   6.25 tok/s,   46.33 GB/s, param   45.07 GB/s
 61.36 ms,  16.30 tok/s,  120.90 GB/s, param  117.56 GB/s
 61.83 ms,  16.17 tok/s,  120.03 GB/s, param  116.67 GB/s
 61.46 ms,  16.27 tok/s,  120.79 GB/s, param  117.38 GB/s
 61.57 ms,  16.24 tok/s,  120.61 GB/s, param  117.16 GB/s
 61.40 ms,  16.29 tok/s,  120.98 GB/s, param  117.48 GB/s
 61.62 ms,  16.23 tok/s,  120.59 GB/s, param  117.06 GB/s


 before
 (.venv) ➜  tinygrad git:(master) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.1:8b" --benchmark 10
7407.53 ms,   0.13 tok/s,    3.90 GB/s, param    2.17 GB/s
5533.57 ms,   0.18 tok/s,    5.42 GB/s, param    2.90 GB/s
3953.43 ms,   0.25 tok/s,    7.32 GB/s, param    4.06 GB/s
465.28 ms,   2.15 tok/s,   62.20 GB/s, param   34.52 GB/s
236.08 ms,   4.24 tok/s,  122.62 GB/s, param   68.03 GB/s
234.24 ms,   4.27 tok/s,  123.61 GB/s, param   68.57 GB/s
234.25 ms,   4.27 tok/s,  123.63 GB/s, param   68.56 GB/s
239.41 ms,   4.18 tok/s,  121.00 GB/s, param   67.08 GB/s
236.59 ms,   4.23 tok/s,  122.47 GB/s, param   67.88 GB/s
235.32 ms,   4.25 tok/s,  123.16 GB/s, param   68.25 GB/s

after
(.venv) ➜  tinygrad git:(master) ✗ time .venv/bin/python tinygrad/apps/llm.py --model "llama3.1:8b" --benchmark 10
4120.39 ms,   0.24 tok/s,    3.88 GB/s, param    3.90 GB/s
4249.29 ms,   0.24 tok/s,    3.79 GB/s, param    3.78 GB/s
3963.26 ms,   0.25 tok/s,    3.80 GB/s, param    4.05 GB/s
232.72 ms,   4.30 tok/s,   64.73 GB/s, param   69.01 GB/s
119.98 ms,   8.33 tok/s,  125.58 GB/s, param  133.86 GB/s
120.44 ms,   8.30 tok/s,  125.14 GB/s, param  133.35 GB/s
120.31 ms,   8.31 tok/s,  125.30 GB/s, param  133.49 GB/s
120.72 ms,   8.28 tok/s,  124.90 GB/s, param  133.04 GB/s
122.39 ms,   8.17 tok/s,  123.22 GB/s, param  131.23 GB/s
121.05 ms,   8.26 tok/s,  124.62 GB/s, param  132.68 GB/s

No impact on olmoe.
```