### PR TITLE
remove redundant iteration and toposort in _deepwalk

### DIFF
--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -84,9 +84,9 @@ pm_gradient = PatternMatcher([
 def _deepwalk(root:UOp, targets:set[UOp]) -> tuple[list[UOp], dict[UOp, bool]]:
   # compute the target path (top down)
   in_target_path: dict[UOp, bool] = {}
-  for u in root.toposort(): in_target_path[u] = any(x in targets or in_target_path[x] for x in u.src)
+  root.topovisit(lambda u: any(in_target_path[x] or x in targets for x in u.src), in_target_path)
   # don't flow through DETACH or anything not in target path
-  return list(root.toposort(lambda node: node.op is not Ops.DETACH and in_target_path[node])), in_target_path
+  return [node for node in in_target_path if node.op is not Ops.DETACH and in_target_path[node]], in_target_path
 
 def compute_gradient(root:UOp, root_grad:UOp, targets:set[UOp]) -> dict[UOp, UOp]:
   walk, in_target_path = _deepwalk(root, targets)


### PR DESCRIPTION
Right now, _deepwalk toposorts the graph, then iterates over the ordering to build in_target_path.  Then it uses a gated toposort to build walk.  This can just be a single call to topovisit plus a list comprehension.  