### PR TITLE
stable_diffusion: skip random init for fakeweights

### DIFF
--- a/examples/stable_diffusion.py
+++ b/examples/stable_diffusion.py
@@ -266,7 +266,12 @@ if __name__ == "__main__":
   args = parser.parse_args()
 
   profile_marker("create model")
+  # for fakeweights, use empty tensors instead of random initialization since weight values are irrelevant
+  if args.fakeweights:
+    _orig_uniform = Tensor.uniform
+    Tensor.uniform = staticmethod(lambda *shape, low=-1.0, high=1.0, **kw: Tensor.empty(*shape, **kw))
   model = StableDiffusion()
+  if args.fakeweights: Tensor.uniform = _orig_uniform
 
   profile_marker("load in weights")
   with WallTimeEvent(BenchEvent.LOAD_WEIGHTS):


### PR DESCRIPTION
with `--fakeweights`, weight values are never used — the flag exists purely to benchmark framework overhead without downloading checkpoints. currently, model construction still runs `Tensor.uniform` for every parameter, building random initialization graphs that dominate scheduling time.

this uses `Tensor.empty` instead during fakeweights model construction, avoiding all random graph building. the original `Tensor.uniform` is restored immediately after construction so it doesn't affect anything else.

5 lines, no behavior change for real weights or any other code path.