### PR TITLE
upcast log to float32 for bf16 precision

### DIFF
--- a/test/backend/test_dtype.py
+++ b/test/backend/test_dtype.py
@@ -508,5 +508,10 @@ class TestOpsBFloat16(unittest.TestCase):
     expected = torch.tensor(data, dtype=torch.bfloat16).sqrt().float().numpy()
     np.testing.assert_allclose(Tensor(data, dtype=dtypes.bfloat16).sqrt().numpy(), expected)
 
+  def test_bf16_log(self):
+    data = [12.0, 1.0, 0.5, 100.0]
+    expected = torch.tensor(data, dtype=torch.bfloat16).log().float().numpy()
+    np.testing.assert_allclose(Tensor(data, dtype=dtypes.bfloat16).log().numpy(), expected)
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/mixin/elementwise.py
+++ b/tinygrad/mixin/elementwise.py
@@ -688,6 +688,8 @@ class ElementwiseMixin(DTypeMixin):
     print(Tensor([1., 2., 4., 8.]).log().numpy())
     ```
     """
+    if self.is_floating_point():
+      return self.cast(least_upper_dtype(self.dtype, dtypes.float32)).log2().mul(math.log(2)).cast(self.dtype)
     return self.log2()*math.log(2)
 
   def log10(self) -> Self:


### PR DESCRIPTION
log(x) = log2(x)*log(2) loses precision for bf16 because the log(2) constant is in bf16. upcast to float32 before multiplying, same as exp and cos.

fixes #11756 (log part)