### PR TITLE
fix OpenCL sqrt ambiguity for half dtype

### DIFF
--- a/tinygrad/renderer/cstyle.py
+++ b/tinygrad/renderer/cstyle.py
@@ -293,6 +293,8 @@ class OpenCLRenderer(CStyleLanguage):
   smem_prefix = "__local "
   barrier = "barrier(CLK_LOCAL_MEM_FENCE);"
   float4 = "(float4)"
+  code_for_op = { **CStyleLanguage.code_for_op,
+    Ops.SQRT: lambda x,dtype: f"sqrt((float){x})" if dtype == dtypes.half else f"sqrt({x})" }
   code_for_workitem = {"g": lambda x: f"get_group_id({x})", "l": lambda x: f"get_local_id({x})", "i": lambda x: f"get_global_id({x})"}
   type_map = { dtypes.int8: "char", dtypes.uint8: "uchar", dtypes.uint32: "uint", dtypes.uint16: "ushort", dtypes.uint64: "ulong",
               dtypes.bfloat16: "ushort" }


### PR DESCRIPTION
## Summary
- Explicitly cast `half` input to `float` for `sqrt()` in OpenCL renderer to avoid ambiguous overload resolution
- Some OpenCL implementations can't resolve `sqrt(half)` when both `sqrt(float)` and `sqrt(double)` overloads exist
- bf16 already handled by `create_non_native_float_pats` which upcasts ALU ops to float32

Fixes #12237

## Test plan
- [x] Run whisper example with `CL=1 TINY=1` on OpenCL device with half support
- [x] Verify sqrt is rendered as `sqrt((float)x)` for half-type inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)