### PR TITLE
clang: map bfloat16 to unsigned short for portability

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -231,7 +231,11 @@ class ClangRenderer(CStyleLanguage):
 
   # language options
   buffer_suffix = " restrict"
-  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16"}
+  type_map = {dtypes.bool:"_Bool", dtypes.half:"__fp16", dtypes.bfloat16:"unsigned short"}
+  string_rewrite = PatternMatcher([
+    (UPat(Ops.CONST, dtypes.bfloat16, name="x"),
+      lambda ctx,x: f"{(struct.unpack('I', struct.pack('f', float_to_bf16(x.arg)))[0] >> 16)}u"),
+  ]) + base_rewrite
   code_for_op = {**({k:v for k,v in CStyleLanguage.code_for_op.items() if k not in [Ops.EXP2, Ops.SIN, Ops.LOG2, Ops.TRUNC, Ops.RECIPROCAL]}),
                  Ops.SQRT: lambda x,dtype: f"__builtin_sqrt({x})" if dtype == dtypes.float64 else f"__builtin_sqrtf({x})",
                  Ops.TRUNC: lambda x,dtype: f"__builtin_trunc({x})" if dtype == dtypes.float64 else f"__builtin_truncf({x})",


### PR DESCRIPTION
Fixes #6909

## Summary
- Map `dtypes.bfloat16` to `unsigned short` in `ClangRenderer.type_map` for systems without native `__bf16` support (e.g. Intel Broadwell)
- Add `string_rewrite` rule to render BF16 constants as their bit pattern (e.g. `0x3F80u` for 1.0) instead of invalid float casts
- Follows the same approach used by the OpenCL renderer

## How it works
The existing `pm_manual_bf16_cast` already promotes BF16 ALU operations to float32 via `x.bitcast(ushort).cast(uint) << 16).bitcast(float)` (BF16 << 16 = F32). This change only addresses the type declaration and constant rendering level, ensuring the Clang backend can compile BF16 code on targets where `__bf16` is unavailable.

## Test plan
- [x] `TestBFloat16` — 3 passed
- [x] `TestBFloat16DType` — 3 passed
- [x] `TestBFloat16Type` — 10 passed, 1 skipped
- [x] `TestBFloat16DTypeCast` — 4 passed
- [x] `TestOpsBFloat16` — 2 passed
- [x] Full dtype test suite — 224 passed, 60 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)