### PR TITLE
fix: propagate NaN in Tensor.max() and min()

### DIFF
--- a/tinygrad/uop/decompositions.py
+++ b/tinygrad/uop/decompositions.py
@@ -445,7 +445,16 @@ def get_late_rewrite_patterns(ops:tuple[Ops, ...], device:str, disable_fast_idiv
   # no real hardware supports THREEFRY, but NullRenderer does
   if Ops.THREEFRY not in ops: pat.append((UPat(Ops.THREEFRY, dtype=dtypes.uint64, src=(UPat.var("x"), UPat.var("key"))), threefry2x32))
   # MAX can be rewritten as CMPLT + WHERE (max function is annoying on many cstyle backends)
-  if Ops.MAX not in ops and Ops.CMPLT in ops: pat.append((UPat(Ops.MAX, name="m"), lambda m: (m.src[0] < m.src[1]).where(m.src[1], m.src[0])))
+  # For floats, NaN must propagate: if either operand is NaN, result is NaN
+  if Ops.MAX not in ops and Ops.CMPLT in ops:
+    def _max_with_nan(m: UOp) -> UOp:
+      a, b = m.src[0], m.src[1]
+      naive = (a < b).where(b, a)
+      if a.dtype in dtypes.floats:
+        # NaN propagates: isnan(a) | isnan(b) → NaN, else naive max
+        return a.ne(a).where(a, b.ne(b).where(b, naive))
+      return naive
+    pat.append((UPat(Ops.MAX, name="m"), _max_with_nan))
   # rewrite MOD to AND (which should always be supported, but not for generic in tests): x % (2**y) -> x & (2**y-1)
   if Ops.AND in ops: pat += [(UPat.var("x", dtypes.ints)%UPat.cvar("c"), lambda x,c: x & (c.arg-1) if c.arg in powers_of_two else None)]
   if Ops.OR in ops: pat += [(UPat.var("x", dtypes.bool).logical_not()&UPat.var("y", dtypes.bool).logical_not(),


### PR DESCRIPTION
Fixes #862

When MAX is decomposed to CMPLT+WHERE, NaN operands are silently ignored because `(a < NaN)` is always False, so the non-NaN operand is always selected. This differs from `torch.max`/`np.max` which propagate NaN.

**Fix:** For float dtypes, add NaN detection before the naive max. Uses `a.ne(a)` as isnan check (NaN != NaN is True). Integer MAX is unaffected.

This also fixes `min()` since it delegates to `maximum(-a, -b).negate()`.

```python
# Before
Tensor([1, nan]).max()  # → 1.0 (wrong)

# After
Tensor([1, nan]).max()  # → nan (correct, matches torch/np)
```