### PR TITLE
fix max backward underflow for float16

### DIFF
--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -76,6 +76,12 @@ class TestTensorGradient(unittest.TestCase):
     x = Tensor.randn(4, 4)
     np.testing.assert_allclose(x.pad(((1,0),(0,0))).gradient(x, gradient=g2)[0].numpy(), np.zeros((4, 4)))
 
+  def test_max_backward_half(self):
+    n = 70000
+    t = Tensor.ones(n, dtype=dtypes.float16, requires_grad=True).contiguous()
+    t.max().backward()
+    np.testing.assert_allclose(t.grad.numpy(), np.full(n, 1.0/n, dtype=np.float16), rtol=1e-2)
+
 class TestViewGradient(unittest.TestCase):
   def test_expand(self):
     x = Tensor.randn(5,2)

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -1,6 +1,7 @@
 from typing import cast
 import math, dataclasses, itertools
 from tinygrad.uop.ops import UOp, PatternMatcher, UPat, Ops, all_metadata, graph_rewrite
+from tinygrad.dtype import sum_acc_dtype
 from tinygrad.helpers import argsort
 
 def reduce_gradient(ctx:UOp, ret:UOp, op:Ops):
@@ -8,9 +9,10 @@ def reduce_gradient(ctx:UOp, ret:UOp, op:Ops):
   if op == Ops.ADD: return (broadcast_to_input(ctx),)
   if op == Ops.MAX:
     assert ret.op is Ops.REDUCE_AXIS, "only works on REDUCE_AXIS"
-    mask = ret.src[0].eq(broadcast_to_input(ret)).cast(ctx.dtype)
+    acc_dtype = sum_acc_dtype(ctx.dtype)
+    mask = ret.src[0].eq(broadcast_to_input(ret)).cast(acc_dtype)
     count = mask.r(Ops.ADD, ret.arg[1])
-    return ((mask/broadcast_to_input(count)) * broadcast_to_input(ctx),)
+    return ((mask/broadcast_to_input(count)).cast(ctx.dtype) * broadcast_to_input(ctx),)
   if op == Ops.MUL: return (broadcast_to_input(ctx * ret) / ret.src[0],)
 
 def _compact_params(body:UOp, all_args:tuple[UOp, ...]) -> tuple[UOp, tuple[UOp, ...]]:


### PR DESCRIPTION
Fixes #12296

`Tensor.ones(70000, dtype="half").max().backward()` returns all-zero gradients because the mask counting in `reduce_gradient` uses the gradient dtype (float16) for accumulation. Float16 can only represent integers up to 2048 exactly, so the count of 70000 matching elements overflows and the subsequent division produces zeros.

**Fix:** Use `sum_acc_dtype` (already used throughout the codebase for safe accumulation, e.g. in `Tensor.sum` and `Tensor.mean`) to upcast the mask before counting, then cast back to the gradient dtype afterward.

Before:
```
>>> Tensor.ones(70000, dtype="half", requires_grad=True).contiguous().max().backward()
>>> t.grad.tolist()[:5]
[0.0, 0.0, 0.0, 0.0, 0.0]
```

After:
```
>>> t.grad.tolist()[:5]
[1.430511474609375e-05, 1.430511474609375e-05, 1.430511474609375e-05, 1.430511474609375e-05, 1.430511474609375e-05]
```