### PR TITLE
fix emulator: conditional VGPR bit-slice writes and fp8 inf/nan

### DIFF
--- a/test/mockgpu/amd/emu.py
+++ b/test/mockgpu/amd/emu.py
@@ -700,16 +700,13 @@ class _Ctx:
 
     raw_stores: list = []
     vcc_val, exec_val = None, None
+    vgpr_bitslice_pending: dict[int, list[tuple]] = {}  # conditional VGPR bit-slice writes to merge
     for dest, val in assigns:
-      # VGPR bit-slice assignment: VGPR[lane][reg][hi:lo] = (vgpr_idx, rhs_val, hi, lo[, cond]) -> read-modify-write
+      # VGPR bit-slice: collect conditionals to merge (both if/else branches write same reg with different slices)
       if dest.startswith('VGPR[') and re.search(r'\[\d+:\d+\]', dest):
-        # VGPR bit-slice: (vgpr_idx, rhs_val, hi_bit, lo_bit) - hi/lo are UOp constants
         hi_bit, lo_bit = int(val[2].arg), int(val[3].arg)
-        width = hi_bit - lo_bit + 1
-        old = self.vgpr.index(val[0].cast(dtypes.int), ptr=True).load()
-        new_val = _set_bits(old, _val_to_bits(val[1]), width, lo_bit).cast(dtypes.uint32)
-        active = _lane_active(exec_mask, lane)
-        raw_stores.append(('vgpr_direct', self.vgpr.index(val[0].cast(dtypes.int), active).store(new_val)))
+        cond = val[4] if len(val) > 4 else None
+        vgpr_bitslice_pending.setdefault(id(val[0]), []).append((hi_bit, lo_bit, val[0], val[1], cond))
         continue
       if 'D0' in dest and '[laneId]' in dest:
         old_vcc = self.rmask(_c(VCC_LO.offset))
@@ -749,6 +746,18 @@ class _Ctx:
       elif dest.startswith('VCC'): vcc_val = val
       elif dest.startswith('EXEC'): exec_val = val
       elif dest.startswith('SCC'): raw_stores.append(('scc', self.wsgpr_dyn(_c(SCC.offset), _to_u32(val))))
+
+    # merge conditional bit-slice writes: read old value once, apply each slice under its condition, write once
+    for _, slices in vgpr_bitslice_pending.items():
+      vgpr_idx = slices[0][2]
+      old = self.vgpr.index(vgpr_idx.cast(dtypes.int), ptr=True).load()
+      result = old
+      for hi_bit, lo_bit, _, rhs, cond in slices:
+        width = hi_bit - lo_bit + 1
+        candidate = _set_bits(old, _val_to_bits(rhs), width, lo_bit).cast(dtypes.uint32)
+        result = cond.where(candidate, result) if cond is not None else candidate
+      active = _lane_active(exec_mask, lane)
+      raw_stores.append(('vgpr_direct', self.vgpr.index(vgpr_idx.cast(dtypes.int), active).store(result)))
 
     lane_stores = [s for t, s in raw_stores if t in ('vgpr', 'vgpr_s0', 'vgpr_direct')]
     stores, scalar_stores = [], [s for t, s in raw_stores if t == 'scc']

--- a/test/mockgpu/amd/pcode.py
+++ b/test/mockgpu/amd/pcode.py
@@ -89,9 +89,22 @@ def _bf8_to_f32(v: UOp) -> UOp:
   return is_sub.where(sub_f32.bitcast(dtypes.float32), normal)
 
 def _f32_to_fp8(v: UOp) -> UOp:
-  return f2f((v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32), dtypes.float32, dtypes.fp8e4m3)
+  fv = v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v
+  bits = fv.bitcast(dtypes.uint32)
+  normal = f2f(bits, dtypes.float32, dtypes.fp8e4m3)
+  # E4M3 has no inf representation, inf/nan -> NaN (FP16_OVFL=0)
+  sign_byte = ((bits >> _u32(24)) & _u32(0x80)).cast(normal.dtype)
+  nan_val = UOp.const(normal.dtype, 0x7F)
+  is_nan, is_inf = _isnan(fv), (bits & _u32(0x7FFFFFFF)).eq(_u32(0x7F800000))
+  return is_nan.where(nan_val, is_inf.where(nan_val | sign_byte, normal))
 def _f32_to_bf8(v: UOp) -> UOp:
-  return f2f((v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32), dtypes.float32, dtypes.fp8e5m2)
+  fv = v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v
+  bits = fv.bitcast(dtypes.uint32)
+  normal = f2f(bits, dtypes.float32, dtypes.fp8e5m2)
+  # E5M2 has inf (0x7C), preserve inf/nan (FP16_OVFL=0)
+  sign_byte = ((bits >> _u32(24)) & _u32(0x80)).cast(normal.dtype)
+  is_nan, is_inf = _isnan(fv), (bits & _u32(0x7FFFFFFF)).eq(_u32(0x7F800000))
+  return is_nan.where(UOp.const(normal.dtype, 0x7F) | sign_byte, is_inf.where(UOp.const(normal.dtype, 0x7C) | sign_byte, normal))
 def _f32_to_bf16(v: UOp) -> UOp:
   """Convert f32 to bf16 with round-to-nearest-even. BF16 is the upper 16 bits of F32 with rounding."""
   bits = (v.bitcast(dtypes.float32) if v.dtype != dtypes.float32 else v).bitcast(dtypes.uint32)


### PR DESCRIPTION
two bugs in the pcode emulator:

1. conditional VGPR bit-slice writes (e.g. V_CVT_PK_FP8_F32 OPSEL) both if/else branches wrote independently, second clobbered the first. collect all conditional slices per register, merge with cond.where().

2. _f32_to_fp8/_f32_to_bf8 didn't handle inf/nan before calling f2f, which clamps to max. now checks inf/nan first per ISA section 7.3 (FP16_OVFL=0).