### PR TITLE
remove *0 hack in sign

### DIFF
--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -677,7 +677,7 @@ class ElementwiseMixin(DTypeMixin):
     print(Tensor([-3., -2., -1., 0., 1., 2., 3.]).sign().numpy())
     ```
     """
-    return self.ne(0).where((self < 0).where(self.const_like(-1), self.const_like(1)), self.const_like(0)) + self * 0
+    return self.ne(0).where((self < 0).where(self.const_like(-1), self.const_like(1)), self.const_like(0))
 
   def abs(self) -> Self:
     """


### PR DESCRIPTION
After [this](https://github.com/tinygrad/tinygrad/pull/15367/changes) PR `+ self * 0` is no longer needed for `.gradient` to not raise an error. I used AI [here is my conversation](https://ampcode.com/threads/T-019d1612-6322-706b-a94d-a812400a55cb).

Note: This causes bool to output true/false instead of 1/0 (matches torch).