### PR TITLE
viz: nanoseconds time axis in sqtt

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -647,7 +647,8 @@ async function renderProfiler(path, opts) {
       lastLabelEnd = labelX + ctx.measureText(label).width + 4;
       if (secondaryTick != null) {
         drawLine(ctx, [x, x], [y, y-tickSize]);
-        ctx.textBaseline = "top"; ctx.fillText(secondaryTick(tick, st, et), labelX, 0);
+        const label = secondaryTick(tick, st, et); ctx.fillText(label, labelX, 0);
+        lastLabelEnd = Math.max(lastLabelEnd, labelX + ctx.measureText(label).width + 4);
       }
     }
     if (data.axes.y != null) {


### PR DESCRIPTION
Converts cycles to nanoseconds using the shader clock frequency data in client side.
It's used in the x axis, and clicking on a packet shows the nanoseconds timestmap:
<img width="2560" height="650" alt="image" src="https://github.com/user-attachments/assets/fd38a604-afcf-4db8-9803-341f232d541e" />
