### PR TITLE
viz: smaller view for repeated asm instructions in cfg

### DIFF
--- a/test/testextra/test_cfg_viz.py
+++ b/test/testextra/test_cfg_viz.py
@@ -69,8 +69,8 @@ class TestCfg(unittest.TestCase):
     self.assertEqual(len(references["r0"]), 2)
     insts = [cfg["pc_tokens"][pc][0]["st"] for pc in references["r0"]]
     self.assertEqual(insts, ['s_mov_b32', 's_cmp_eq_u64'])
-    end_block_content = "\n".join([cfg["pc_tokens"][pc][0]["st"] for pc in list(cfg["blocks"].values())[-1]])
-    self.assertEqual(end_block_content, "s_endpgm\ns_code_end (40x)")
+    end_block_content = "\n".join(" ".join(t["st"] for t in cfg["pc_tokens"][pc]) for pc in list(cfg["blocks"].values())[-1])
+    self.assertEqual(end_block_content, "s_endpgm\ns_code_end (217x)")
 
   def test_loop(self):
     k = Kernel(arch=Device["AMD"].arch)


### PR DESCRIPTION
the paddings make it harder to see the graph's shape:

this is `VIZ=1 PYTHONPATH=. DEBUG=2 AMD=1 MOCKGPU=1 MOCKGPU_ARCH="rdna4" python test/test_tiny.py TestTiny.test_sum` here vs master
<img width="3024" height="1718" alt="image" src="https://github.com/user-attachments/assets/7610cef8-d018-4a11-bfcb-644a62b49b1b" />

<img width="3024" height="1718" alt="image" src="https://github.com/user-attachments/assets/cd569977-611c-4429-96da-ccf4631a7f4f" />
