### PR TITLE
lazy basic setitem to unrealized Tensor

### DIFF
--- a/test/unit/test_setitem_schedule.py
+++ b/test/unit/test_setitem_schedule.py
@@ -7,11 +7,13 @@ class TestSetitemInto(unittest.TestCase):
     t = Tensor.arange(4, dtype=dtypes.int32).reshape(2, 2)
     self.assertEqual(GlobalCounters.kernel_count, 0)
     t[1] = 5
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertEqual(GlobalCounters.global_mem, 4*4+4*2)
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 16)
     t[1].realize()
     t.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(GlobalCounters.kernel_count, 1)
     self.assertListEqual(t.tolist(), [[0, 1], [5, 5]])
 
   def test_setitem_into_unrealized_sliced_compute(self):
@@ -21,17 +23,21 @@ class TestSetitemInto(unittest.TestCase):
     w = a[0] + a[1]  # unrealized ADD with SHRINK in graph: [4, 6, 8, 10]
     self.assertEqual(GlobalCounters.kernel_count, 0)
     w[1] = 99
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertEqual(GlobalCounters.global_mem, 4*4+4)
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    w.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 4*4)
     self.assertListEqual(w.tolist(), [4, 99, 8, 10])
 
   def test_setitem_into_empty(self):
     GlobalCounters.reset()
     t = Tensor.empty(4, dtype=dtypes.int32)
-    self.assertEqual(GlobalCounters.kernel_count, 0)
     t[1] = 5
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t.realize()
     self.assertEqual(GlobalCounters.kernel_count, 1)
-    self.assertEqual(GlobalCounters.global_mem, 4)
+    # TODO: this can be just 4 if empty goes through is_realized setitem path
+    self.assertEqual(GlobalCounters.global_mem, 4*(3*2+1)) # 3 elements had +1, 1 is assigned directly
     t[1].realize()
     t.realize()
     self.assertEqual(GlobalCounters.kernel_count, 1)
@@ -42,11 +48,13 @@ class TestSetitemInto(unittest.TestCase):
     t = Tensor.empty(4, dtype=dtypes.int32) + 1
     self.assertEqual(GlobalCounters.kernel_count, 0)
     t[1] = 5
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertEqual(GlobalCounters.global_mem, 4*4*2+4)
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 4*(3*2+1)) # 3 elements had +1, 1 is assigned directly
     t[1].realize()
     t.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(GlobalCounters.kernel_count, 1)
     self.assertEqual(t[1].item(), 5)
 
   def test_setitem_into_tensor(self):
@@ -65,44 +73,49 @@ class TestSetitemInto(unittest.TestCase):
     t = Tensor([1, 2, 3, 4], dtype=dtypes.int32).realize() + 1
     GlobalCounters.reset()
     t[1] = 5
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertEqual(GlobalCounters.global_mem, 4*4*2+4)
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t[1].realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 4*(3*2+1)) # 3 elements had +1, 1 is assigned directly
     t[1].realize()
     t.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(GlobalCounters.kernel_count, 1)
     self.assertListEqual(t.tolist(), [2, 5, 4, 5])
 
   def test_setitem_into_cont(self):
-    t = Tensor.ones(4, dtype=dtypes.int32)
-    with self.assertRaises(RuntimeError): t[1] = 5
-
-  def test_setitem_into_const_alu(self):
-    # TODO: this is not consistent
     GlobalCounters.reset()
-    t = Tensor.ones(4, dtype=dtypes.int32) + 1
-    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t = Tensor.ones(4, dtype=dtypes.int32)
     t[1] = 5
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertEqual(GlobalCounters.global_mem, 4*4+4)
+    self.assertEqual(GlobalCounters.kernel_count, 0)
+    t.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 4*4)
     t[1].realize()
     t.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    self.assertListEqual(t.tolist(), [2, 5, 2, 2])
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertListEqual(t.tolist(), [1, 5, 1, 1])
 
+  def test_setitem_into_const_alu(self):
+    GlobalCounters.reset()
     t = Tensor.ones(4, dtype=dtypes.int32) + 1
+    t[1] = 5
+    self.assertEqual(GlobalCounters.kernel_count, 0)
     t.realize()
-    with self.assertRaises(RuntimeError): t[1] = 5
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertEqual(GlobalCounters.global_mem, 4*4)
+    t[1].realize()
+    t.realize()
+    self.assertEqual(GlobalCounters.kernel_count, 1)
+    self.assertListEqual(t.tolist(), [2, 5, 2, 2])
 
   def test_setitem_into_arange(self):
     # NOTE: arange has no real buffer, but assigning to it is fine
     GlobalCounters.reset()
     t = Tensor.arange(4, dtype=dtypes.int32)
-    self.assertEqual(GlobalCounters.kernel_count, 0)
     t[1] = 5
-    self.assertEqual(GlobalCounters.kernel_count, 2)
-    t[1].realize()
+    self.assertEqual(GlobalCounters.kernel_count, 0)
     t.realize()
-    self.assertEqual(GlobalCounters.kernel_count, 2)
+    self.assertEqual(GlobalCounters.kernel_count, 1)
     self.assertListEqual(t.tolist(), [0, 5, 2, 3])
 
   def test_setitem_slice_const(self):

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -43,7 +43,6 @@ def assign_to_contiguous(assign:UOp, target:UOp, src:UOp):
   if target is not t and target.op_in_backward_slice_with_self(Ops.SHRINK):
     # base already realized: copy src only if it reads from the same buffer (overlapping read/write hazard)
     if t.op is Ops.CONTIGUOUS: return assign.replace(src=(target, src.contiguous())) if t in src.toposort() else None
-    if t.op is Ops.CONST: raise RuntimeError("setitem target must be a writable view backed by a buffer")
     mops: list[UOp] = []
     while target.op in GroupOp.Movement:
       mops.append(target)


### PR DESCRIPTION
undo the view and make it a mask, this fuses the setitem with any pending compute too.

one behavior change is that for target not backed by a buffer (const and arange), rangeify makes output contiguous under the hood. this is stricter better than raise and ask user to call contiguous, as that would no longer be fuse-able.