### PR TITLE
fix abstractions4.py

### DIFF
--- a/docs/abstractions4.py
+++ b/docs/abstractions4.py
@@ -19,10 +19,10 @@ def eval_harness(name, tensor, fxn, check=None):
 SZ = 32*1024 if getenv("MOCKGPU") else 1024*1024*1024
 
 def example_2_hip(a:Tensor, correct):
-  GLOBALS = 1024
-  THREADS = 256
+  GLOBALS = 8   if getenv("MOCKGPU") else 1024
+  THREADS = 16  if getenv("MOCKGPU") else 256
   def hip_reduce_sum(out:UOp, buf:UOp) -> UOp:
-    CHUNK = SZ // (GLOBALS * THREADS)
+    CHUNK = SZ // (GLOBALS * THREADS)  # 256 for MOCKGPU, 4096 on real hardware
     # NOTE: tinygrad doesn't populate HIP hidden kernargs, so blockDim.x/gridDim.x read as 0.
     # We hardcode block/grid sizes as constexpr to avoid any dependency on those builtins.
     code = f"""
@@ -249,4 +249,5 @@ if __name__ == "__main__":
     # *****
     # If you really want to go crazy with speed, you can code in assembly.
     # There's not too much to gain here over BEAM, but it's a few percent faster.
-    example_5_custom_assembly(a, correct)
+    if getenv("MOCKGPU"): print("***** RDNA3 assembly kernel: SKIPPED (not supported under MOCKGPU)")
+    else: example_5_custom_assembly(a, correct)


### PR DESCRIPTION
abstractions4.py was failing on mockgpu because of:
- GLOBALS * THREADS = 262144 exceeded SZ = 32768, making it 0
- example 5 kernel requires buf.numel() to be a multiple of 262144, but mockgpu only provides 32768 elements.

Before:
<img width="1641" height="553" alt="screenshot-2026-04-11_16-48-35" src="https://github.com/user-attachments/assets/0392f0ff-b61c-4d6f-9ff4-2cdc41d25994" />
After:
<img width="1672" height="658" alt="screenshot-2026-04-11_20-06-04" src="https://github.com/user-attachments/assets/8aa90c04-da89-4949-8b36-ebee8308cd6d" />
