### PR TITLE
validate lr, momentum, weight_decay in optimizers

### DIFF
--- a/test/backend/test_edgecases.py
+++ b/test/backend/test_edgecases.py
@@ -124,21 +124,18 @@ class TestInputValidation(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       Tensor([1, 2, 3]).repeat(-1, 2)
 
-  @unittest.expectedFailure
   def test_negative_weight_decay(self):
     with self.assertRaises(ValueError):
       torch.optim.AdamW([torch.tensor([1.], requires_grad=True)], lr=0.1, weight_decay=-0.1)
     with self.assertRaises(ValueError):
       nn.optim.AdamW([Tensor([1.], requires_grad=True)], lr=0.1, weight_decay=-0.1)
 
-  @unittest.expectedFailure
   def test_negative_lr(self):
     with self.assertRaises(ValueError):
       torch.optim.SGD([torch.tensor([1.], requires_grad=True)], lr=-0.1)
     with self.assertRaises(ValueError):
       nn.optim.SGD([Tensor([1.], requires_grad=True)], lr=-0.1)
 
-  @unittest.expectedFailure
   def test_negative_momentum(self):
     with self.assertRaises(ValueError):
       torch.optim.SGD([torch.tensor([1.], requires_grad=True)], lr=0.1, momentum=-0.1)

--- a/tinygrad/nn/optim.py
+++ b/tinygrad/nn/optim.py
@@ -9,6 +9,7 @@ class Optimizer:
   Base class for all optimizers.
   """
   def __init__(self, params: list[Tensor], lr: float, device=None, fused=FUSE_OPTIM):
+    if lr < 0: raise ValueError(f"Invalid learning rate: {lr}")
     # if requires_grad is None, but being put into an optimizer, set it to True
     for x in params:
       if x.requires_grad is None: x.requires_grad_(True)
@@ -103,6 +104,7 @@ class LARS(Optimizer):
   """
   def __init__(self, params:list[Tensor], lr=0.001, momentum=0.9, weight_decay=1e-4, ns_steps=0, ns_coefficients=None,
                nesterov=False, classic=True, pre_wd=True, tcoef=0.001, device=None, fused=FUSE_OPTIM):
+    if momentum < 0: raise ValueError(f"Invalid momentum value: {momentum}")
     super().__init__(params, lr, device, fused)
     self.momentum, self.wd, self.ns_steps, self.ns_coefficients  = momentum, weight_decay, ns_steps, ns_coefficients
     self.nesterov, self.classic, self.pre_wd, self.tcoef = nesterov, classic, pre_wd, tcoef
@@ -153,6 +155,7 @@ class LAMB(Optimizer):
   - Paper: https://arxiv.org/abs/1904.00962
   """
   def __init__(self, params: list[Tensor], lr=0.001, b1=0.9, b2=0.999, eps=1e-6, weight_decay=0.0, adam=False, device=None, fused=FUSE_OPTIM):
+    if weight_decay < 0: raise ValueError(f"Invalid weight_decay value: {weight_decay}")
     super().__init__(params, lr, device, fused)
     self.b1, self.b2, self.eps, self.wd, self.adam = b1, b2, eps, weight_decay, adam
     self.b1_t, self.b2_t = (Tensor.ones((1,), dtype=dtypes.float32, device=self.device, requires_grad=False) for _ in [b1, b2])


### PR DESCRIPTION
`SGD` and `AdamW` silently accepted negative `lr`, `momentum`, and `weight_decay` instead of raising `ValueError` like PyTorch does.

Fixes the three `@unittest.expectedFailure` tests in `TestInputValidation`:
- `test_negative_lr` — `SGD(lr=-0.1)` now raises `ValueError`
- `test_negative_momentum` — `SGD(momentum=-0.1)` now raises `ValueError`
- `test_negative_weight_decay` — `AdamW(weight_decay=-0.1)` now raises `ValueError`

Three one-line guards added: one in `Optimizer.__init__` (covers all optimizers), one in `LARS.__init__` for momentum, one in `LAMB.__init__` for weight_decay.