### PR TITLE
sqtt: comment out flaky rocprof timestamp assert

### DIFF
--- a/test/amd/test_sqtt_examples.py
+++ b/test/amd/test_sqtt_examples.py
@@ -190,7 +190,7 @@ class SQTTExamplesTestBase(unittest.TestCase):
             elif isinstance(p, (WAVEEND, CDNA_WAVEEND)) and (key := (p.wave, p.simd, p.cu)) in wave_starts:
               our_waves.append((wave_starts[key], p._time))
           for st in wave_starts.values():
-            self.assertGreater(st, first_timestamp, f"wave start must be after the first packet")
+            self.assertGreater(st, first_timestamp, "wave start must be after the first packet")
         # rocprof fails non deterministically and gives inaccurate timestamps.
         #self.assertEqual(sorted(our_waves), sorted(roc_waves), f"wave times mismatch in {name}")
         for st, et in our_waves:


### PR DESCRIPTION
Replacing with some simpler asserts and will still run both decoders in the tests.

The rocprof timestamp equality assert had many non deterministic failures in CI, can't reproduce on my laptop.
https://github.com/tinygrad/tinygrad/actions/runs/23429405027/job/68151718232
https://github.com/tinygrad/tinygrad/actions/runs/23188126584/job/67376781451#step:5:163