### PR TITLE
gemm/asm: smallest cdna4 asm gemm test

### DIFF
--- a/test/backend/test_asm_gemm.py
+++ b/test/backend/test_asm_gemm.py
@@ -67,6 +67,7 @@ class TestGemmLarge(unittest.TestCase):
     if not is_cdna4():
       self.skipTest("very slow on non mi350x")
 
+  def test_tiny(self): verify_asm_gemm(1, 256, 256, 64)
   def test_simple(self): verify_asm_gemm(1, N:=getenv("N", 4096), N, N, dtype=dtypes.half)
   def test_gemm(self): verify_asm_gemm(1, 8192, 4096, 14336)
   def test_gemm_batched(self): verify_asm_gemm(2, 8192, 4096, 4096)


### PR DESCRIPTION
takes ~2 seconds in emulator
<img width="3840" height="866" alt="image" src="https://github.com/user-attachments/assets/3a04ebe9-535d-4b34-95cb-8876508e6bd1" />
real hw
<img width="3840" height="866" alt="image" src="https://github.com/user-attachments/assets/6a3eb137-d1ce-4980-9f27-b6fa673040cc" />
