### PR TITLE
add R9700 (0x7551) support for AM driver and SQTT [pr]

### DIFF
--- a/extra/sqtt/rgptool.py
+++ b/extra/sqtt/rgptool.py
@@ -210,7 +210,7 @@ class RGP:
         flags=0,
         trace_shader_core_clock=0x93f05080,
         trace_memory_clock=0x4a723a40,
-        device_id={110000: 0x744c, 110003: 0x7480, 120001: 0x7550, 120000: 0x7550}[device_props['gfx_target_version']],
+        device_id={110000: 0x744c, 110003: 0x7480, 120000: 0x7550, 120001: 0x7551}[device_props['gfx_target_version']],
         device_revision_id=0xc8,
         vgprs_per_simd=1536,
         sgprs_per_simd=128*16,

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -827,7 +827,8 @@ class PCIIface(PCIIfaceBase):
   gpus:ClassVar[list[str]] = []
 
   def __init__(self, dev, dev_id):
-    super().__init__(dev, dev_id, vendor=0x1002, devices=[(0xffff, [0x74a1, 0x744c, 0x7480, 0x7550, 0x7590, 0x75a0])], bars=[0, 2, 5], vram_bar=0,
+    super().__init__(dev, dev_id, vendor=0x1002, devices=[(0xffff, [0x74a1, 0x744c, 0x7480, 0x7550, 0x7551, 0x7590, 0x75a0])],
+      bars=[0, 2, 5], vram_bar=0,
       va_start=AMMemoryManager.va_allocator.base, va_size=AMMemoryManager.va_allocator.size)
     self._setup_adev(self.pci_dev)
     self.pci_dev.write_config(pci.PCI_COMMAND, self.pci_dev.read_config(pci.PCI_COMMAND, 2) | pci.PCI_COMMAND_MASTER, 2)


### PR DESCRIPTION
## Summary
Sorry about the previous PR — I accidentally included unrelated commits from my fork. This is a clean single-commit PR with only the R9700 changes.

- Add PCI device ID `0x7551` (Radeon R9700 / gfx1201) to AM driver supported devices list
- Fix SQTT device ID mapping for gfx1201: was incorrectly mapped to `0x7550` (9070 XT), now correctly maps to `0x7551` (R9700)

R9700 (gfx1201) is the same Navi 48 die as 9070 XT (gfx1200) — same ISA, same tensor cores. Tested with `BEAM=2` on AM driver, runs fine.

## Test plan
- Verified R9700 is detected and works with AM driver (`AMD_IFACE=PCI`)
- Ran `examples/hlb_cifar10.py` with `BEAM=2 DEFAULT_FLOAT=HALF` successfully
- Line length passes ruff (was fixed from previous 154-char violation)