### PR TITLE
push even powers into WHERE branches

### DIFF
--- a/test/backend/test_ops.py
+++ b/test/backend/test_ops.py
@@ -918,6 +918,12 @@ class TestOps(unittest.TestCase):
     for v in [-1., -0., 0., 1., math.inf, -math.inf, math.nan, -math.nan]:
       # abs(nan) gradient is undefined: torch=0, tinygrad=1, jax=-1
       helper_test_op(None, torch.abs, Tensor.abs, vals=[[v]], forward_only=math.isnan(v))
+  def test_abs_pow_even(self):
+    helper_test_op(None, lambda x: torch.abs(x)**2, lambda x: x.abs()**2, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
+    helper_test_op(None, lambda x: torch.abs(x)**4, lambda x: x.abs()**4, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
+    helper_test_op(None, lambda x: torch.abs(x)**2, lambda x: x.abs()**2, vals=[[-5, -1, 0, 1, 5]], forward_only=True, atol=0)
+  def test_abs_pow_odd(self):
+    helper_test_op(None, lambda x: torch.abs(x)**3, lambda x: x.abs()**3, vals=[[-5., -1., -0., 0., 1., 5.]], forward_only=True)
 
   def test_log(self):
     helper_test_op([(45,65)], torch.log, Tensor.log)

--- a/test/null/test_schedule.py
+++ b/test/null/test_schedule.py
@@ -660,6 +660,22 @@ class TestSchedule(unittest.TestCase):
     t = Tensor([1.0, 2.0, 3.0]) ** 8
     self.assertEqual(self._alu_from_tensor(t), [Ops.MUL, Ops.MUL, Ops.MUL])
 
+  def test_abs_pow_2_is_x_pow_2(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 2
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL])
+
+  def test_abs_pow_2_int_is_x_pow_2(self):
+    t = Tensor([1, 2, 3]).abs() ** 2
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL])
+
+  def test_abs_pow_4_is_x_pow_4(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 4
+    self.assertEqual(self._alu_from_tensor(t), [Ops.MUL, Ops.MUL])
+
+  def test_abs_pow_3_not_simplified(self):
+    t = Tensor([1.0, 2.0, 3.0]).abs() ** 3
+    self.assertIn(Ops.WHERE, self._alu_from_tensor(t))
+
   @unittest.skip("const folding is removed")
   def test_pow_const_tensor_to_zero(self):
     x = Tensor([1,2,3,4])

--- a/tinygrad/uop/symbolic.py
+++ b/tinygrad/uop/symbolic.py
@@ -9,6 +9,12 @@ from tinygrad.uop.divandmod import div_and_mod_symbolic
 
 # ******** phase 1 of symbolic used to live in ops, it's the most generic folding rules ********
 
+def _has_mul_factor(expr:UOp, x:UOp) -> bool:
+  """Check if x appears as a multiplicative factor in expr (so expr=0 when x=0)."""
+  if expr is x: return True
+  if expr.op is Ops.MUL: return _has_mul_factor(expr.src[0], x) or _has_mul_factor(expr.src[1], x)
+  return False
+
 def simplify_pow(x:UOp, c:UOp) -> UOp|None:
   if c.arg < 0: return x.reciprocal().pow(-c)
   if c.arg == 0: return x.const_like(1)
@@ -129,6 +135,9 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.var('x').cast(name="a").cast(name="b"), lambda x,a,b: x if x.dtype == b.dtype and can_lossless_cast(b.dtype, a.dtype) else None),
   (UPat.var("x").cast(dtypes.bool), lambda x: x != 0),
   # ** pow **
+  # pow(a * where(c, t, f), even) -> where(c, pow(a*t, even), pow(a*f, even))
+  ((UPat.var("a") * UPat.var("c").where(UPat.var("t"), UPat.var("f"))).alu(Ops.POW, UPat.cvar("e", vec=False)),
+   lambda a, c, t, f, e: c.where((a*t).pow(e), (a*f).pow(e)) if int(e.arg) == e.arg and e.arg % 2 == 0 and e.arg > 0 else None),
   (UPat.var("x").alu(Ops.POW, UPat.cvar("c", vec=False)), simplify_pow),
   # positive const ** x
   (UPat.cvar("c", vec=False).alu(Ops.POW, UPat.var("x")), lambda c,x: c if c.arg == 1 else (x*math.log2(c.arg)).exp2() if c.arg > 0 else None),
@@ -144,6 +153,9 @@ symbolic_simple = propagate_invalid + PatternMatcher([
   (UPat.cvar("gate", vec=False).where(UPat.var("c0"), UPat.var("c1")), lambda gate, c0, c1: c0 if gate.arg else c1),
   # a.where(b.where(c, d), d) -> (a & b).where(c, d)
   (UPat.var("a").where(UPat.var("b").where(UPat.var("c"), UPat.var("d")), UPat.var("d")), lambda a,b,c,d: (a&b).where(c,d)),
+  # where(x!=0, expr, 0) -> expr when x is a multiplicative factor of expr (so expr=0 when x=0)
+  (UPat(Ops.CMPNE, src=(UPat.var("x"), UPat.cvar(arg=0))).where(UPat.var("expr"), UPat.cvar(arg=0)),
+   lambda x, expr: expr if _has_mul_factor(expr, x) else None),
 ])
 
 # ******** phase 2 builds on phase 1, it includes the old "symbolic", rules that match deeper ********


### PR DESCRIPTION
closes #11626

two rules:
- `pow(a * where(c, t, f), even) -> where(c, pow(a*t, even), pow(a*f, even))`
- `where(x!=0, expr, 0) -> expr` when x is a multiplicative factor of expr

the first pushes even powers into where branches. both branches simplify to the same thing, the existing `where(c, val, val) -> val` collapses the where. the second removes `where(x!=0, x*x, 0) -> x*x` since x*x is already 0 when x=0