### PR TITLE
add CONTIGUOUS_BACKWARD to base passthrough

### DIFF
--- a/test/unit/test_assign.py
+++ b/test/unit/test_assign.py
@@ -823,10 +823,9 @@ class TestAssignToUnrealizedView(unittest.TestCase):
   def test_contiguous_backward(self):
     t = Tensor([[1,2],[3,4]]).contiguous().realize()
     cb = t.contiguous_backward()  # unrealized CONTIGUOUS_BACKWARD
-    self.assertIs(cb.uop.base.op, Ops.CONTIGUOUS_BACKWARD)
+    self.assertIs(cb.uop.base.op, Ops.BUFFER)
     cb[:, 1:2].assign(Tensor.ones(2,1, dtype=dtypes.int).contiguous().realize())
-    # TODO: should be [[1,1],[3,1]]
-    self.assertEqual(cb.tolist(), [[1,2],[3,4]])
+    self.assertEqual(cb.tolist(), [[1,1],[3,1]])
 
   def test_detach_copy(self):
     t = Tensor.zeros(2,2, dtype=dtypes.int).to("CPU:0").contiguous().realize()

--- a/test/unit/test_function.py
+++ b/test/unit/test_function.py
@@ -70,6 +70,14 @@ class TestFunction(unittest.TestCase):
     b = Tensor([4,5,6])
     np.testing.assert_equal(f(a, b).numpy(), [5,7,9])
 
+  def test_contiguous_backward(self):
+    @function
+    def f(a:Tensor, b:Tensor) -> Tensor: return (a + b).contiguous_backward()
+
+    a = Tensor([1,2,3])
+    b = Tensor([4,5,6])
+    np.testing.assert_equal(f(a, b).numpy(), [5,7,9])
+
   def test_method(self):
     class Foo:
       def __init__(self): self.w = Tensor([10,20,30])

--- a/tinygrad/engine/allocations.py
+++ b/tinygrad/engine/allocations.py
@@ -83,8 +83,6 @@ pm_early_transform_tensor_graph = PatternMatcher([
   (UPat(Ops.ASSIGN, name="u"), replace_assign_with_contig),
   # replace CONTIGUOUS with ASSIGNs
   (UPat(Ops.CONTIGUOUS, name="u"), replace_contig_with_assign),
-  # remove DETACH/CONTIGUOUS_BACKWARD
-  (UPat((Ops.DETACH, Ops.CONTIGUOUS_BACKWARD), name="x"), lambda x: x.src[0]),
   # reduce of size 0 is the identity element
   (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)),
    lambda reduce,x: reduce.const_like(identity_element(reduce.arg[0], reduce.dtype)) if x.size == 0 and reduce.size != 0 else None),

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -102,7 +102,7 @@ earliest_rewrites = mop_cleanup+PatternMatcher([
   # split_reduceop
   (UPat(Ops.REDUCE_AXIS, name="reduce", src=(UPat.var("x"),)), split_reduceop),
 
-  # remove DETACH/CONTIGUOUS_BACKWARD (TODO: this is copied in allocations)
+  # remove DETACH/CONTIGUOUS_BACKWARD
   (UPat((Ops.DETACH, Ops.CONTIGUOUS_BACKWARD), name="x"), lambda x: x.src[0]),
 
   # remove contiguous on movement ops before a copy on disk

--- a/tinygrad/uop/ops.py
+++ b/tinygrad/uop/ops.py
@@ -568,13 +568,13 @@ class UOp(OpMixin, metaclass=UOpMetaClass):
   def base(self) -> UOp:
     if self.op in GroupOp.Movement: return self.src[0].base
     if self.op is Ops.MULTI: return self.src[0].base  # MULTI is really a VIEW
-    if self.op is Ops.DETACH: return self.src[0].base  # DETACH can't change base
+    if self.op in {Ops.DETACH, Ops.CONTIGUOUS_BACKWARD}: return self.src[0].base  # can't change base
     return self
 
   @property
   def multibase(self) -> UOp:
     if self.op in GroupOp.Movement: return self.src[0].base
-    if self.op is Ops.DETACH: return self.src[0].base  # DETACH can't change base
+    if self.op in {Ops.DETACH, Ops.CONTIGUOUS_BACKWARD}: return self.src[0].base  # can't change base
     return self
 
   # like gep, but might return an integer


### PR DESCRIPTION
can remove the "remove DETACH/CONTIGUOUS_BACKWARD" in allocations.py