### PR TITLE
viz: remove duplicate Ops.PARAM color

### DIFF
--- a/tinygrad/viz/serve.py
+++ b/tinygrad/viz/serve.py
@@ -43,7 +43,7 @@ from tinygrad.renderer import ProgramSpec
 from tinygrad.dtype import dtypes
 
 uops_colors = {Ops.LOAD: "#ffc0c0", Ops.STORE: "#87CEEB", Ops.CONST: "#e0e0e0", Ops.VCONST: "#e0e0e0", Ops.REDUCE: "#FF5B5B",
-               Ops.PARAM:"#cb9037", **{x:"#f2cb91" for x in {Ops.DEFINE_LOCAL, Ops.DEFINE_REG}}, Ops.REDUCE_AXIS: "#FF6B6B",
+               **{x:"#f2cb91" for x in {Ops.DEFINE_LOCAL, Ops.DEFINE_REG}}, Ops.REDUCE_AXIS: "#FF6B6B",
                Ops.RANGE: "#c8a0e0", Ops.ASSIGN: "#909090", Ops.BARRIER: "#ff8080", Ops.IF: "#c8b0c0", Ops.SPECIAL: "#c0c0ff",
                Ops.INDEX: "#cef263", Ops.WMMA: "#efefc0", Ops.MULTI: "#f6ccff", Ops.INS: "#eec4ff",
                **{x:"#D8F9E4" for x in GroupOp.Movement}, **{x:"#ffffc0" for x in GroupOp.ALU}, Ops.THREEFRY:"#ffff80",


### PR DESCRIPTION
dead code in uop to color mapping in viz, Ops.PARAM defined twice (lines 46 and 51). i just removed the first definition because its overwritten by the second definition which seems more intentional

first definition was leftover from when DEFINE_GLOBAL was renamed to PARAM globally: https://github.com/tinygrad/tinygrad/pull/14511
second one was added here: https://github.com/tinygrad/tinygrad/pull/14433

PARAMs are teal and still teal:
<img width="142" height="113" alt="Screenshot 2026-02-16 at 7 13 07 PM" src="https://github.com/user-attachments/assets/04ab4021-a989-4142-89cc-d5710f98740b" />

old DEFINE_GLOBAL was orange