### PR TITLE
test: add testamd-cdna4-ops CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -702,6 +702,32 @@ jobs:
       - name: Run process replay tests
         uses: ./.github/actions/process-replay
 
+  testamd-cdna4-ops:
+    name: Linux (amd cdna4 ops)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    env:
+      AMD: 1
+      MOCKGPU: 1
+      MOCKGPU_ARCH: cdna4
+      SKIP_SLOW_TEST: 1
+      AMD_LLVM: 0
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Environment
+        uses: ./.github/actions/setup-tinygrad
+        with:
+          key: amd-minimal
+          deps: testing_unit
+          amd: 'true'
+      - name: Check Device.DEFAULT and print some source
+        run: |
+          python3 -c "from tinygrad import Device; assert Device.DEFAULT in ['AMD'], Device.DEFAULT"
+          DEBUG=5 FORWARD_ONLY=1 python3 test/test_tiny.py TestTiny.test_plus
+      - name: Run pytest (cdna4 ops)
+        run: SKIP_SLOW_TEST=1 PYTHONPATH="." AMD=1 MOCKGPU_ARCH=cdna4 MOCKGPU=1 AMD_LLVM=0 pytest -n=12 test/backend/test_ops.py --durations=20
+
   testnvidia:
     strategy:
       fail-fast: false

--- a/test/mockgpu/amd/README
+++ b/test/mockgpu/amd/README
@@ -28,6 +28,9 @@ The ops tests also pass, but they are very slow, so you should run them one at a
 `SKIP_SLOW_TEST=1 AMD=1 PYTHON_REMU=1 MOCKGPU=1 AMD_LLVM=0 pytest -n=12 test/backend/test_ops.py`
 `SKIP_SLOW_TEST=1 AMD=1 PYTHON_REMU=1 MOCKGPU=1 AMD_LLVM=1 pytest -n=12 test/backend/test_ops.py`
 
+For bring-up/evaluation of emulator readiness on a specific architecture, use:
+`python3 eval_mockgpu_amd_ops.py --arch rdna4 --arch cdna4 --jobs 12 --allow-no-xdist`
+
 When something is caught by main tinygrad tests, a local regression test should be added to `test/amd`.
 While working with tinygrad, you can dump the assembly with `DEBUG=7`. These tests all pass on real hardware
 If a test is failing with `AMD=1 PYTHON_REMU=1 MOCKGPU=1` it's because an instruction is emulated incorrectly.
@@ -36,4 +39,3 @@ IMPORTANT: if a test is failing in the emulator, it's an instruction bug. Use DE
 
 Currently, only RDNA3 is well supported, but when finished, this will support RDNA3+RDNA4+CDNA in ~3000 lines.
 Get line count with `cloc --by-file tinygrad/renderer/amd/*.py`
-

--- a/test/mockgpu/amd/amdgpu.py
+++ b/test/mockgpu/amd/amdgpu.py
@@ -17,7 +17,7 @@ regCOMPUTE_USER_DATA_0 = 0x1be0 + amd_gpu.GC_BASE__INST0_SEG0
 regCOMPUTE_NUM_THREAD_X = 0x1ba7 + amd_gpu.GC_BASE__INST0_SEG0
 regGRBM_GFX_INDEX = 0x2200 + amd_gpu.GC_BASE__INST0_SEG1
 regSQ_THREAD_TRACE_BUF0_BASE = 0x39e8 + amd_gpu.GC_BASE__INST0_SEG1
-regSQ_THREAD_TRACE_BUF0_SIZE = {"rdna3": 0x39e9, "rdna4": 0x39e6}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1
+regSQ_THREAD_TRACE_BUF0_SIZE = {"rdna3": 0x39e9, "rdna4": 0x39e6, "cdna4": 0x39e9}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1
 regSQ_THREAD_TRACE_WPTR = 0x39ef + amd_gpu.GC_BASE__INST0_SEG1
 regSQ_THREAD_TRACE_STATUS = 0x39f4 + amd_gpu.GC_BASE__INST0_SEG1
 regCP_PERFMON_CNTL = 0x3808 + amd_gpu.GC_BASE__INST0_SEG1
@@ -239,7 +239,7 @@ class PM4Executor(AMDQueue):
         for se in range(self.gpu.regs.n_se):
           self.gpu.regs.grbm_index = 0b011 << 29 | se << 16 # select se, broadcast sa and instance
           self.gpu.regs[regSQ_THREAD_TRACE_STATUS] = 1 << 12 # FINISH_PENDING==0 FINISH_DONE==1 BUSY==0
-          if MOCKGPU_ARCH == "rdna3":
+          if MOCKGPU_ARCH != "rdna4":
             buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_SIZE]&0xf)<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE])<<12
           else:
             buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_HI])<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_LO])<<12
@@ -249,7 +249,7 @@ class PM4Executor(AMDQueue):
           # Write blob to trace buffer
           if se_blob: ctypes.memmove(buf_addr, se_blob, len(se_blob))
           # RDNA3 has absolute address for wptr, RDNA4 has relative
-          wptr_val = (((buf_addr if MOCKGPU_ARCH == "rdna3" else 0) + len(se_blob)) // 32) & 0x1FFFFFFF
+          wptr_val = (((buf_addr if MOCKGPU_ARCH != "rdna4" else 0) + len(se_blob)) // 32) & 0x1FFFFFFF
           self.gpu.regs[regSQ_THREAD_TRACE_WPTR] = wptr_val
         self.gpu.regs.grbm_index = old_idx
       case _: pass # NOTE: for now most events aren't emulated


### PR DESCRIPTION
## Summary
- Add CI job for CDNA4 mockgpu ops testing
- Add cdna4 support in mockgpu register handling

## Test plan
- Watch `testamd-cdna4-ops` CI job for results
- This PR is primarily for CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)