### PR TITLE
viz: preserve zoom between re renders

### DIFF
--- a/tinygrad/viz/js/index.js
+++ b/tinygrad/viz/js/index.js
@@ -713,10 +713,10 @@ async function renderProfiler(path, opts) {
     canvas.style.height = `${height}px`;
     canvas.style.width = `${width}px`;
     ctx.scale(dpr, dpr);
-    zoomLevel = getZoomIdentity();
     d3.select(canvas).call(canvasZoom.transform, zoomLevel);
   }
 
+  zoomLevel = getZoomIdentity();
   canvasZoom = d3.zoom().filter(vizZoomFilter).on("zoom", e => render(e.transform));
   d3.select(canvas).call(canvasZoom);
   document.addEventListener("contextmenu", e => e.ctrlKey && e.preventDefault());


### PR DESCRIPTION
small difference but when you jump back and forth between rewrites and profile it shouldn't change zoom, regressed in https://github.com/tinygrad/tinygrad/commit/9a7173b7a082424e8aa430bc0cf88a9bb9a1bcc5.