### PR TITLE
fix where backward nan on inactive sqrt branch

### DIFF
--- a/test/unit/test_gradient.py
+++ b/test/unit/test_gradient.py
@@ -76,6 +76,13 @@ class TestTensorGradient(unittest.TestCase):
     x = Tensor.randn(4, 4)
     np.testing.assert_allclose(x.pad(((1,0),(0,0))).gradient(x, gradient=g2)[0].numpy(), np.zeros((4, 4)))
 
+  def test_where_inactive_nan_branch_gradient(self):
+    x = Tensor([0.0], requires_grad=True)
+    y = Tensor.where(x == 0, 0, x * x.sqrt())
+    y.sum().backward()
+    self.assertFalse(np.isnan(x.grad.numpy()).any())
+    np.testing.assert_allclose(x.grad.numpy(), [0.0])
+
 class TestViewGradient(unittest.TestCase):
   def test_expand(self):
     x = Tensor.randn(5,2)

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -52,7 +52,7 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.SIN, name="ret"), lambda ctx, ret: ((math.pi/2 - ret.src[0]).sin() * ctx,)),
   (UPat(Ops.LOG2, name="ret"), lambda ctx, ret: (ctx / (ret.src[0] * math.log(2)),)),
   (UPat(Ops.EXP2, name="ret"), lambda ctx, ret: (ret * ctx * math.log(2),)),
-  (UPat(Ops.SQRT, name="ret"), lambda ctx, ret: (ctx.eq(0).where(ctx.const_like(0), ctx / (ret*2)),)),
+  (UPat(Ops.SQRT, name="ret"), lambda ctx, ret: (((ctx.eq(0) & ret.eq(0)).where(ctx.const_like(0), ctx / (ret*2))),)),
   (UPat((Ops.CMPLT, Ops.CMPNE)), lambda: (None, None)),
   (UPat(Ops.ADD), lambda ctx: (ctx, ctx)),
   (UPat(Ops.POW, name="ret", src=(UPat.var("b"), UPat.var("e"))), lambda ctx, ret, b, e:

--- a/tinygrad/gradient.py
+++ b/tinygrad/gradient.py
@@ -52,7 +52,7 @@ pm_gradient = PatternMatcher([
   (UPat(Ops.SIN, name="ret"), lambda ctx, ret: ((math.pi/2 - ret.src[0]).sin() * ctx,)),
   (UPat(Ops.LOG2, name="ret"), lambda ctx, ret: (ctx / (ret.src[0] * math.log(2)),)),
   (UPat(Ops.EXP2, name="ret"), lambda ctx, ret: (ret * ctx * math.log(2),)),
-  (UPat(Ops.SQRT, name="ret"), lambda ctx, ret: (ctx / (ret*2),)),
+  (UPat(Ops.SQRT, name="ret"), lambda ctx, ret: (ctx.eq(0).where(ctx.const_like(0), ctx / (ret*2)),)),
   (UPat((Ops.CMPLT, Ops.CMPNE)), lambda: (None, None)),
   (UPat(Ops.ADD), lambda ctx: (ctx, ctx)),
   (UPat(Ops.POW, name="ret", src=(UPat.var("b"), UPat.var("e"))), lambda ctx, ret, b, e:


### PR DESCRIPTION
**Summary**
Fixes NaN gradient leakage through `where` when the inactive branch contains sqrt-domain-invalid math.

**Problem**
Issue #12409 reports gradients becoming NaN even when the `where` condition selects the safe branch and the expected gradient should be zero.

**What Changed**
1. Updated `sqrt` backward logic to short-circuit when upstream gradient is zero.
2. Returned zero gradient instead of performing division by `2 * sqrt(x)`.
3. Prevented masked-path `0/0` style contamination from inactive branch math.

**Test Plan**
1. Added regression test: `test_where_inactive_nan_branch_gradient`.
2. Verified gradient has no NaN values.
3. Verified expected gradient is `[0.0]`.
4. Ran: `python -m unittest test.unit.test_gradient.TestTensorGradient.test_where_inactive_nan_branch_gradient`

**Risk**
Low. Change is localized to `sqrt` backward behavior for zero upstream gradient paths only.