### PR TITLE
Fix no module named error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ packages = [
   'tinygrad.runtime.graph',
   'tinygrad.runtime.support',
   'tinygrad.runtime.support.am',
+  'tinygrad.runtime.support.mlx',
   'tinygrad.runtime.support.nv',
   'tinygrad.schedule',
   'tinygrad.uop',


### PR DESCRIPTION
After installing latest tinygrad via `uv pip` or whatever, when you import it, we get `No module named 'tinygrad.runtime.support.mlx'`.
This PR fixes it.