### PR TITLE
Respect PCI base class on macOS scans

### DIFF
--- a/test/unit/test_system_apl_remote.py
+++ b/test/unit/test_system_apl_remote.py
@@ -1,4 +1,5 @@
 import socket
+import pytest
 import tinygrad.runtime.support.system as system
 
 def test_list_devices_osx_uses_usb4_indices(monkeypatch):
@@ -24,3 +25,19 @@ def test_apl_remote_pcidevice_preserves_pcibus(monkeypatch):
   system.APLRemotePCIDevice("NV", "usb4:3")
   assert called["devpref"] == "NV"
   assert called["pcibus"] == "usb4:3"
+
+def test_apl_remote_pcidevice_fails_fast_on_all_ones_config(monkeypatch):
+  monkeypatch.setattr(system.APLRemotePCIDevice, "ensure_app", classmethod(lambda cls: None))
+  monkeypatch.setattr(system, "temp", lambda name: f"/tmp/{name}")
+
+  class FakeSocket:
+    def connect(self, path): pass
+    def setsockopt(self, *args, **kwargs): pass
+    def getpeername(self): return ("peer",)
+
+  monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: FakeSocket())
+  monkeypatch.setattr(system.RemotePCIDevice, "__init__", lambda self, devpref, pcibus, sock: setattr(self, "dev_id", 0))
+  monkeypatch.setattr(system.APLRemotePCIDevice, "read_config", lambda self, offset, size: 0xffffffff)
+
+  with pytest.raises(RuntimeError, match="TinyGPU returned 0xffffffff for PCI config"):
+    system.APLRemotePCIDevice("NV", "usb4:0")

--- a/test/unit/test_system_apl_remote.py
+++ b/test/unit/test_system_apl_remote.py
@@ -1,0 +1,26 @@
+import socket
+import tinygrad.runtime.support.system as system
+
+def test_list_devices_osx_uses_usb4_indices(monkeypatch):
+  monkeypatch.setattr(system, "OSX", True)
+  monkeypatch.setattr(system.System, "pci_scan_bus", lambda vendor, devices, base_class=None: ["10de:2b85", "10de:2b04"])
+
+  devs = system.System.list_devices(0x10de, devices=((0xff00, (0x2b00, 0x2d00)),), base_class=0x03)
+  assert devs == [(system.APLRemotePCIDevice, "usb4:0"), (system.APLRemotePCIDevice, "usb4:1")]
+
+def test_apl_remote_pcidevice_preserves_pcibus(monkeypatch):
+  monkeypatch.setattr(system.APLRemotePCIDevice, "ensure_app", classmethod(lambda cls: None))
+  monkeypatch.setattr(system, "temp", lambda name: f"/tmp/{name}")
+
+  class FakeSocket:
+    def connect(self, path): assert path == "/tmp/tinygpu.sock"
+    def setsockopt(self, *args, **kwargs): pass
+    def getpeername(self): return ("peer",)
+
+  called = {}
+  monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: FakeSocket())
+  monkeypatch.setattr(system.RemotePCIDevice, "__init__", lambda self, devpref, pcibus, sock: called.update(devpref=devpref, pcibus=pcibus, sock=sock))
+
+  system.APLRemotePCIDevice("NV", "usb4:3")
+  assert called["devpref"] == "NV"
+  assert called["pcibus"] == "usb4:3"

--- a/test/unit/test_system_apl_remote.py
+++ b/test/unit/test_system_apl_remote.py
@@ -1,4 +1,4 @@
-import socket
+import ctypes, socket
 import pytest
 import tinygrad.runtime.support.system as system
 
@@ -8,6 +8,36 @@ def test_list_devices_osx_uses_usb4_indices(monkeypatch):
 
   devs = system.System.list_devices(0x10de, devices=((0xff00, (0x2b00, 0x2d00)),), base_class=0x03)
   assert devs == [(system.APLRemotePCIDevice, "usb4:0"), (system.APLRemotePCIDevice, "usb4:1")]
+
+def test_pci_scan_bus_osx_respects_base_class(monkeypatch):
+  monkeypatch.setattr(system, "OSX", True)
+
+  services = iter([1, 2, 0])
+  monkeypatch.setattr(system.iokit, "IOServiceGetMatchingServices", lambda *args: 0)
+  monkeypatch.setattr(system.iokit, "IOServiceMatching", lambda name: name)
+  monkeypatch.setattr(system.iokit, "IOIteratorNext", lambda iterator: next(services))
+
+  props = {
+    1: {"vendor-id": 0x10de, "device-id": 0x22e8, "class-code": 0x00040300},
+    2: {"vendor-id": 0x10de, "device-id": 0x2b85, "class-code": 0x00030000},
+  }
+  refs: dict[int, tuple[int, str]] = {}
+  next_ref = iter(range(1, 100))
+
+  def fake_create_cf_property(svc, key, *_args):
+    ref = next(next_ref)
+    refs[ref] = (svc, ctypes.cast(key, ctypes.c_char_p).value.decode())
+    return ctypes.c_void_p(ref)
+
+  monkeypatch.setattr(system.iokit, "IORegistryEntryCreateCFProperty", fake_create_cf_property)
+  monkeypatch.setattr(system.corefoundation, "CFStringCreateWithCString",
+                      lambda _alloc, raw, _enc: ctypes.c_char_p(raw))
+  monkeypatch.setattr(system.corefoundation, "CFDataGetLength", lambda ref: 4)
+  monkeypatch.setattr(system.corefoundation, "CFDataGetBytes",
+                      lambda ref, _rng, buf: ctypes.memmove(buf, props[refs[ctypes.cast(ref, ctypes.c_void_p).value][0]][refs[ctypes.cast(ref, ctypes.c_void_p).value][1]].to_bytes(4, "little"), 4))
+
+  scanned = system.System.pci_scan_bus(0x10de, ((0xff00, (0x2200, 0x2b00)),), base_class=0x03)
+  assert scanned == ["10de:2b85"]
 
 def test_apl_remote_pcidevice_preserves_pcibus(monkeypatch):
   monkeypatch.setattr(system.APLRemotePCIDevice, "ensure_app", classmethod(lambda cls: None))

--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -78,7 +78,9 @@ class _System:
   @functools.cache
   def list_devices(self, vendor:int, devices:tuple[tuple[int, tuple[int, ...]], ...], base_class:int|None=None):
     if getenv("REMOTE", ""): return [(functools.partial(RemotePCIDevice,sock=s), x) for s,x in RemotePCIDevice.remote_list(vendor,devices,base_class)]
-    return [(APLRemotePCIDevice if OSX else PCIDevice, x) for x in System.pci_scan_bus(vendor, devices, base_class)]
+    scanned = System.pci_scan_bus(vendor, devices, base_class)
+    if OSX: return [(APLRemotePCIDevice, f"usb4:{i}") for i, _ in enumerate(scanned)]
+    return [(PCIDevice, x) for x in scanned]
 
   def pci_probe_device(self, device:str, dev_id:int, vendor:int, devices:tuple[tuple[int, tuple[int, ...]], ...], base_class:int|None=None):
     cl, pcibus = hcq_filter_visible_devices(self.list_devices(vendor, devices, base_class), device)[dev_id]
@@ -422,7 +424,7 @@ class APLRemotePCIDevice(RemotePCIDevice):
       if i == 0: subprocess.Popen([self.APP_PATH, "server", sock_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
       time.sleep(0.05)
     else: raise RuntimeError(f"Failed to connect to TinyGPU server at {sock_path}.")
-    super().__init__(devpref, "usb4", sock=sock)
+    super().__init__(devpref, pcibus, sock=sock)
 
   def alloc_sysmem(self, size:int, vaddr:int=0, contiguous:bool=False) -> tuple[MMIOInterface, list[int]]:
     mapped_size, _, _, fd = self._rpc(self.sock, self.dev_id, RemoteCmd.MAP_SYSMEM_FD, size, int(contiguous), has_fd=True)

--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -64,7 +64,9 @@ class _System:
         return int.from_bytes(bytes(buf), "little")
 
       iokit.IOServiceGetMatchingServices(0, iokit.IOServiceMatching(b"IOPCIDevice"), ctypes.byref(iterator:=ctypes.c_uint()))
-      while svc:=iokit.IOIteratorNext(iterator): all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
+      while svc:=iokit.IOIteratorNext(iterator):
+        if base_class is not None and read_prop(svc, "class-code") >> 16 != base_class: continue
+        all_devs.append((v:=read_prop(svc, "vendor-id"), d:=read_prop(svc, "device-id"), f"{v:x}:{d:x}"))
     else:
       try: devs = FileIOInterface("/sys/bus/pci/devices")
       except FileNotFoundError: raise RuntimeError("no pcie")

--- a/tinygrad/runtime/support/system.py
+++ b/tinygrad/runtime/support/system.py
@@ -425,6 +425,12 @@ class APLRemotePCIDevice(RemotePCIDevice):
       time.sleep(0.05)
     else: raise RuntimeError(f"Failed to connect to TinyGPU server at {sock_path}.")
     super().__init__(devpref, pcibus, sock=sock)
+    if self.read_config(0, 4) == 0xffffffff:
+      raise RuntimeError(
+        f"TinyGPU returned 0xffffffff for PCI config on {pcibus}. "
+        "This usually means the macOS TinyGPU transport is not exposing a live PCI function yet "
+        "(driver extension approval/state, enclosure reset state, or USB4/TB bridge enumeration)."
+      )
 
   def alloc_sysmem(self, size:int, vaddr:int=0, contiguous:bool=False) -> tuple[MMIOInterface, list[int]]:
     mapped_size, _, _, fd = self._rpc(self.sock, self.dev_id, RemoteCmd.MAP_SYSMEM_FD, size, int(contiguous), has_fd=True)


### PR DESCRIPTION
## Summary
- filter macOS IOPCIDevice scans by base class like Linux already does
- prevent PCI+NV from selecting the eGPU audio function during device discovery
- add coverage for the macOS class-code filtering path

## Why
On macOS eGPU setups, NVIDIA devices can expose both the display function and the HDMI/DP audio function. The existing macOS scan path ignored base_class, so NV discovery could include both and sort the audio function (0x22e8) ahead of the actual display function (0x2b85). That made default PCI+NV selection ambiguous and wrong on Blackwell eGPU hosts.
