### PR TITLE
add LRU=0 to gguf_tests

### DIFF
--- a/test/unit/test_gguf.py
+++ b/test/unit/test_gguf.py
@@ -2,6 +2,7 @@ import os, unittest, ctypes
 from tinygrad import dtypes, Tensor, fetch, Device
 from tinygrad.nn.state import ggml_data_to_tensor, gguf_load
 from tinygrad.device import is_dtype_supported
+from tinygrad.helpers import Context
 import numpy as np
 import ggml
 
@@ -103,6 +104,7 @@ class TestGGUF(unittest.TestCase):
 
     np.testing.assert_equal(dq_tensor.numpy(), np.frombuffer(c_dq_data, dtype=np.float32))
 
+  @Context(LRU=0)
   def _test_gguf_load(self, url: str):
     fp = fetch(url)
     model_size = os.stat(fp).st_size


### PR DESCRIPTION
saved like 300M ram which might reduce OOM chance especially with -nauto, maybe