### PR TITLE
Remove redundant matrix dimentions in matvec test names

### DIFF
--- a/test/speed/external_test_speed_v_torch.py
+++ b/test/speed/external_test_speed_v_torch.py
@@ -258,10 +258,10 @@ class TestSpeed(unittest.TestCase):
     def f2(a, b): return (a.permute(1,0).reshape(N, 1, N).expand(N, N, N) * b.permute(1,0).reshape(1, N, N).expand(N, N, N)).sum(axis=2)
     helper_test_generic_square('gemm_unrolled_permute_lr', N, f1, f2)
 
-  def test_matvec_1024_1024(self): helper_test_matvec('matvec_1024_1024', 1024, 1024)
-  def test_matvec_1024_4096(self): helper_test_matvec('matvec_1024_4096', 1024, 4096)
-  def test_matvec_4096_1024(self): helper_test_matvec('matvec_4096_1024', 4096, 1024)
-  def test_matvec_4096_4096(self): helper_test_matvec('matvec_4096_4096', 4096, 4096)
+  def test_matvec_1024_1024(self): helper_test_matvec('matvec', 1024, 1024)
+  def test_matvec_1024_4096(self): helper_test_matvec('matvec', 1024, 4096)
+  def test_matvec_4096_1024(self): helper_test_matvec('matvec', 4096, 1024)
+  def test_matvec_4096_4096(self): helper_test_matvec('matvec', 4096, 4096)
 
   def test_openpilot_conv2d(self):
     bs, in_chans, out_chans = 1,12,32


### PR DESCRIPTION
The matvec tests in `external_test_speed_v_torch.py` have the dimensions of the test matrix in their name which is redundant. This is because its already included in the dimension column.

Before this change when running `external_test_speed_v_torch.py`you would get the following output:
<img width="1285" height="154" alt="Screenshot 2026-03-21 at 9 42 57 PM" src="https://github.com/user-attachments/assets/d9787ae3-59a3-44cf-90ca-f5967212f42c" />


After the change, you get the following output:  
<img width="1285" height="151" alt="Screenshot 2026-03-21 at 9 26 55 PM" src="https://github.com/user-attachments/assets/5920a5d3-63ed-49a6-8b99-fabb8c631955" />
