### PR TITLE
explicitly request 3.12.10 instead of 3.12 in ci

### DIFF
--- a/.github/actions/setup-tinygrad/action.yml
+++ b/.github/actions/setup-tinygrad/action.yml
@@ -4,7 +4,7 @@ inputs:
   python-version:
     description: 'Python version to use'
     required: false
-    default: '3.12.12'
+    default: '3.12.10'
   key:
     description: 'Key for the python cache'
     required: false

--- a/.github/workflows/szdiff.yml
+++ b/.github/workflows/szdiff.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12.12'
+          python-version: '3.12.10'
       - name: Count Line Diff
         run: |
           BASE="$GITHUB_WORKSPACE/base"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -443,7 +443,7 @@ jobs:
         with:
           key: onnxoptc
           deps: testing
-          python-version: '3.12.12'
+          python-version: '3.12.10'
           llvm: 'true'
       - name: Test ONNX (CPU)
         run: CPU=1 CPU_LLVM=0 python -m pytest -n=auto test/external/external_test_onnx_backend.py --durations=20
@@ -471,7 +471,7 @@ jobs:
           key: onnxoptl
           deps: testing
           pydeps: "tensorflow==2.19"
-          python-version: '3.12.12'
+          python-version: '3.12.10'
           opencl: 'true'
       - name: Test ONNX (CL)
         run: CL=1 python -m pytest -n=auto test/external/external_test_onnx_backend.py --durations=20
@@ -545,7 +545,7 @@ jobs:
       with:
         key: metal
         deps: testing
-        python-version: '3.12.12'
+        python-version: '3.12.10'
     - name: Test models (Metal)
       run: METAL=1 python -m pytest -n=auto test/models --durations=20
     - name: Test LLaMA compile speed
@@ -620,7 +620,7 @@ jobs:
       with:
         key: webgpu-minimal
         deps: testing_unit
-        python-version: '3.12.12'
+        python-version: '3.12.10'
         webgpu: 'true'
     - name: Check Device.DEFAULT (WEBGPU) and print some source
       run: |
@@ -824,7 +824,7 @@ jobs:
       with:
         key: metal
         deps: testing
-        python-version: '3.12.12'
+        python-version: '3.12.10'
         amd: 'true'
         cuda: 'true'
         ocelot: 'true'
@@ -1001,7 +1001,7 @@ jobs:
           key: compile-${{ matrix.backend }}
           deps: testing_unit
           mesa: ${{ (matrix.backend == 'ir3' || matrix.backend == 'nak') && 'true' }}
-          python-version: '3.12.12'
+          python-version: '3.12.10'
       - name: Set env
         shell: bash
         run: printf "NULL=1\nNULL_ALLOW_COPYOUT=1\n${{ matrix.backend == 'ir3' && 'NULL_IR3=1' || matrix.backend == 'nak' && 'NULL_NAK=1' }}" >> $GITHUB_ENV
@@ -1024,7 +1024,7 @@ jobs:
           key: compile-qcomcl
           deps: testing_unit
           tinydreno: 'true'
-          python-version: '3.12.12'
+          python-version: '3.12.10'
       - name: Set env
         shell: bash
         run: printf "NULL=1\nNULL_ALLOW_COPYOUT=1\nNULL_QCOMCL=1" >> $GITHUB_ENV


### PR DESCRIPTION
`/opt/hostedtoolcache/Python/3.12.13/x64/bin/python: No module named pytest`
https://github.com/tinygrad/tinygrad/actions/runs/23007448269/job/66808216227

3.12.10 is the most recent 3.12 version that has toolcache builds for linux, macos, and windows