### PR TITLE
fix: replace 13 bare except clauses with except Exception

### DIFF
--- a/examples/vgg7.py
+++ b/examples/vgg7.py
@@ -16,7 +16,7 @@ def get_sample_count(samples_dir):
     v = samples_dir_count_file.readline()
     samples_dir_count_file.close()
     return int(v)
-  except:
+  except Exception:
     return 0
 
 def set_sample_count(samples_dir, sc):
@@ -135,7 +135,7 @@ elif cmd == "train":
     if sample_probs.shape[0] != samples_count:
       print("sample probs size != sample count - initializing")
       sample_probs = None
-  except:
+  except Exception:
     # it's fine
     print("sample probs could not be loaded - initializing")
 
@@ -157,7 +157,7 @@ elif cmd == "train":
     sample_idx = 0
     try:
       sample_idx = numpy.random.choice(samples_count, p = sample_probs / sample_probs.sum())
-    except:
+    except Exception:
       print("exception occurred (PROBABLY value-probabilities-dont-sum-to-1)")
       sample_idx = random.randint(0, samples_count - 1)
 

--- a/examples/yolov3.py
+++ b/examples/yolov3.py
@@ -122,7 +122,7 @@ def process_results(prediction, confidence=0.9, num_classes=80, nms_conf=0.4):
       # Get the IOUs of all boxes that come after the one we are looking at in the loop
       try:
         ious = bbox_iou(np.expand_dims(image_pred_class[i], axis=0), image_pred_class[i+1:])
-      except:
+      except Exception:
         break
       # Zero out all the detections that have IoU > threshold
       iou_mask = np.expand_dims((ious < nms_conf), axis=1)
@@ -215,7 +215,7 @@ class Darknet:
       if module_type == "convolutional":
         try:
           batch_normalize, bias = int(x["batch_normalize"]), False
-        except:
+        except Exception:
           batch_normalize, bias = 0, True
         # layer
         activation = x["activation"]
@@ -241,7 +241,7 @@ class Darknet:
         # End if it exists
         try:
           end = int(x["layers"][1])
-        except:
+        except Exception:
           end = 0
         if start > 0: start -= index
         if end > 0: end -= index

--- a/extra/thunder/tiny/visualize_tile.py
+++ b/extra/thunder/tiny/visualize_tile.py
@@ -120,7 +120,7 @@ def visualize_tile(inst=INST):
     for r, c in rc_list:
       try:
         tile[r][c] = threadIdx_x
-      except:
+      except Exception:
         pass
 
   bank_conflicts = {}


### PR DESCRIPTION
## What
Replace 13 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.