### PR TITLE
viz/cli: better error message for empty itrace

### DIFF
--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -105,7 +105,10 @@ if __name__ == "__main__":
       assert args.limit > 1, f"SQTT limit must be greater than 1, got {args.limit}"
       sqtt_events, has_more = viz.sqtt_timeline(*sqtt_data, max_pkts=args.offset+args.limit)
       sqtt_pkts = [e for e in sqtt_events if type(e).__name__ == "ProfileRangeEvent"]
-      pc_map = next(e.arg for e in sqtt_events if type(e).__name__ == "ProfilePointEvent" and e.key == 'pcMap')
+      pc_map = next((e.arg for e in sqtt_events if type(e).__name__ == "ProfilePointEvent" and e.key == 'pcMap'), None)
+      if pc_map is None:
+        print(f"No SQTT instruction trace data for {args.device}")
+        sys.exit(0)
       # modern terminals support 24-bit color
       def hex_colored(st:str, color:str) -> str: return f"\x1b[38;2;{int(color[1:3],16)};{int(color[3:5],16)};{int(color[5:7],16)}m{st}\x1b[0m"
       WAVE_COLORS = ((('VALU', 'VINTERP'), '#ffffc0'), (('SALU',), '#cef263'), (('VMEM',), '#b2b7c9'), (('LOAD', 'SMEM'), '#ffc0c0'),


### PR DESCRIPTION
It can happen if the SE doesn't capture anything, or there's just no instructions, like:
`./extra/viz/cli.py --profile-path ./extra/sqtt/examples/gfx1100/profile_empty_run_0.pkl --profile --device "Exec E SQTT PKTS SE:0"`
I usually instruct the agent to use AM_RESET=1 VIZ=-2, but we need to figure out how to fix this in the driver.