### PR TITLE
rand: break rng counter chain with periodic realize [pr]

### DIFF
--- a/tinygrad/tensor.py
+++ b/tinygrad/tensor.py
@@ -630,6 +630,13 @@ class Tensor(OpMixin):
     new_low = Tensor._device_rng_counters[device][0:1] + (num & 0xffffffff)
     new_high = Tensor._device_rng_counters[device][1:2] + (num >> 32) + (new_low < Tensor._device_rng_counters[device][0]).cast(dtypes.uint32)
     Tensor._device_rng_counters[device].assign(new_low.cat(new_high))
+    # periodically realize the counter outside JIT to prevent O(n^2) graph growth across n rand() calls
+    from tinygrad.engine.realize import capturing
+    if not capturing:
+      Tensor._rng_realize_counter = getattr(Tensor, '_rng_realize_counter', 0) + 1
+      if Tensor._rng_realize_counter >= 32:
+        Tensor._device_rng_counters[device].realize()
+        Tensor._rng_realize_counter = 0
 
     low = Tensor._device_rng_counters[device][0:1] - (num & 0xffffffff)
     high = Tensor._device_rng_counters[device][1:2] - (num >> 32) - (Tensor._device_rng_counters[device][0] < (num & 0xffffffff)).cast(dtypes.uint32)


### PR DESCRIPTION
the rng counter's assign chain grows O(n) across n `rand()` calls. each random tensor's graph includes the full counter chain up to that point, so `Tensor.realize()` on all model weights hits **O(n^2) total UOps** — 4.2M for stable diffusion's 1131 params.

every 32 `rand()` calls outside JIT, realize the counter to reset the chain. inside JIT the counter stays fully lazy for correct capture/replay. the counter remains a Tensor — this just breaks the dependency chain periodically.

**before:** max per-tensor graph = 10,867 nodes, total = 4.2M UOps
**after:** max per-tensor graph = 471 nodes, total = 120K UOps

no test changes. stable diffusion `--fakeweights` NULL: model init + weight realize drops from ~40s to ~18s.