### PR TITLE
viz: the whole pc should be in view

### DIFF
--- a/tinygrad/viz/index.html
+++ b/tinygrad/viz/index.html
@@ -143,9 +143,6 @@
   g.label rect.bg.highlight {
     fill: #5f0059;
   }
-  #insts span.highlight {
-    background-color: rgba(0, 199, 47, 0.2);
-  }
   #insts .line {
     display: flex;
     flex-direction: column;
@@ -153,8 +150,12 @@
     margin-bottom: 8px;
   }
   #insts .left {
+    width: fit-content;
     display: flex;
-    gap: 8px;
+    gap: 4px;
+  }
+  #insts .left.highlight {
+    background-color: rgba(0, 199, 47, 0.2);
   }
   #insts .n {
     color: #787fa1;


### PR DESCRIPTION
the last digit is important for quickly seeing the PC a jump resulted in.
<img width="2688" height="648" alt="image" src="https://github.com/user-attachments/assets/71ff9444-14cb-4c23-8142-fca3cca3c931" />
