### PR TITLE
UOp.axis raises for invalid reshape

### DIFF
--- a/test/null/test_multitensor.py
+++ b/test/null/test_multitensor.py
@@ -54,5 +54,18 @@ class TestMultiRamUsage(unittest.TestCase):
   def test_matmul_half(self): self._test_matmul_half(dev_count=2)
   def test_matmul_half_alt(self): self._test_matmul_half(dev_count=4)
 
+class TestMultiAxis(unittest.TestCase):
+  def test_reshape_shard_invalid(self):
+    devices = ("NULL:0", "NULL:1")
+    t = Tensor.ones(4, 3).shard(devices, axis=0)
+    with self.assertRaises(RuntimeError, msg="reshape cannot move items between shards"):
+      t.reshape(3, 4).uop.axis
+
+  def test_reshape_shard_valid(self):
+    devices = ("NULL:0", "NULL:1")
+    t = Tensor.ones(4, 8).shard(devices, axis=0)
+    self.assertEqual(t.reshape(2, 16).uop.axis, 0)
+    self.assertEqual(t.reshape(2, 2, 8).uop.axis, 0)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/schedule/multi.py
+++ b/tinygrad/schedule/multi.py
@@ -156,7 +156,6 @@ def reshape_multi(root:UOp, multi:UOp):
   arg = root.marg
   if (new_axis:=root.axis) is None: return multi.src[0].reshape(arg).multi(new_axis)
   assert prod(multi.shape) == prod(arg), "reshape must maintain prod(shape)"
-  assert prod(multi.src[0].shape[multi.axis:])%prod(arg[new_axis+1:]) == 0, f"reshape cannot move items between shards {multi.shape} -> {arg=}"
   new_shape_axis = prod(multi.src[0].shape[multi.axis:]) // prod(arg[new_axis+1:])
   return multi.src[0].reshape(tuple(s if a!=new_axis else new_shape_axis for a,s in enumerate(arg))).multi(new_axis)
 

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -499,8 +499,9 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
       if src_axis is None: return None
       arg_acc:list[sint] = list(itertools.accumulate(self.marg, operator.mul, initial=1))
       # new_axis is the last one that preserves prod(prior to new_axis) and must not move items between shards
-      # TODO: what to do about shrinking to self.shape[self.axis]==1 len(self.real_lbs)==1?
-      return len(arg_acc) - arg_acc[::-1].index(prod(self.src[0].shape[:src_axis])) - 1
+      new_axis = len(arg_acc) - arg_acc[::-1].index(prod(self.src[0].shape[:src_axis])) - 1
+      if self.shape[new_axis] % len(self.device) != 0: raise RuntimeError(f"reshape {self.src[0].shape} -> {self.shape} moved items between shards")
+      return new_axis
     if self.op is Ops.PERMUTE: return self.marg.index(src_axis) if src_axis is not None else None
     return src_axis
 


### PR DESCRIPTION
reshape is lazy now, so better to raise from the .axis call and not have caller to handle invalid case