### PR TITLE
fix: CDNA4 emulator — all tests passing with MOCKGPU_ARCH=cdna4

### DIFF
--- a/test/mockgpu/amd/emu.py
+++ b/test/mockgpu/amd/emu.py
@@ -703,13 +703,8 @@ class _Ctx:
     for dest, val in assigns:
       # VGPR bit-slice assignment: VGPR[lane][reg][hi:lo] = (vgpr_idx, rhs_val, hi, lo[, cond]) -> read-modify-write
       if dest.startswith('VGPR[') and re.search(r'\[\d+:\d+\]', dest):
-        # VGPR bit-slice: (vgpr_idx, rhs_val, hi_bit, lo_bit) - hi/lo are UOp constants
-        hi_bit, lo_bit = int(val[2].arg), int(val[3].arg)
-        width = hi_bit - lo_bit + 1
-        old = self.vgpr.index(val[0].cast(dtypes.int), ptr=True).load()
-        new_val = _set_bits(old, _val_to_bits(val[1]), width, lo_bit).cast(dtypes.uint32)
-        active = _lane_active(exec_mask, lane)
-        raw_stores.append(('vgpr_direct', self.vgpr.index(val[0].cast(dtypes.int), active).store(new_val)))
+        # Collect for deferred merge (multiple conditional bit-slice writes to same VGPR)
+        raw_stores.append(('vgpr_bitslice', val))
         continue
       if 'D0' in dest and '[laneId]' in dest:
         old_vcc = self.rmask(_c(VCC_LO.offset))
@@ -759,6 +754,25 @@ class _Ctx:
         mask = UOp.const(dtypes.uint32, ((1 << width) - 1) << lo_bit)
         result = (result & (mask ^ UOp.const(dtypes.uint32, 0xFFFFFFFF))) | (val_bits << UOp.const(dtypes.uint32, lo_bit))
       lane_stores.append(self.wvgpr_dyn(vdst_reg, lane, result, exec_mask))
+    # Merge conditional VGPR bit-slice writes (e.g. from if/else branches writing different bit ranges of same VGPR)
+    vgpr_bitslice_stores = [s for t, s in raw_stores if t == 'vgpr_bitslice']
+    if vgpr_bitslice_stores:
+      from collections import defaultdict
+      by_idx: dict = defaultdict(list)
+      for val in vgpr_bitslice_stores:
+        idx_key = val[0]  # vgpr_idx UOp
+        by_idx[id(idx_key)].append((idx_key, val))
+      for _, entries in by_idx.items():
+        vgpr_idx = entries[0][0]
+        result = self.vgpr.index(vgpr_idx.cast(dtypes.int), ptr=True).load()
+        for _, val in entries:
+          hi_bit, lo_bit = int(val[2].arg), int(val[3].arg)
+          width = hi_bit - lo_bit + 1
+          new_val = _set_bits(result, _val_to_bits(val[1]), width, lo_bit).cast(dtypes.uint32)
+          cond = val[4] if len(val) > 4 else None
+          result = cond.where(new_val, result) if cond is not None else new_val
+        active = _lane_active(exec_mask, lane)
+        lane_stores.append(self.vgpr.index(vgpr_idx.cast(dtypes.int), active).store(result))
     # VCC/EXEC mask writes must be computed BEFORE VGPR stores to avoid reading modified VGPRs.
     # When vdst overlaps with src operands (e.g. v_add_co_u32 v[0], vcc, s[8], v[0]), the carry
     # computation reads the original source values only if its range loop runs before the VGPR write loop.

--- a/test/mockgpu/amd/pcode.py
+++ b/test/mockgpu/amd/pcode.py
@@ -91,7 +91,18 @@ def _bf8_to_f32(v: UOp) -> UOp:
 def _f32_to_fp8(v: UOp) -> UOp:
   return f2f((v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32), dtypes.float32, dtypes.fp8e4m3)
 def _f32_to_bf8(v: UOp) -> UOp:
-  return f2f((v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32), dtypes.float32, dtypes.fp8e5m2)
+  # fp8e5m2 has inf (byte 0x7C) and nan (bytes 0x7D-0x7F) — preserve them before f2f clamps
+  fv = v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v
+  bits = fv.bitcast(dtypes.uint32)
+  sign = (bits >> _u32(31)) & _u32(1)
+  exp_bits = bits & _u32(0x7F800000)
+  mant_bits = bits & _u32(0x007FFFFF)
+  is_inf = exp_bits.eq(_u32(0x7F800000)) & mant_bits.eq(_u32(0))
+  is_nan = exp_bits.eq(_u32(0x7F800000)) & mant_bits.ne(_u32(0))
+  normal = f2f(bits, dtypes.float32, dtypes.fp8e5m2)
+  inf_byte = (sign * _u32(128) + _u32(0x7C)).cast(normal.dtype)
+  nan_byte = (sign * _u32(128) + _u32(0x7F)).cast(normal.dtype)
+  return is_inf.where(inf_byte, is_nan.where(nan_byte, normal))
 def _f32_to_bf16(v: UOp) -> UOp:
   """Convert f32 to bf16 with round-to-nearest-even. BF16 is the upper 16 bits of F32 with rounding."""
   bits = (v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32)


### PR DESCRIPTION
## Summary

Fixes two bugs in the CDNA4 GPU emulator that caused 49 test failures with `MOCKGPU_ARCH=cdna4`:

- **VGPR bit-slice conditional writes** (`test/mockgpu/amd/emu.py`): When pcode `if/else` branches wrote to different bit ranges of the same VGPR (e.g. `V_CVT_PK_FP8_F32` writing low or high 16 bits based on `OPSEL[3]`), both branches executed unconditionally — the second store overwrote the first with stale data. Fixed by deferring bit-slice writes and merging them into a single conditional read-modify-write.

- **fp8e5m2 inf/nan preservation** (`test/mockgpu/amd/pcode.py`): The `f2f` decomposition clamps fp8 values to max normal before conversion, mapping `inf → 57344`. But fp8e5m2 (unlike fp8e4m3) has infinity representation (byte `0x7C`). Added explicit inf/nan detection in `_f32_to_bf8` before calling `f2f`.

## Test results

| Suite | Before | After |
|-------|--------|-------|
| `AMD_LLVM=0` (comgr) | 49 failed, 888 passed | **937 passed, 0 failed** |
| `AMD_LLVM=1` (llvm) | untested | **936 passed, 0 failed** |

Both runs with `MOCKGPU=1 MOCKGPU_ARCH=cdna4 SKIP_SLOW_TEST=1` on Ubuntu 22.04, Python 3.12, ROCm 6.4.1, LLVM 20.

## Files changed

- `test/mockgpu/amd/emu.py` — VGPR bit-slice write merging with branch conditions
- `test/mockgpu/amd/pcode.py` — `_f32_to_bf8()` inf/nan handling