### PR TITLE
VIZ=2 in MOCKGPU_ARCH="cdna4"

### DIFF
--- a/test/mockgpu/amd/amdgpu.py
+++ b/test/mockgpu/amd/amdgpu.py
@@ -16,10 +16,15 @@ regCOMPUTE_TMPRING_SIZE = 0x1bb8 + amd_gpu.GC_BASE__INST0_SEG0
 regCOMPUTE_USER_DATA_0 = 0x1be0 + amd_gpu.GC_BASE__INST0_SEG0
 regCOMPUTE_NUM_THREAD_X = 0x1ba7 + amd_gpu.GC_BASE__INST0_SEG0
 regGRBM_GFX_INDEX = 0x2200 + amd_gpu.GC_BASE__INST0_SEG1
-regSQ_THREAD_TRACE_BUF0_BASE = 0x39e8 + amd_gpu.GC_BASE__INST0_SEG1
-regSQ_THREAD_TRACE_BUF0_SIZE = {"rdna3": 0x39e9, "rdna4": 0x39e6, "cdna4": 0x39e9}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1
-regSQ_THREAD_TRACE_WPTR = 0x39ef + amd_gpu.GC_BASE__INST0_SEG1
-regSQ_THREAD_TRACE_STATUS = 0x39f4 + amd_gpu.GC_BASE__INST0_SEG1
+# SQTT registers - different offsets for different architectures
+regSQ_THREAD_TRACE_BUF0_BASE = 0x39e8 + amd_gpu.GC_BASE__INST0_SEG1  # rdna3/rdna4 only
+regSQ_THREAD_TRACE_BUF0_SIZE = {"rdna3": 0x39e9, "rdna4": 0x39e6}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1 if MOCKGPU_ARCH != "cdna4" else 0
+regSQ_THREAD_TRACE_WPTR = {"rdna3": 0x39ef, "rdna4": 0x39ef, "cdna4": 0x2339}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1
+regSQ_THREAD_TRACE_STATUS = {"rdna3": 0x39f4, "rdna4": 0x39f4, "cdna4": 0x233a}[MOCKGPU_ARCH] + amd_gpu.GC_BASE__INST0_SEG1
+# CDNA4 (GFX9) uses different registers for trace buffer
+regSQ_THREAD_TRACE_BASE = 0x2330 + amd_gpu.GC_BASE__INST0_SEG1  # cdna4 only
+regSQ_THREAD_TRACE_BASE2 = 0x2337 + amd_gpu.GC_BASE__INST0_SEG1  # cdna4 hi part
+regSQ_THREAD_TRACE_MODE = 0x2336 + amd_gpu.GC_BASE__INST0_SEG1  # cdna4 only
 regCP_PERFMON_CNTL = 0x3808 + amd_gpu.GC_BASE__INST0_SEG1
 regCPG_PERFCOUNTER1_LO = 0x3000 + amd_gpu.GC_BASE__INST0_SEG1
 regGUS_PERFCOUNTER_HI = 0x3643 + amd_gpu.GC_BASE__INST0_SEG1
@@ -160,7 +165,10 @@ class PM4Executor(AMDQueue):
     _ = (info >> 8) & 0b1 # mem_engine
 
     if mem_space == 0 and mem_op == 1: mval = val # hack for memory barrier, should properly handle (req_req, reg_done)
-    elif mem_space == 0: mval = self.gpu.regs[addr_hi<<32|addr_lo]
+    elif mem_space == 0:
+      # GFX9 (cdna4): register addresses in WAIT_REG_MEM are relative to UCONFIG_START
+      reg_addr = (addr_hi<<32|addr_lo) + (pm4.PACKET3_SET_UCONFIG_REG_START if MOCKGPU_ARCH == "cdna4" else 0)
+      mval = self.gpu.regs[reg_addr]
     elif mem_space == 1: mval = to_mv(self.gpu.translate_addr(addr_lo + (addr_hi << 32)), 4).cast('I')[0]
 
     mval &= mask
@@ -176,8 +184,40 @@ class PM4Executor(AMDQueue):
   def _exec_set_reg(self, n, off):
     reg = off + self._next_dword()
     for i in range(n):
-      self.gpu.regs[reg] = self._next_dword()
+      val = self._next_dword()
+      self.gpu.regs[reg] = val
+      # cdna4 SQTT finalization: when mode=0 is written to regSQ_THREAD_TRACE_MODE, trigger trace finish
+      if MOCKGPU_ARCH == "cdna4" and reg == regSQ_THREAD_TRACE_MODE and (val & 0b11) == 0:
+        self._finalize_sqtt_cdna4()
       reg += 1
+
+  def _finalize_sqtt_cdna4(self):
+    """Handle SQTT finalization for cdna4 (GFX9) when regSQ_THREAD_TRACE_MODE is written with mode=0."""
+    from test.mockgpu.amd.emu import sqtt_traces
+    blob = sqtt_traces.pop(0) if sqtt_traces else b''
+    old_idx = self.gpu.regs.grbm_index
+    for se in range(self.gpu.regs.n_se):
+      self.gpu.regs.grbm_index = 0b011 << 29 | se << 16  # select se, broadcast sa and instance
+      # Check if trace buffer was configured for this SE
+      try:
+        buf_lo = self.gpu.regs[regSQ_THREAD_TRACE_BASE]
+        buf_hi = self.gpu.regs[regSQ_THREAD_TRACE_BASE2]
+        buf_addr = ((buf_hi & 0xffff) << 32 | buf_lo) << 12
+      except KeyError:
+        # Trace buffer not configured for this SE, skip
+        self.gpu.regs[regSQ_THREAD_TRACE_STATUS] = 1 << 12  # FINISH_DONE=1, BUSY=0
+        self.gpu.regs[regSQ_THREAD_TRACE_WPTR] = 0
+        continue
+
+      self.gpu.regs[regSQ_THREAD_TRACE_STATUS] = 1 << 12  # FINISH_DONE=1, BUSY=0
+      # Use real trace blob for SE 0 (which has itrace enabled), empty blob for other SEs
+      se_blob = blob if se == 0 else b''
+      # Write blob to trace buffer
+      if se_blob and buf_addr: ctypes.memmove(buf_addr, se_blob, len(se_blob))
+      # cdna4 wptr is relative offset in 32-byte units
+      wptr_val = (len(se_blob) // 32) & 0x1FFFFFFF
+      self.gpu.regs[regSQ_THREAD_TRACE_WPTR] = wptr_val
+    self.gpu.regs.grbm_index = old_idx
 
   def _exec_dispatch_direct(self, n):
     assert n == 3
@@ -240,11 +280,19 @@ class PM4Executor(AMDQueue):
         old_idx = self.gpu.regs.grbm_index
         for se in range(self.gpu.regs.n_se):
           self.gpu.regs.grbm_index = 0b011 << 29 | se << 16 # select se, broadcast sa and instance
+          # Check if trace buffer was configured for this SE
+          try:
+            if MOCKGPU_ARCH == "rdna3":
+              buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_SIZE]&0xf)<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE])<<12
+            else:
+              buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_HI])<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_LO])<<12
+          except KeyError:
+            # Trace buffer not configured for this SE, skip
+            self.gpu.regs[regSQ_THREAD_TRACE_STATUS] = 1 << 12  # FINISH_DONE=1, BUSY=0
+            self.gpu.regs[regSQ_THREAD_TRACE_WPTR] = 0
+            continue
+
           self.gpu.regs[regSQ_THREAD_TRACE_STATUS] = 1 << 12 # FINISH_PENDING==0 FINISH_DONE==1 BUSY==0
-          if MOCKGPU_ARCH == "rdna3":
-            buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_SIZE]&0xf)<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE])<<12
-          else:
-            buf_addr = ((self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_HI])<<32|self.gpu.regs[regSQ_THREAD_TRACE_BUF0_BASE_LO])<<12
           # Use real trace blob for SE 0 (which has itrace enabled), empty blob for other SEs
           se_blob = blob if se == 0 else b''
 

--- a/test/mockgpu/amd/emu.py
+++ b/test/mockgpu/amd/emu.py
@@ -101,6 +101,7 @@ def _init_sqtt_encoder():
   """Initialize and return SQTT encoder state. Called once per dispatch with tracing enabled."""
   from tinygrad.runtime.autogen.amd.rdna3.enum import SOPPOp as SOPPOp3
   from tinygrad.runtime.autogen.amd.rdna4.enum import SOPPOp as SOPPOp4
+  from tinygrad.runtime.autogen.amd.cdna.enum import SOPPOp as SOPPOpC
   import re
 
   _SOPP = (ir3.SOPP, ir4.SOPP, irc.SOPP)
@@ -113,22 +114,26 @@ def _init_sqtt_encoder():
   _FLAT = (ir3.FLAT, ir4.VFLAT, irc.FLAT)
   _SCRATCH = (ir3.SCRATCH, ir4.VSCRATCH, irc.SCRATCH)
 
-  # SOPP classification sets
+  # SOPP classification sets (include both RDNA3/4 and CDNA opcodes since values differ)
   _SOPP_SKIP = {SOPPOp3.S_ENDPGM.value, SOPPOp3.S_ENDPGM_SAVED.value, SOPPOp3.S_ENDPGM_ORDERED_PS_DONE.value,
-                SOPPOp3.S_DELAY_ALU.value}
+                SOPPOp3.S_DELAY_ALU.value, SOPPOpC.S_ENDPGM.value}
   _SOPP_IMMEDIATE = {SOPPOp3.S_NOP.value, SOPPOp3.S_CLAUSE.value, SOPPOp3.S_WAITCNT.value, SOPPOp3.S_WAITCNT_DEPCTR.value,
                      SOPPOp3.S_WAIT_IDLE.value, SOPPOp3.S_WAIT_EVENT.value, SOPPOp3.S_SLEEP.value,
-                     SOPPOp3.S_SET_INST_PREFETCH_DISTANCE.value}
+                     SOPPOp3.S_SET_INST_PREFETCH_DISTANCE.value,
+                     SOPPOpC.S_NOP.value, SOPPOpC.S_WAITCNT.value}
   for _op in (SOPPOp4.S_WAIT_ALU, SOPPOp4.S_WAIT_LOADCNT, SOPPOp4.S_WAIT_STORECNT, SOPPOp4.S_WAIT_SAMPLECNT,
               SOPPOp4.S_WAIT_BVHCNT, SOPPOp4.S_WAIT_EXPCNT, SOPPOp4.S_WAIT_DSCNT, SOPPOp4.S_WAIT_KMCNT,
               SOPPOp4.S_WAIT_LOADCNT_DSCNT, SOPPOp4.S_WAIT_STORECNT_DSCNT):
     _SOPP_IMMEDIATE.add(_op.value)
-  _SOPP_BARRIER = {SOPPOp3.S_BARRIER.value}
+  _SOPP_BARRIER = {SOPPOp3.S_BARRIER.value, SOPPOpC.S_BARRIER.value}
   if hasattr(SOPPOp4, 'S_BARRIER_WAIT'): _SOPP_BARRIER.add(SOPPOp4.S_BARRIER_WAIT.value)
   if hasattr(SOPPOp4, 'S_BARRIER_LEAVE'): _SOPP_BARRIER.add(SOPPOp4.S_BARRIER_LEAVE.value)
   _SOPP_BRANCH = {SOPPOp3.S_BRANCH.value, SOPPOp3.S_CBRANCH_SCC0.value, SOPPOp3.S_CBRANCH_SCC1.value,
                   SOPPOp3.S_CBRANCH_VCCZ.value, SOPPOp3.S_CBRANCH_VCCNZ.value,
-                  SOPPOp3.S_CBRANCH_EXECZ.value, SOPPOp3.S_CBRANCH_EXECNZ.value}
+                  SOPPOp3.S_CBRANCH_EXECZ.value, SOPPOp3.S_CBRANCH_EXECNZ.value,
+                  SOPPOpC.S_BRANCH.value, SOPPOpC.S_CBRANCH_SCC0.value, SOPPOpC.S_CBRANCH_SCC1.value,
+                  SOPPOpC.S_CBRANCH_VCCZ.value, SOPPOpC.S_CBRANCH_VCCNZ.value,
+                  SOPPOpC.S_CBRANCH_EXECZ.value, SOPPOpC.S_CBRANCH_EXECNZ.value}
 
   # VALU sub-classification patterns
   _VALU_TRANS_RE = re.compile(r'V_(EXP|LOG|RCP|RSQ|SQRT|SIN|COS|CEIL|FLOOR|TRUNC|RNDNE|FRACT|FREXP)_')
@@ -164,11 +169,17 @@ def _init_sqtt_encoder():
       started.add(wave_id)
     inst_type, inst_op, op_name = type(inst), inst.op.value if hasattr(inst, 'op') else 0, inst.op.name if hasattr(inst, 'op') else ""
     if issubclass(inst_type, _SOPP):
-      if inst_op in _SOPP_SKIP: return
-      elif inst_op in _SOPP_IMMEDIATE: _emit_nibbles(nibbles, IMMEDIATE, delta=1, wave=w)
-      elif inst_op in _SOPP_BARRIER: _emit_nibbles(nibbles, INST, delta=1, wave=w, op=InstOp.BARRIER)
-      elif inst_op in _SOPP_BRANCH:
+      # Use op_name for classification since opcode values overlap between RDNA3/CDNA
+      if "BRANCH" in op_name:
         _emit_nibbles(nibbles, INST, delta=1, wave=w, op=InstOp.JUMP if branch_taken else InstOp.JUMP_NO)
+      elif op_name in {"S_ENDPGM", "S_ENDPGM_SAVED", "S_ENDPGM_ORDERED_PS_DONE", "S_DELAY_ALU"}: return
+      elif op_name in {"S_NOP", "S_CLAUSE", "S_WAITCNT", "S_WAITCNT_DEPCTR", "S_WAIT_IDLE", "S_WAIT_EVENT", "S_SLEEP",
+                       "S_SET_INST_PREFETCH_DISTANCE", "S_WAIT_ALU", "S_WAIT_LOADCNT", "S_WAIT_STORECNT",
+                       "S_WAIT_SAMPLECNT", "S_WAIT_BVHCNT", "S_WAIT_EXPCNT", "S_WAIT_DSCNT", "S_WAIT_KMCNT",
+                       "S_WAIT_LOADCNT_DSCNT", "S_WAIT_STORECNT_DSCNT"}:
+        _emit_nibbles(nibbles, IMMEDIATE, delta=1, wave=w)
+      elif op_name in {"S_BARRIER", "S_BARRIER_WAIT", "S_BARRIER_LEAVE"}:
+        _emit_nibbles(nibbles, INST, delta=1, wave=w, op=InstOp.BARRIER)
       else: _emit_nibbles(nibbles, INST, delta=1, wave=w, op=InstOp.SALU)
     elif issubclass(inst_type, _VALU):
       op = _valu_op(op_name)
@@ -1956,7 +1967,9 @@ def _get_runner(inst_bytes: bytes, arch: str = "rdna3"):
 _BARRIER_OPS = {ir3.SOPPOp.S_BARRIER, irc.SOPPOp.S_BARRIER}
 if hasattr(ir4.SOPPOp, 'S_BARRIER_WAIT'): _BARRIER_OPS.add(ir4.SOPPOp.S_BARRIER_WAIT)
 _BRANCH_OPS: set[int] = {op.value for op in (ir3.SOPPOp.S_BRANCH, ir3.SOPPOp.S_CBRANCH_SCC0, ir3.SOPPOp.S_CBRANCH_SCC1,
-  ir3.SOPPOp.S_CBRANCH_VCCZ, ir3.SOPPOp.S_CBRANCH_VCCNZ, ir3.SOPPOp.S_CBRANCH_EXECZ, ir3.SOPPOp.S_CBRANCH_EXECNZ)}
+  ir3.SOPPOp.S_CBRANCH_VCCZ, ir3.SOPPOp.S_CBRANCH_VCCNZ, ir3.SOPPOp.S_CBRANCH_EXECZ, ir3.SOPPOp.S_CBRANCH_EXECNZ,
+  irc.SOPPOp.S_BRANCH, irc.SOPPOp.S_CBRANCH_SCC0, irc.SOPPOp.S_CBRANCH_SCC1,
+  irc.SOPPOp.S_CBRANCH_VCCZ, irc.SOPPOp.S_CBRANCH_VCCNZ, irc.SOPPOp.S_CBRANCH_EXECZ, irc.SOPPOp.S_CBRANCH_EXECNZ)}
 
 def _decode_at(pc: int, arch: str):
   """Decode and compile instruction at absolute address pc. Returns (runner, decoded_inst)."""

--- a/tinygrad/runtime/ops_amd.py
+++ b/tinygrad/runtime/ops_amd.py
@@ -626,7 +626,9 @@ class AMDProgram(HCQProgram):
           print(colored(f"{self.dev.device}: Warning: SQTT buffer is full (SE {se})! Increase SQTT buffer with SQTT_BUFFER_SIZE=X (in MB)", "yellow"))
 
         self.dev.allocator._copyout(sqtt_mv:=memoryview(bytearray(wptr)), buf)
-        resbuf = (struct.pack('<Q', 0x11 | (4 << 13) | (0xf << 16) | (se << 24)) + bytes(sqtt_mv)) if self.dev.target[0] == 9 else bytes(sqtt_mv)
+        # GFX9 real HW needs CDNA header, but mockgpu emits RDNA3-style packets that decode directly
+        resbuf = bytes(sqtt_mv) if getenv("MOCKGPU") else \
+                 (struct.pack('<Q', 0x11 | (4 << 13) | (0xf << 16) | (se << 24)) + bytes(sqtt_mv)) if self.dev.target[0] == 9 else bytes(sqtt_mv)
         Compiled.profile_events += [ProfileSQTTEvent(self.dev.device, self.prof_prg_counter, se, resbuf,
                                                      bool((SQTT_ITRACE_SE_MASK.value >> se) & 1), self.dev.prof_exec_counter)]
     return res


### PR DESCRIPTION
needs a more careful review, I wasn't expecting the diff would be this large,
`VIZ=2 AMD=1 MOCKGPU=1 MOCKGPU_ARCH="cdna4" DEBUG=2 PYTHONPATH=. python3 test/backend/test_asm_gemm.py TestAsmGEMM.test_verify_with_numpy`
<img width="2560" height="352" alt="image" src="https://github.com/user-attachments/assets/81a90fd5-2a08-4f72-98e2-e3c5d93ce264" />
the hardcoded header thing in ops_amd has always been a pain to deal with, we need it to stay compatible with the other SQTT decoder. But in emulator LAYOUT_HEADER should be detected as RDNA3.