### PR TITLE
abs(x)**even = x**even

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -918,6 +918,12 @@ class TestOps(unittest.TestCase):
     for v in [-1., -0., 0., 1., math.inf, -math.inf, math.nan, -math.nan]:
       # abs(nan) gradient is undefined: torch=0, tinygrad=1, jax=-1
       helper_test_op(None, torch.abs, Tensor.abs, vals=[[v]], forward_only=math.isnan(v))
+  def test_abs_pow_even(self):
+    helper_test_op(None, lambda x: torch.abs(x)**2, lambda x: x.abs()**2, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
+    helper_test_op(None, lambda x: torch.abs(x)**4, lambda x: x.abs()**4, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
+    helper_test_op(None, lambda x: torch.abs(x)**2, lambda x: x.abs()**2, vals=[[-5, -1, 0, 1, 5]], forward_only=True, atol=0)
+  def test_abs_pow_odd(self):
+    helper_test_op(None, lambda x: torch.abs(x)**3, lambda x: x.abs()**3, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
 
   def test_log(self):
     helper_test_op([(45,65)], torch.log, Tensor.log)

--- a/test/null/test_schedule.py
+++ b/test/null/test_schedule.py
@@ -660,6 +660,22 @@ class TestSchedule(unittest.TestCase):
     t = Tensor([1.0, 2.0, 3.0]) ** 8
     self.assertEqual(self._alu_from_tensor(t), [Ops.MUL, Ops.MUL, Ops.MUL])
 
+  def test_abs_pow_2_is_x_pow_2(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 2
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL])
+
+  def test_abs_pow_2_int_is_x_pow_2(self):
+    t = Tensor([1, 2, 3]).abs() ** 2
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL])
+
+  def test_abs_pow_4_is_x_pow_4(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 4
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL, Ops.MUL])
+
+  def test_abs_pow_3_not_simplified(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 3
+    self.assertIn(Ops.WHERE, self._alu_from_tensor(t))
+
   @unittest.skip("const folding is removed")
   def test_pow_const_tensor_to_zero(self):
     x = Tensor([1,2,3,4])

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -129,6 +129,10 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var('x').cast(name="a").cast(name="b"), lambda x,a,b: x if x.dtype == b.dtype and can_lossless_cast(b.dtype, a.dtype) else None),
   (UPat.var("x").cast(dtypes.bool), lambda x: x != 0),
   # ** pow **
+  # abs(x)**even -> x**even
+  (((u := UPat.var("u")) * UPat(Ops.WHERE, src=(UPat(Ops.CMPNE, src=(u, UPat.cvar(arg=0))),
+    UPat(Ops.WHERE, src=(UPat(), UPat.cvar("a"), UPat.cvar("b"))), UPat.cvar(arg=0)))).alu(Ops.POW, UPat.cvar("c", vec=False)),
+  lambda u, a, b, c: u.pow(c) if abs(a.arg) == abs(b.arg) == 1 and int(c.arg) == c.arg and c.arg % 2 == 0 and c.arg > 0 else None),
   (UPat.var("x").alu(Ops.POW, UPat.cvar("c", vec=False)), simplify_pow),
   # positive const ** x
   (UPat.cvar("c", vec=False).alu(Ops.POW, UPat.var("x")), lambda c,x: c if c.arg == 1 else (x*math.log2(c.arg)).exp2() if c.arg > 0 else None),


### PR DESCRIPTION
Closes #11626

Squaring already makes things positive so the sign computation from abs is just dead work

Before:
```c
int alu0 = ((val0<0)?-1:1);
int alu1 = ((val0!=0)?alu0:0);
int alu2 = (val0*alu1);
*(data0) = (alu2*alu2);
```

After: 
```c
*(data0) = (val0*val0);
```

One rewrite rule before `simplify_pow` that catches POW while it still exists. matches the outer structure of abs `MUL(u, WHERE(u!=0, WHERE(_, a, b), 0))` and strips it when `|a|=|b|=1` and exponent is even. 

I think this should be correct:
- u=0: sign is 0, abs is 0, 0^anything = 0
- u!=0: sign is +/-1, squaring it away gives 1, so its just u^even
