### PR TITLE
viz/cli: multi device profiler output, print markers

### DIFF
--- a/extra/viz/README.md
+++ b/extra/viz/README.md
@@ -14,11 +14,11 @@ Flags: VIZ=-1 to only save the trace to a file, VIZ=1 also launches a web server
 Use `extra/viz/cli.py --profile` to list all sources.
 
 ```bash
-# View top 40 slowest kernels and their AST (DEBUG=4 to see source code)
+# View top 40 slowest kernels on the AMD device and their AST (DEBUG=4 to see source code)
 DEBUG=3 extra/viz/cli.py --profile -s AMD --top 40
 
-# Reconstruct DEBUG=3 output exactly as the runtime.
-DEBUG=3 extra/viz/cli.py --profile -s AMD
+# Reconstruct DEBUG=3 output exactly as the runtime. (all devices)
+DEBUG=3 extra/viz/cli.py --profile -s ALL
 ```
 
 ## Inspect codegen and PatternMatcher

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, pathlib, signal, sys, struct, json, itertools, heapq, os
+import argparse, pathlib, signal, sys, struct, json, os, itertools, heapq,
 os.environ["VIZ"] = "0"
 if hasattr(signal, "SIGPIPE"): signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 from typing import Iterator
@@ -145,19 +145,20 @@ def main(args) -> None:
   # ** Profiler printer
   else:
     timelines = [(n,l) for n,l in profile["layout"].items() if l.get("event_type") == 0]
-    def produce_top_kernelss() -> Iterator[dict]:
-      events_flat = itertools.chain.from_iterable(l["events"] for _,l in timelines) if args.src == "ALL" else iter(data["events"])
-      agg:dict[str, tuple[float, int, int|None]] = {} # map kernel name to (total time, count and ref)
+    def produce_top_kernels() -> Iterator[dict]:
+      tagged = ((n,e) for n,l in timelines for e in l["events"]) if args.src == "ALL" else ((args.src,e) for e in data["events"])
+      agg:dict[tuple[str,str], tuple[float, int, int|None]] = {} # map (device, kernel name) to (total time, count and ref)
       total = 0
-      for e in events_flat:
+      for dev,e in tagged:
         et = e["dur"] * 1e-6
-        t, c, ref = agg.get(e["name"], (0.0, 0, None))
-        agg[e["name"]] = (t+et, c+1, e["ref"])
+        t, c, ref = agg.get((dev,e["name"]), (0.0, 0, None))
+        agg[(dev,e["name"])] = (t+et, c+1, e["ref"])
         total += et
       items = sorted(agg.items(), key=lambda kv:kv[1][0], reverse=True)
       num_rows = len(items) if args.top < 0 else args.top
-      for name,(t,c,ref) in items[:num_rows]:
-        yield {"name":name, "fmt":f"{time_to_str(t, w=9)} {c:7d} {t/total*100.0:6.2f}%", "ref":ref}
+      for (dev,name),(t,c,ref) in items[:num_rows]:
+        display = f"{dev[:7]:7s} {name}" if args.src == "ALL" else name
+        yield {"name":display, "fmt":f"{time_to_str(t, w=9)} {c:7d} {t/total*100.0:6.2f}%", "ref":ref}
       if num_rows > 0 and items[num_rows:]:
         other_t = sum(t for _,(t,_,_) in items[num_rows:])
         other_c = sum(c for _,(_,c,_) in items[num_rows:])
@@ -174,7 +175,7 @@ def main(args) -> None:
         fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in e["fmt"].split("\n"))
         name = f"*** {dev[:7]:7s} {k+1:4d} "+e["name"]+" "*(46-ansilen(e["name"]))
         yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"]}
-    for k in (produce_top_kernelss if args.top else produce_all_kernels)():
+    for k in (produce_top_kernels if args.top else produce_all_kernels)():
       print(f"{fmt_colored(k['name'])}{' ' * max(0, 36 - ansilen(k['name']))} {k['fmt']}")
       if k["ref"] is not None:
         steps = rewrites[viz_data.ctxs[k["ref"]]["name"]]

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -84,7 +84,7 @@ def main(args) -> None:
   profile = decode_profile(profile_bytes)
   profile["layout"].update([(f'{c["name"][5:]}{" SQTT" if s["name"].endswith("PKTS") else ""} {s["name"]}', s["data"]) for c in viz_data.ctxs
                             if c["name"].startswith("SQTT") for s in c["steps"] if s["name"].endswith(("PMC", "PKTS"))])
-  if args.src is None: return print("Select a source with -s"+"\n"+"\n".join([f"  {fmt_colored(k)}" for k in profile["layout"]])+"\n  ALL")
+  if args.src is None: return print("Select a source with -s"+"\n  ALL\n"+"\n".join([f"  {fmt_colored(k)}" for k in profile["layout"]]))
 
   # ** SQTT printer
   data = None if args.src == "ALL" else get(profile["layout"], args.src)

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -165,23 +165,27 @@ def main(args) -> None:
         yield {"name":"Other", "fmt":f"{time_to_str(other_t, w=9)} {other_c:7d} {other_t/total*100.0:6.2f}%", "ref":None}
     def produce_all_kernels() -> Iterator[dict]:
       st0:int|None = None
-      stream = ((n,e) for _,n,e in heapq.merge(*[[(e["st"], n, e) for e in l["events"]] for n,l in timelines], key=lambda t:t[0])) \
-          if args.src == "ALL" else ((args.src, e) for e in data["events"])
-      for k,(dev,e) in enumerate(stream):
-        if st0 is None: st0 = e["st"]
-        et, timestamp = e["dur"] * 1e-6, (e["st"] - st0 + e["dur"]) * 1e-6
+      event_streams = [[(e["st"], n, e) for e in l["events"]] for n,l in timelines] if args.src == "ALL" \
+                      else [[(e["st"], args.src, e) for e in data["events"]]]
+      marker_stream = sorted([(m["ts"], "MARKER", m) for m in profile.get("markers", [])], key=lambda t:t[0])
+      for ts,dev,e in heapq.merge(*event_streams, marker_stream, key=lambda t:t[0]):
+        if st0 is None: st0 = ts
+        if dev == "MARKER":
+          yield {"name":f"--- MARKER {e['name']}", "fmt":f"@ {(ts-st0)*1e-3:9.2f}ms", "ref":None, "ext":None}
+          continue
+        et, timestamp, ext = e["dur"] * 1e-6, (e["st"] - st0 + e["dur"]) * 1e-6, None
         ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None)
-        if e["fmt"].startswith("TB:"): e["ext"], e["fmt"] = e["fmt"].replace("TB:\n", ""), ""
+        if e["fmt"].startswith("TB:"): ext, e["fmt"] = e["fmt"].replace("TB:\n", ""), ""
         fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in e["fmt"].split("\n"))
-        name = f"*** {dev[:7]:7s} {k+1:4d} "+e["name"]+" "*(46-ansilen(e["name"]))
-        yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"]}
+        name = f"*** {dev[:7]:7s} "+e["name"]+" "*(46-ansilen(e["name"]))
+        yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"], "ext":ext}
     for k in (produce_top_kernels if args.top else produce_all_kernels)():
       print(f"{fmt_colored(k['name'])}{' ' * max(0, 36 - ansilen(k['name']))} {k['fmt']}")
       if k["ref"] is not None:
         steps = rewrites[viz_data.ctxs[k["ref"]]["name"]]
         if DEBUG >= 3 and (ast_step:=steps.get("View Base AST")) is not None: print_step(ast_step)
         if DEBUG >= 4: print_step(steps["View Source"])
-      elif DEBUG >= 4 and e.get("ext") is not None: print(e["ext"])
+      elif DEBUG >= 4 and k.get("ext") is not None: print(k["ext"])
 
 def get_arg_parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(add_help=False)

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -88,7 +88,7 @@ def main(args) -> None:
 
   # ** SQTT printer
   data = None if args.src == "ALL" else get(profile["layout"], args.src)
-  if data is not None and "SQTT" in args.src:
+  if "SQTT" in args.src:
     # modern terminals support 24-bit color
     def hex_colored(st:str, color:str) -> str: return f"\x1b[38;2;{int(color[1:3],16)};{int(color[3:5],16)};{int(color[5:7],16)}m{st}\x1b[0m"
     print(f"{'Clk':<12} {'Unit':<20} {'Op':<22} {'Dur':<4} {'Delay':<4} {'Info'}")
@@ -119,7 +119,7 @@ def main(args) -> None:
       print(f"{int(e.st)-inst_st:<12} {unit:<20} {op_str}{' '*(22-ansilen(op_str))} {int(unwrap(e.en)-e.st):<4} {str(delay or ''):<4} {info}")
 
   # ** PMC printer
-  elif data is not None and "PMC" in args.src:
+  elif "PMC" in args.src:
     pmc = viz.unpack_pmc(data)
     cols = pmc["cols"]
     rows:list = []
@@ -175,7 +175,7 @@ def main(args) -> None:
           continue
         et, timestamp, ext = e["dur"] * 1e-6, (e["st"] - st0 + e["dur"]) * 1e-6, None
         ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None)
-        if e["fmt"].startswith("TB:"): ext, e["fmt"] = e["fmt"].replace("TB:\n", ""), ""
+        if e["fmt"].startswith("TB:"): e["fmt"] = "" # TODO: print python backtrace at a reasonable DEBUG level
         fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in e["fmt"].split("\n"))
         name = f"*** {dev[:7]:7s} "+e["name"]+" "*(46-ansilen(e["name"]))
         yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"], "ext":ext}
@@ -184,8 +184,7 @@ def main(args) -> None:
       if k["ref"] is not None:
         steps = rewrites[viz_data.ctxs[k["ref"]]["name"]]
         if DEBUG >= 3 and (ast_step:=steps.get("View Base AST")) is not None: print_step(ast_step)
-        if DEBUG >= 4: print_step(steps["View Source"])
-      elif DEBUG >= 4 and k.get("ext") is not None: print(k["ext"])
+        if DEBUG >= 4 and (src_step:=steps.get("View Source")) is not None: print_step(src_step)
 
 def get_arg_parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(add_help=False)

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, pathlib, signal, sys, struct, json, os, itertools, heapq,
+import argparse, pathlib, signal, sys, struct, json, os, itertools, heapq
 os.environ["VIZ"] = "0"
 if hasattr(signal, "SIGPIPE"): signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 from typing import Iterator

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import argparse, pathlib, signal, sys, struct, json, itertools, os
+import argparse, pathlib, signal, sys, struct, json, itertools, heapq, os
 os.environ["VIZ"] = "0"
 if hasattr(signal, "SIGPIPE"): signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 from typing import Iterator
@@ -84,11 +84,11 @@ def main(args) -> None:
   profile = decode_profile(profile_bytes)
   profile["layout"].update([(f'{c["name"][5:]}{" SQTT" if s["name"].endswith("PKTS") else ""} {s["name"]}', s["data"]) for c in viz_data.ctxs
                             if c["name"].startswith("SQTT") for s in c["steps"] if s["name"].endswith(("PMC", "PKTS"))])
-  if args.src is None: return print("Select a source with -s"+"\n"+"\n".join([f"  {fmt_colored(k)}" for k in profile["layout"]]))
+  if args.src is None: return print("Select a source with -s"+"\n"+"\n".join([f"  {fmt_colored(k)}" for k in profile["layout"]])+"\n  ALL")
 
   # ** SQTT printer
-  data = get(profile["layout"], args.src)
-  if "SQTT" in args.src:
+  data = None if args.src == "ALL" else get(profile["layout"], args.src)
+  if data is not None and "SQTT" in args.src:
     # modern terminals support 24-bit color
     def hex_colored(st:str, color:str) -> str: return f"\x1b[38;2;{int(color[1:3],16)};{int(color[3:5],16)};{int(color[5:7],16)}m{st}\x1b[0m"
     print(f"{'Clk':<12} {'Unit':<20} {'Op':<22} {'Dur':<4} {'Delay':<4} {'Info'}")
@@ -119,7 +119,7 @@ def main(args) -> None:
       print(f"{int(e.st)-inst_st:<12} {unit:<20} {op_str}{' '*(22-ansilen(op_str))} {int(unwrap(e.en)-e.st):<4} {str(delay or ''):<4} {info}")
 
   # ** PMC printer
-  elif "PMC" in args.src:
+  elif data is not None and "PMC" in args.src:
     pmc = viz.unpack_pmc(data)
     cols = pmc["cols"]
     rows:list = []
@@ -134,7 +134,7 @@ def main(args) -> None:
     print(fmt(pmc_data[0])+"\n"+fmt(["-"*w for w in widths])+"\n"+("\n".join([fmt(row) for row in pmc_data[1:]])))
 
   # ** Memory printer
-  elif data["event_type"] == 1:
+  elif data is not None and data["event_type"] == 1:
     print(f"Peak: {data['peak']}"+"\n"+f"{'TS':<10}  {'Event':<6}  {'Key':>8}  Info")
     for e in data["events"]:
       info = str(e.get("arg", {}))
@@ -143,11 +143,13 @@ def main(args) -> None:
       print(f"{e['ts']:<10}  {e['event']:<6}  {e.get('key', ''):>8}  {info}")
 
   # ** Profiler printer
-  elif data["event_type"] == 0:
+  else:
+    timelines = [(n,l) for n,l in profile["layout"].items() if l.get("event_type") == 0]
     def produce_top_kernelss() -> Iterator[dict]:
+      events_flat = itertools.chain.from_iterable(l["events"] for _,l in timelines) if args.src == "ALL" else iter(data["events"])
       agg:dict[str, tuple[float, int, int|None]] = {} # map kernel name to (total time, count and ref)
       total = 0
-      for e in data["events"]:
+      for e in events_flat:
         et = e["dur"] * 1e-6
         t, c, ref = agg.get(e["name"], (0.0, 0, None))
         agg[e["name"]] = (t+et, c+1, e["ref"])
@@ -161,12 +163,16 @@ def main(args) -> None:
         other_c = sum(c for _,(_,c,_) in items[num_rows:])
         yield {"name":"Other", "fmt":f"{time_to_str(other_t, w=9)} {other_c:7d} {other_t/total*100.0:6.2f}%", "ref":None}
     def produce_all_kernels() -> Iterator[dict]:
-      st0 = data["events"][0]["st"] if data["events"] else 0
-      for k,e in enumerate(data["events"]):
+      st0:int|None = None
+      stream = ((n,e) for _,n,e in heapq.merge(*[[(e["st"], n, e) for e in l["events"]] for n,l in timelines], key=lambda t:t[0])) \
+          if args.src == "ALL" else ((args.src, e) for e in data["events"])
+      for k,(dev,e) in enumerate(stream):
+        if st0 is None: st0 = e["st"]
         et, timestamp = e["dur"] * 1e-6, (e["st"] - st0 + e["dur"]) * 1e-6
         ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None)
+        if e["fmt"].startswith("TB:"): e["ext"], e["fmt"] = e["fmt"].replace("TB:\n", ""), ""
         fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in e["fmt"].split("\n"))
-        name = f"*** {args.src[:7]:7s} {k+1:4d} "+e["name"]+" "*(46-ansilen(e["name"]))
+        name = f"*** {dev[:7]:7s} {k+1:4d} "+e["name"]+" "*(46-ansilen(e["name"]))
         yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"]}
     for k in (produce_top_kernelss if args.top else produce_all_kernels)():
       print(f"{fmt_colored(k['name'])}{' ' * max(0, 36 - ansilen(k['name']))} {k['fmt']}")
@@ -174,6 +180,7 @@ def main(args) -> None:
         steps = rewrites[viz_data.ctxs[k["ref"]]["name"]]
         if DEBUG >= 3 and (ast_step:=steps.get("View Base AST")) is not None: print_step(ast_step)
         if DEBUG >= 4: print_step(steps["View Source"])
+      elif DEBUG >= 4 and e.get("ext") is not None: print(e["ext"])
 
 def get_arg_parser() -> argparse.ArgumentParser:
   parser = argparse.ArgumentParser(add_help=False)

--- a/extra/viz/cli.py
+++ b/extra/viz/cli.py
@@ -144,8 +144,7 @@ def main(args) -> None:
 
   # ** Profiler printer
   elif data["event_type"] == 0:
-    kernels:list[dict] = []
-    if args.top:
+    def produce_top_kernelss() -> Iterator[dict]:
       agg:dict[str, tuple[float, int, int|None]] = {} # map kernel name to (total time, count and ref)
       total = 0
       for e in data["events"]:
@@ -156,20 +155,20 @@ def main(args) -> None:
       items = sorted(agg.items(), key=lambda kv:kv[1][0], reverse=True)
       num_rows = len(items) if args.top < 0 else args.top
       for name,(t,c,ref) in items[:num_rows]:
-        kernels.append({"name":name, "fmt":f"{time_to_str(t, w=9)} {c:7d} {t/total*100.0:6.2f}%", "ref":ref})
+        yield {"name":name, "fmt":f"{time_to_str(t, w=9)} {c:7d} {t/total*100.0:6.2f}%", "ref":ref}
       if num_rows > 0 and items[num_rows:]:
         other_t = sum(t for _,(t,_,_) in items[num_rows:])
         other_c = sum(c for _,(_,c,_) in items[num_rows:])
-        kernels.append({"name":"Other", "fmt":f"{time_to_str(other_t, w=9)} {other_c:7d} {other_t/total*100.0:6.2f}%", "ref":None})
-    else:
+        yield {"name":"Other", "fmt":f"{time_to_str(other_t, w=9)} {other_c:7d} {other_t/total*100.0:6.2f}%", "ref":None}
+    def produce_all_kernels() -> Iterator[dict]:
       st0 = data["events"][0]["st"] if data["events"] else 0
       for k,e in enumerate(data["events"]):
         et, timestamp = e["dur"] * 1e-6, (e["st"] - st0 + e["dur"]) * 1e-6
         ptm = colored(time_to_str(et, w=9), "yellow" if et > 0.01 else None)
         fmt_str = "  ".join(p+" "*max(0, 14-ansilen(p)) for p in e["fmt"].split("\n"))
         name = f"*** {args.src[:7]:7s} {k+1:4d} "+e["name"]+" "*(46-ansilen(e["name"]))
-        kernels.append({"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"]})
-    for k in kernels:
+        yield {"name":name, "fmt":f"tm {ptm}/{timestamp*1e3:9.2f}ms"+(f" ({fmt_str})" if e["fmt"] else ""), "ref":e["ref"]}
+    for k in (produce_top_kernelss if args.top else produce_all_kernels)():
       print(f"{fmt_colored(k['name'])}{' ' * max(0, 36 - ansilen(k['name']))} {k['fmt']}")
       if k["ref"] is not None:
         steps = rewrites[viz_data.ctxs[k["ref"]]["name"]]

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -921,8 +921,8 @@ class TestCLI(unittest.TestCase):
       # get the top slowest functions across all devices
       with Context(DEBUG=2):
         times = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--top", "-1")
-      for dev in ["TINY", "USER", "NULL"]:
-        self.assertIn(dev, times)
+      self.assertIn("TINY", times)
+      self.assertIn("NULL", times)
 
 if __name__ == "__main__":
   unittest.main()

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -1,4 +1,4 @@
-import unittest, decimal, sys, json, contextlib, tempfile, pickle, io
+import unittest, decimal, sys, json, contextlib, tempfile, pickle, io, itertools
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Generator
@@ -896,22 +896,30 @@ def run_cli(*cli_args) -> str:
 class TestCLI(unittest.TestCase):
   def test_simple(self):
     a = Tensor.empty(1, device="NULL")+2.0
+    empty_counter = itertools.count(0)
     def custom_empty_prg(B:UOp, A:UOp) -> UOp:
-      sink = UOp(Ops.SINK, arg=KernelInfo(name="custom_empty"))
+      sink = UOp(Ops.SINK, arg=KernelInfo(name=f"custom_empty_n{next(empty_counter)}"))
       return UOp(Ops.PROGRAM, src=(sink, UOp(Ops.DEVICE, arg=a.device), UOp(Ops.LINEAR, src=(sink,))))
     b = Tensor.custom_kernel(Tensor.empty_like(a), a, fxn=custom_empty_prg)[0]
+    c = Tensor.custom_kernel(Tensor.empty_like(a), a, fxn=custom_empty_prg)[0]
     with save_viz() as viz:
       b.realize()
+      profile_marker("marker @ 1")
+      c.realize()
     # save trace to disk for CLI to consume it
     with tempfile.TemporaryDirectory() as tmpdir:
       (r:=Path(tmpdir)/"rewrites.pkl").write_bytes(pickle.dumps(viz.data.trace))
       (p:=Path(tmpdir)/"profile.pkl").write_bytes(pickle.dumps(cpu_events))
-      # reconstruct DEBUG=4 output
+      # reconstruct DEBUG=4 output and see all markers.
       with Context(DEBUG=4):
         kernels = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "NULL")
-      self.assertIn("void custom_empty", kernels)
+      self.assertIn("void custom_empty_n0", kernels)
+      self.assertIn("marker @ 1", kernels)
+      self.assertIn("void custom_empty_n1", kernels)
       self.assertIn("E", kernels)
       self.assertIn("UOp.const", kernels)
+      # TODO: assert line numbers
+
       # get the top slowest functions across all devices
       with Context(DEBUG=2):
         times = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--top", "-1")

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -918,8 +918,6 @@ class TestCLI(unittest.TestCase):
       self.assertIn("void custom_empty_n1", kernels)
       self.assertIn("E", kernels)
       self.assertIn("UOp.const", kernels)
-      # TODO: assert line numbers
-
       # get the top slowest functions across all devices
       with Context(DEBUG=2):
         times = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--top", "-1")

--- a/test/null/test_viz.py
+++ b/test/null/test_viz.py
@@ -906,11 +906,17 @@ class TestCLI(unittest.TestCase):
     with tempfile.TemporaryDirectory() as tmpdir:
       (r:=Path(tmpdir)/"rewrites.pkl").write_bytes(pickle.dumps(viz.data.trace))
       (p:=Path(tmpdir)/"profile.pkl").write_bytes(pickle.dumps(cpu_events))
+      # reconstruct DEBUG=4 output
       with Context(DEBUG=4):
         kernels = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "NULL")
       self.assertIn("void custom_empty", kernels)
       self.assertIn("E", kernels)
       self.assertIn("UOp.const", kernels)
+      # get the top slowest functions across all devices
+      with Context(DEBUG=2):
+        times = run_cli("--rewrites-path", str(r), "--profile-path", str(p), "-p", "-s", "ALL", "--top", "-1")
+      for dev in ["TINY", "USER", "NULL"]:
+        self.assertIn(dev, times)
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
`DEBUG=2 extra/viz/cli.py --profile -s ALL` to use.
VIZ CLI shows USER / TINY and GPUs in a DEBG=2 style:
<img width="1280" height="228" alt="Screenshot 2026-04-17 at 11 41 09 PM" src="https://github.com/user-attachments/assets/2df8077c-928b-4a97-b24d-30b399fdb12f" />