### PR TITLE
viz: skip flaky sever tests

### DIFF
--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -26,6 +26,7 @@ def get_viz_details(rewrite_idx:int, step:int) -> Generator[dict, None, None]:
   assert len(lst) > rewrite_idx, "only loaded {len(lst)} traces, expecting at least {idx}"
   return get_full_rewrite(tracked_ctxs[rewrite_idx][step])
 
+@unittest.skip("TODO: flaky")
 class BaseTestViz(unittest.TestCase):
   def setUp(self):
     # clear the global context


### PR DESCRIPTION
has errors when running `DEV=NULL pytest -n auto --dist=loadfile test/null -x` multiple times, the tests that use the global context should be rewritten. Will add them back one at a time.