### PR TITLE
system: preserve TinyGPU remote device index on macOS

### DIFF
--- a/test/unit/test_system_apl_remote.py
+++ b/test/unit/test_system_apl_remote.py
@@ -1,0 +1,26 @@
+import socket
+import tinygrad.runtime.support.system as system
+
+def test_list_devices_osx_uses_usb4_indices(monkeypatch):
+  monkeypatch.setattr(system, "OSX", True)
+  monkeypatch.setattr(system.System, "pci_scan_bus", lambda vendor, devices, base_class=None: ["10de:2b85", "10de:2b04"])
+
+  devs = system.System.list_devices(0x10de, devices=((0xff00, (0x2b00, 0x2d00)),), base_class=0x03)
+  assert devs == [(system.APLRemotePCIDevice, "usb4:0"), (system.APLRemotePCIDevice, "usb4:1")]
+
+def test_apl_remote_pcidevice_preserves_pcibus(monkeypatch):
+  monkeypatch.setattr(system.APLRemotePCIDevice, "ensure_app", classmethod(lambda cls: None))
+  monkeypatch.setattr(system, "temp", lambda name: f"/tmp/{name}")
+
+  class FakeSocket:
+    def connect(self, path): assert path == "/tmp/tinygpu.sock"
+    def setsockopt(self, *args, **kwargs): pass
+    def getpeername(self): return ("peer",)
+
+  called = {}
+  monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: FakeSocket())
+  monkeypatch.setattr(system.RemotePCIDevice, "__init__", lambda self, devpref, pcibus, sock: called.update(devpref=devpref, pcibus=pcibus, sock=sock))
+
+  system.APLRemotePCIDevice("NV", "usb4:3")
+  assert called["devpref"] == "NV"
+  assert called["pcibus"] == "usb4:3"

--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -78,7 +78,9 @@ class _System:
   @functools.cache
   def list_devices(self, vendor:int, devices:tuple[tuple[int, tuple[int, ...]], ...], base_class:int|None=None):
     if getenv("REMOTE", ""): return [(functools.partial(RemotePCIDevice,sock=s), x) for s,x in RemotePCIDevice.remote_list(vendor,devices,base_class)]
-    return [(APLRemotePCIDevice if OSX else PCIDevice, x) for x in System.pci_scan_bus(vendor, devices, base_class)]
+    scanned = System.pci_scan_bus(vendor, devices, base_class)
+    if OSX: return [(APLRemotePCIDevice, f"usb4:{i}") for i, _ in enumerate(scanned)]
+    return [(PCIDevice, x) for x in scanned]
 
   def pci_probe_device(self, device:str, dev_id:int, vendor:int, devices:tuple[tuple[int, tuple[int, ...]], ...], base_class:int|None=None):
     cl, pcibus = hcq_filter_visible_devices(self.list_devices(vendor, devices, base_class), device)[dev_id]
@@ -422,7 +424,7 @@ class APLRemotePCIDevice(RemotePCIDevice):
       if i == 0: subprocess.Popen([self.APP_PATH, "server", sock_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
       time.sleep(0.05)
     else: raise RuntimeError(f"Failed to connect to TinyGPU server at {sock_path}.")
-    super().__init__(devpref, "usb4", sock=sock)
+    super().__init__(devpref, pcibus, sock=sock)
 
   def alloc_sysmem(self, size:int, vaddr:int=0, contiguous:bool=False) -> tuple[MMIOInterface, list[int]]:
     mapped_size, _, _, fd = self._rpc(self.sock, self.dev_id, RemoteCmd.MAP_SYSMEM_FD, size, int(contiguous), has_fd=True)


### PR DESCRIPTION
## Summary
Fix a macOS TinyGPU regression in `system.py` where the remote device index is lost during `APLRemotePCIDevice` construction.

Current `master` combines:
- IOKit discovery values like `10de:2b85`
- `RemotePCIDevice` parsing that expects a numeric suffix for `dev_id`

and then `APLRemotePCIDevice.__init__` hardcodes `"usb4"`, which collapses every macOS TinyGPU device to remote device `0`.

This patch restores the old behavior in the merged remote path:
- macOS `System.list_devices` now enumerates matching devices as `usb4:{i}`
- `APLRemotePCIDevice` now preserves the passed `pcibus` string instead of hardcoding `"usb4"`

## Tests
Added unit coverage for:
- macOS device enumeration producing `usb4:0`, `usb4:1`, ...
- `APLRemotePCIDevice` preserving the supplied `pcibus` into `RemotePCIDevice`

## Notes
I verified the behavior with direct runtime sanity checks in this environment. `pytest` was not installed here, so I could not run the unit tests through pytest locally.