### PR TITLE
viz: split all long labels with ...

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -353,7 +353,11 @@ async function renderProfiler(path, unit, opts) {
           colorMap.set(colorKey, d3.rgb(color));
         }
         const fillColor = colorMap.get(colorKey).brighter(0.3*depth).toString();
-        const label = parseColors(e.name).map(({ color, st }) => ({ color, st, width:ctx.measureText(st).width }));
+        const label = parseColors(e.name).flatMap(({ color, st }) => {
+          const parts = [];
+          for (let i=0; i<st.length; i+=4) { const part = st.slice(i, i+4); parts.push({ color, st:part, width:ctx.measureText(part).width }); }
+          return parts;
+        });
         let shapeRef = e.ref;
         if (shapeRef != null) { ref = {ctx:e.ref, step:0}; shapeRef = ref; }
         else if (ref != null) {


### PR DESCRIPTION
it used to only split on colors, now it's based on the character count
<img width="3840" height="980" alt="image" src="https://github.com/user-attachments/assets/9286e769-8fc1-499c-8bc3-07772887d399" />
