### PR TITLE
cache buffer set computation in limit_bufs to fix n^2 (ai slop)

### DIFF
--- a/tinygrad/schedule/indexing.py
+++ b/tinygrad/schedule/indexing.py
@@ -43,10 +43,13 @@ class BufferizeOpts:
   addrspace: AddrSpace = AddrSpace.GLOBAL
   removable: bool = True
 
+_BUF_OPS = frozenset({Ops.BUFFERIZE, Ops.AFTER, Ops.PARAM, Ops.MSELECT, Ops.MSTACK, Ops.DEFINE_VAR})
+
 @dataclass
 class IndexingContext:
   realize_map: dict[UOp, None|list[int]] = field(default_factory=dict)
   range_map: dict[UOp, tuple[tuple[UOp, ...], tuple[UOp, ...]]] = field(default_factory=dict)
+  bufs_cache: dict[UOp, frozenset[UOp]] = field(default_factory=dict)
 
   # create ranges
   range_idx: Iterator[int] = field(default_factory=itertools.count)

--- a/tinygrad/schedule/rangeify.py
+++ b/tinygrad/schedule/rangeify.py
@@ -8,7 +8,7 @@ from tinygrad.helpers import prod, all_same, getenv, dedup, all_int, DEBUG, SPLI
 from tinygrad.helpers import PCONTIG, FLOAT16, OPENPILOT_HACKS, argsort, partition, get_single_element
 from tinygrad.codegen.simplify import pm_flatten_range, pm_reduce_simplify
 from tinygrad.codegen.opt import Opt
-from tinygrad.schedule.indexing import run_rangeify, BufferizeOpts, IndexingContext, apply_movement_op
+from tinygrad.schedule.indexing import run_rangeify, BufferizeOpts, IndexingContext, apply_movement_op, _BUF_OPS
 from tinygrad.schedule.multi import multi_pm
 from tinygrad.schedule.allreduce import create_allreduce_function
 
@@ -350,17 +350,28 @@ to_bufferview = PatternMatcher([
 ])
 
 DEVICE_MAX_BUFS = {"METAL": 31, "WEBGPU": 8} # TODO: get from device?
+def _get_bufs(u:UOp, cache:dict[UOp, frozenset[UOp]]) -> frozenset[UOp]:
+  if u in cache: return cache[u]
+  if u.op in _BUF_OPS: return cache.setdefault(u, frozenset({u}))
+  stack: list[tuple[UOp, bool]] = [(u, False)]
+  while stack:
+    node, visited = stack.pop()
+    if node in cache: continue
+    if node.op in _BUF_OPS:
+      cache[node] = frozenset({node})
+      continue
+    if not visited:
+      stack.append((node, True))
+      for s in reversed(node.src): stack.append((s, False))
+    else:
+      cache[node] = frozenset().union(*(cache.get(s, frozenset()) for s in node.src)) if node.src else frozenset()
+  return cache.get(u, frozenset())
 def limit_bufs(ctx:IndexingContext, root:UOp):
   if (device:=root._device) is None: return None # no device, index related calculations
   device = device if isinstance(device, str) else device[0].split(":")[0]
   if not (MAX_BUFS:=MAX_KERNEL_BUFFERS.value or DEVICE_MAX_BUFS.get(device, 0)): return None
 
-  bufs: set[UOp] = set()
-  def gate_input(u:UOp):
-    # TODO: add cache to fix n^2
-    if is_load:=(u.op in {Ops.BUFFERIZE, Ops.AFTER, Ops.PARAM, Ops.MSELECT, Ops.MSTACK, Ops.DEFINE_VAR}): bufs.add(u)
-    return not is_load
-  root.toposort(gate=gate_input)
+  bufs = _get_bufs(root, ctx.bufs_cache)
 
   if len(bufs) > MAX_BUFS - 1: # NOTE: this -1 is for the output buffer
     srcs = []


### PR DESCRIPTION
Addresses the TODO at rangeify.py:360 "add cache to fix n^2".

Previously, limit_bufs called root.toposort() for every Binary/Ternary op in the graph, re-traversing shared subtrees each time (O(n^2) total). Now uses a cached bottom-up computation (_get_bufs) that stores each node's reachable buffer set in IndexingContext.bufs_cache, eliminating redundant traversals. Affects METAL (31 buf limit) and WEBGPU (8 buf limit) devices, or when MAX_KERNEL_BUFFERS is set.

Test results (0 regressions introduced):
  - test/null/test_schedule.py: 149 passed, 7 skipped, 6 xfailed (4 pre-existing failures on master deselected)
  - test/null/test_schedule_cache.py: 2 passed
  - test/unit/test_schedule_cache.py: 4 passed
  - test/null/test_attention.py: passed
  - test/null/test_tensor.py: passed
  - test/null/test_uops.py: 34 passed, 2 skipped, 1 xfailed
  - test/null/test_pattern_matcher.py: passed
  - test/null/test_indexing.py: passed
  - test/null/test_linearizer_rewrite.py: passed
  - test/null/test_const_folding.py: passed
  - test/null/test_winograd.py: passed
  - test/unit/test_indexing.py: passed
  - test/unit/test_attention.py: passed
  - test/unit/test_conv.py: passed
  - test/unit/test_assign.py: passed
  - test/unit/test_gradient.py: passed Total: 397 passed, 59 skipped, 7 xfailed, 0 regressions

  - MAX_KERNEL_BUFFERS=8 (WebGPU sim): 149 passed, 7 skipped, 6 xfailed

Correctness verification:
  - Kernel counts match master exactly across all test cases
  - Chain (10 ops): 9 kernels (master: 9)
  - Fan-out (15 ops, 6 inputs): 21 kernels (master: 21)
  - Matmul+softmax (4 layers): 21 kernels (master: 21)
  - BERT-like 12 layers: 389 kernels (master: 389)