### PR TITLE
include optimization env vars in beam search cache key

### DIFF
--- a/tinygrad/codegen/opt/search.py
+++ b/tinygrad/codegen/opt/search.py
@@ -119,7 +119,8 @@ def get_kernel_actions(s:Scheduler, include_0=True, max_up:int|None=None) -> dic
 beam_pool, BEAM_DEBUG = None, getenv("BEAM_DEBUG")
 def beam_search(s:Scheduler, rawbufs:list[Buffer], amt:int, allow_test_size=True, disable_cache=IGNORE_BEAM_CACHE.value):
   global beam_pool
-  key = {"ast": s.ast.key, "amt": amt, "allow_test_size": allow_test_size, "device": s.ren.device, "suffix": s.ren.suffix}
+  key = {"ast": s.ast.key, "amt": amt, "allow_test_size": allow_test_size, "device": s.ren.device, "suffix": s.ren.suffix,
+         "nolocals": getenv("NOLOCALS", 0), "tc": getenv("TC", 1), "tc_opt": getenv("TC_OPT", 0), "tc_select": getenv("TC_SELECT", -1)}
   if not disable_cache and CACHELEVEL >= 1 and (val:=diskcache_get("beam_search", key)) is not None:
     ret = s.copy()
     for o in val[len(s.applied_opts):]: ret.apply_opt(o)


### PR DESCRIPTION
## Summary
- Include `NOLOCALS`, `TC`, `TC_OPT`, and `TC_SELECT` env vars in the beam search cache key
- When these vars change, the cache now properly invalidates instead of returning stale results

Previously, running `BEAM=1 NOLOCALS=1` then `BEAM=1 NOLOCALS=0` would reuse the cached NOLOCALS=1 results, producing incorrect kernels. Same issue with `USE_TC=0` still showing tensor core instructions from cache.

## Test plan
- [x] Run beam search with `NOLOCALS=1`, verify cache miss on subsequent run with `NOLOCALS=0`
- [x] Verify `USE_TC=0` properly invalidates cached TC-enabled results

Fixes #11908

🤖 Generated with [Claude Code](https://claude.com/claude-code)